### PR TITLE
Fix label for service address

### DIFF
--- a/src/main/resources/staff/templates/document/legalSealedClaim.html
+++ b/src/main/resources/staff/templates/document/legalSealedClaim.html
@@ -500,9 +500,7 @@
           {% endif %}
         </td>
         <td class="two-per-row">
-          {% if defendant.representative is defined or defendant.serviceAddress is defined %}
           <h4>Service address</h4>
-          {% endif %}
         </td>
         <td>
           {% if defendant.representative is defined %}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-2463

### Change description ###
This PR fixes the bug for 'Service address' Label is missing for defendant 3 onwards
if they use same service address


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
