### PR TITLE
ROC-2494: Forbid undefined email address

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/models/otherparty/TheirDetails.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/models/otherparty/TheirDetails.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotBlank;
+import org.hibernate.validator.constraints.NotEmpty;
 import uk.gov.hmcts.cmc.claimstore.models.Address;
 import uk.gov.hmcts.cmc.claimstore.models.legalrep.Representative;
 import uk.gov.hmcts.cmc.claimstore.models.party.NamedParty;
@@ -15,6 +16,7 @@ import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.claimstore.utils.ToStringStyle.ourStyle;
@@ -43,7 +45,7 @@ public abstract class TheirDetails implements NamedParty {
     @NotNull
     private final Address address;
 
-    @Email
+    @Email(regexp = "\\S+")
     private final String email;
 
     @Valid

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/models/otherparty/TheirDetails.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/models/otherparty/TheirDetails.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotBlank;
-import org.hibernate.validator.constraints.NotEmpty;
 import uk.gov.hmcts.cmc.claimstore.models.Address;
 import uk.gov.hmcts.cmc.claimstore.models.legalrep.Representative;
 import uk.gov.hmcts.cmc.claimstore.models.party.NamedParty;
@@ -16,7 +15,6 @@ import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.claimstore.utils.ToStringStyle.ourStyle;

--- a/src/main/resources/db/migration/V2017_10_06_1624__Remove_empty_defendant_email_addresses.sql
+++ b/src/main/resources/db/migration/V2017_10_06_1624__Remove_empty_defendant_email_addresses.sql
@@ -1,0 +1,17 @@
+-- Delete defendant email address property if value is a blank string
+
+WITH subquery AS (
+  SELECT
+    id,
+    jsonb_agg(case value ->> 'email' when '' then value - 'email' else value end) as migrated_defendants
+  FROM claim, jsonb_array_elements(claim::JSONB -> 'defendants')
+  GROUP BY id
+)
+UPDATE
+  claim
+SET
+  claim = JSONB_SET(claim, '{defendants}', migrated_defendants)
+FROM
+  subquery
+WHERE
+  claim.id = subquery.id;

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/models/TheirDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/models/TheirDetailsTest.java
@@ -92,9 +92,59 @@ public class TheirDetailsTest {
     }
 
     @Test
+    public void shouldBeValidWhenGivenValidEmail() {
+        TheirDetails theirDetails = SampleTheirDetails.builder()
+            .withEmail("user@example.com")
+            .partyDetails();
+
+        Set<String> validationErrors = validate(theirDetails);
+
+        assertThat(validationErrors).isEmpty();
+    }
+
+    @Test
+    public void shouldBeInvalidWhenGivenEmptyEmail() {
+        TheirDetails theirDetails = SampleTheirDetails.builder()
+            .withEmail("")
+            .partyDetails();
+
+        Set<String> validationErrors = validate(theirDetails);
+
+        assertThat(validationErrors)
+            .hasSize(1)
+            .contains("email : not a well-formed email address");
+    }
+
+    @Test
+    public void shouldBeInvalidWhenGivenEmailWithWhitespacesOnly() {
+        TheirDetails theirDetails = SampleTheirDetails.builder()
+            .withEmail(" ")
+            .partyDetails();
+
+        Set<String> validationErrors = validate(theirDetails);
+
+        assertThat(validationErrors)
+            .hasSize(1)
+            .contains("email : not a well-formed email address");
+    }
+
+    @Test
     public void shouldBeInvalidWhenGivenInvalidEmail() {
         TheirDetails theirDetails = SampleTheirDetails.builder()
-            .withEmail("this is not a valid email address..")
+            .withEmail("this is not a valid email address")
+            .partyDetails();
+
+        Set<String> validationErrors = validate(theirDetails);
+
+        assertThat(validationErrors)
+            .hasSize(1)
+            .contains("email : not a well-formed email address");
+    }
+
+    @Test
+    public void shouldBeInvalidWhenGivenNonTrimmedEmail() {
+        TheirDetails theirDetails = SampleTheirDetails.builder()
+            .withEmail(" user@example.com ")
             .partyDetails();
 
         Set<String> validationErrors = validate(theirDetails);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-2494

### Change description ###

This PR does:
- make email address validation more strict to not allow empty values
- removes empty email address from defendant details

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```