### PR TITLE
ROC-2485: blocked API from accepting response when CCJ was requested

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/CountyCourtJudgmentAlreadyRequestedException.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/CountyCourtJudgmentAlreadyRequestedException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.cmc.claimstore.exceptions;
+
+public class CountyCourtJudgmentAlreadyRequestedException extends ForbiddenActionException {
+    public CountyCourtJudgmentAlreadyRequestedException(long claimId) {
+        super("County Court Judgment for the claim " + claimId + " was already requested");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/ResponseAlreadySubmittedException.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/ResponseAlreadySubmittedException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.cmc.claimstore.exceptions;
+
+public class ResponseAlreadySubmittedException extends ForbiddenActionException {
+    public ResponseAlreadySubmittedException(long claimId) {
+        super("Response for the claim " + claimId + " was already submitted");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseService.java
@@ -44,9 +44,16 @@ public class DefendantResponseService {
             throw new ForbiddenActionException("Response for the claim " + claimId + " was already submitted");
         }
 
+        if (isCCJAlreadyRequested(claim)) {
+            throw new ForbiddenActionException(
+                "County Court Judgment for the claim " + claimId + " was already requested"
+            );
+        }
+
         final String defendantEmail = userService.getUserDetails(authorization).getEmail();
-        defendantResponseRepository.save(claimId, defendantId, defendantEmail,
-            jsonMapper.toJson(responseData));
+        defendantResponseRepository.save(
+            claimId, defendantId, defendantEmail, jsonMapper.toJson(responseData)
+        );
 
         final Claim claimAfterSavingResponse = claimService.getClaimById(claimId);
 
@@ -59,4 +66,7 @@ public class DefendantResponseService {
         return null != claim.getRespondedAt();
     }
 
+    private boolean isCCJAlreadyRequested(final Claim claim) {
+        return null != claim.getCountyCourtJudgmentRequestedAt();
+    }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseService.java
@@ -3,7 +3,8 @@ package uk.gov.hmcts.cmc.claimstore.services;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.cmc.claimstore.events.EventProducer;
-import uk.gov.hmcts.cmc.claimstore.exceptions.ForbiddenActionException;
+import uk.gov.hmcts.cmc.claimstore.exceptions.CountyCourtJudgmentAlreadyRequestedException;
+import uk.gov.hmcts.cmc.claimstore.exceptions.ResponseAlreadySubmittedException;
 import uk.gov.hmcts.cmc.claimstore.models.Claim;
 import uk.gov.hmcts.cmc.claimstore.models.ResponseData;
 import uk.gov.hmcts.cmc.claimstore.processors.JsonMapper;
@@ -41,13 +42,11 @@ public class DefendantResponseService {
         final Claim claim = claimService.getClaimById(claimId);
 
         if (isResponseAlreadySubmitted(claim)) {
-            throw new ForbiddenActionException("Response for the claim " + claimId + " was already submitted");
+            throw new ResponseAlreadySubmittedException(claimId);
         }
 
         if (isCCJAlreadyRequested(claim)) {
-            throw new ForbiddenActionException(
-                "County Court Judgment for the claim " + claimId + " was already requested"
-            );
+            throw new CountyCourtJudgmentAlreadyRequestedException(claimId);
         }
 
         final String defendantEmail = userService.getUserDetails(authorization).getEmail();

--- a/src/main/resources/staff/templates/document/legalSealedClaim.html
+++ b/src/main/resources/staff/templates/document/legalSealedClaim.html
@@ -500,9 +500,7 @@
           {% endif %}
         </td>
         <td class="two-per-row">
-          {% if defendant.representative is defined or defendant.serviceAddress is defined %}
           <h4>Service address</h4>
-          {% endif %}
         </td>
         <td>
           {% if defendant.representative is defined %}

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
@@ -101,6 +101,14 @@ public class ClaimServiceTest {
         assertThat(actual).isEqualTo(claim);
     }
 
+    @Test(expected = NotFoundException.class)
+    public void getClaimByIdShouldThrowNotFoundException() {
+
+        when(claimRepository.getById(eq(CLAIM_ID))).thenReturn(Optional.empty());
+
+        claimService.getClaimById(CLAIM_ID);
+    }
+
     @Test
     public void getClaimByLetterHolderIdShouldCallRepositoryWhenValidClaimIsReturned() {
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseServiceTest.java
@@ -8,7 +8,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.cmc.claimstore.controllers.utils.sampledata.SampleClaim;
 import uk.gov.hmcts.cmc.claimstore.controllers.utils.sampledata.SampleResponseData;
 import uk.gov.hmcts.cmc.claimstore.events.EventProducer;
-import uk.gov.hmcts.cmc.claimstore.exceptions.ForbiddenActionException;
+import uk.gov.hmcts.cmc.claimstore.exceptions.CountyCourtJudgmentAlreadyRequestedException;
+import uk.gov.hmcts.cmc.claimstore.exceptions.ResponseAlreadySubmittedException;
 import uk.gov.hmcts.cmc.claimstore.idam.models.UserDetails;
 import uk.gov.hmcts.cmc.claimstore.models.Claim;
 import uk.gov.hmcts.cmc.claimstore.models.ResponseData;
@@ -77,8 +78,8 @@ public class DefendantResponseServiceTest {
             .createDefendantResponseEvent(eq(claim));
     }
 
-    @Test(expected = ForbiddenActionException.class)
-    public void saveShouldThrowForbiddenActionExceptionWhenResponseSubmitted() {
+    @Test(expected = ResponseAlreadySubmittedException.class)
+    public void saveShouldThrowResponseAlreadySubmittedExceptionWhenResponseSubmitted() {
 
         when(claimService.getClaimById(eq(CLAIM_ID)))
             .thenReturn(SampleClaim.builder().withRespondedAt(LocalDateTime.now()).build());
@@ -86,8 +87,8 @@ public class DefendantResponseServiceTest {
         responseService.save(CLAIM_ID, DEFENDANT_ID, VALID_APP, AUTHORISATION);
     }
 
-    @Test(expected = ForbiddenActionException.class)
-    public void saveShouldThrowForbiddenActionExceptionWhenCCJRequested() {
+    @Test(expected = CountyCourtJudgmentAlreadyRequestedException.class)
+    public void saveShouldThrowCountyCourtJudgmentAlreadyRequestedExceptionWhenCCJRequested() {
 
         when(claimService.getClaimById(eq(CLAIM_ID)))
             .thenReturn(SampleClaim.builder().withCountyCourtJudgmentRequestedAt(LocalDateTime.now()).build());

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.cmc.claimstore.controllers.utils.sampledata.SampleClaim;
 import uk.gov.hmcts.cmc.claimstore.controllers.utils.sampledata.SampleResponseData;
 import uk.gov.hmcts.cmc.claimstore.events.EventProducer;
+import uk.gov.hmcts.cmc.claimstore.exceptions.ForbiddenActionException;
 import uk.gov.hmcts.cmc.claimstore.idam.models.UserDetails;
 import uk.gov.hmcts.cmc.claimstore.models.Claim;
 import uk.gov.hmcts.cmc.claimstore.models.ResponseData;
@@ -15,6 +16,8 @@ import uk.gov.hmcts.cmc.claimstore.processors.JsonMapper;
 import uk.gov.hmcts.cmc.claimstore.repositories.DefendantResponseRepository;
 import uk.gov.hmcts.cmc.claimstore.services.notifications.fixtures.SampleUserDetails;
 import uk.gov.hmcts.cmc.claimstore.utils.ResourceReader;
+
+import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -55,9 +58,8 @@ public class DefendantResponseServiceTest {
     @Test
     public void saveShouldFinishSuccessfully() {
         //given
-        final ResponseData app = SampleResponseData.validDefaults();
         final String jsonApp = new ResourceReader().read("/defendant-response.json");
-        when(mapper.toJson(eq(app))).thenReturn(jsonApp);
+        when(mapper.toJson(eq(VALID_APP))).thenReturn(jsonApp);
 
         when(userService.getUserDetails(AUTHORISATION)).thenReturn(
             new UserDetails(USER_ID, DEFENDANT_EMAIL, "Jonny", "Jones")
@@ -68,11 +70,28 @@ public class DefendantResponseServiceTest {
         when(claimService.getClaimById(eq(CLAIM_ID))).thenReturn(claim);
 
         //when
-        responseService.save(CLAIM_ID, DEFENDANT_ID, app, AUTHORISATION);
+        responseService.save(CLAIM_ID, DEFENDANT_ID, VALID_APP, AUTHORISATION);
 
         //then
         verify(eventProducer, once())
-            .createDefendantResponseEvent(eq(claim) );
+            .createDefendantResponseEvent(eq(claim));
     }
 
+    @Test(expected = ForbiddenActionException.class)
+    public void saveShouldThrowForbiddenActionExceptionWhenResponseSubmitted() {
+
+        when(claimService.getClaimById(eq(CLAIM_ID)))
+            .thenReturn(SampleClaim.builder().withRespondedAt(LocalDateTime.now()).build());
+
+        responseService.save(CLAIM_ID, DEFENDANT_ID, VALID_APP, AUTHORISATION);
+    }
+
+    @Test(expected = ForbiddenActionException.class)
+    public void saveShouldThrowForbiddenActionExceptionWhenCCJRequested() {
+
+        when(claimService.getClaimById(eq(CLAIM_ID)))
+            .thenReturn(SampleClaim.builder().withCountyCourtJudgmentRequestedAt(LocalDateTime.now()).build());
+
+        responseService.save(CLAIM_ID, DEFENDANT_ID, VALID_APP, AUTHORISATION);
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-2485


### Change description ###
API blocked for saving response when response was already submitted for a claim or CCJ was requested.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
