### PR TITLE
ROC-2046: removed @JsonUnwrapped from dateOfBirth field

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/models/otherparty/IndividualDetails.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/models/otherparty/IndividualDetails.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.cmc.claimstore.models.otherparty;
 
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import uk.gov.hmcts.cmc.claimstore.constraints.AgeRangeValidator;
 import uk.gov.hmcts.cmc.claimstore.models.Address;
 import uk.gov.hmcts.cmc.claimstore.models.legalrep.Representative;
@@ -16,7 +15,6 @@ public class IndividualDetails extends TheirDetails implements TitledParty {
     @Size(max = 35, message = "must be at most {max} characters")
     private final String title;
 
-    @JsonUnwrapped
     @AgeRangeValidator
     private final LocalDate dateOfBirth;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-2046


### Change description ###
Removed `@JsonUnwrapped` from dateOfBirth field. With this annotation it was not mapped from JSON.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
