### PR TITLE
Pass along error codes from external API

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandler.java
@@ -58,7 +58,8 @@ public class ResourceExceptionHandler {
     @ExceptionHandler(value = HttpClientErrorException.class)
     public ResponseEntity<Object> httpClientErrorException(HttpClientErrorException exception) {
         logger.error(exception.getMessage(), exception);
-        return new ResponseEntity<>(exception.getMessage(), new HttpHeaders(), HttpStatus.valueOf(exception.getRawStatusCode()));
+        return new ResponseEntity<>(exception.getMessage(), new HttpHeaders(),
+            HttpStatus.valueOf(exception.getRawStatusCode()));
     }
 
     @ExceptionHandler(value = ForbiddenActionException.class)

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.cmc.claimstore.exceptions.ConflictException;
 import uk.gov.hmcts.cmc.claimstore.exceptions.ForbiddenActionException;
 import uk.gov.hmcts.cmc.claimstore.exceptions.InvalidApplicationException;
@@ -54,6 +55,11 @@ public class ResourceExceptionHandler {
         return new ResponseEntity<>("Internal server error", new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    @ExceptionHandler(value = HttpClientErrorException.class)
+    public ResponseEntity<Object> httpClientErrorException(HttpClientErrorException exception) {
+        logger.error(exception.getMessage(), exception);
+        return new ResponseEntity<>(exception.getMessage(), new HttpHeaders(), HttpStatus.valueOf(exception.getRawStatusCode()));
+    }
 
     @ExceptionHandler(value = ForbiddenActionException.class)
     public ResponseEntity<Object> forbidden(Exception exception) {


### PR DESCRIPTION
This will mean getting a 401 back from the claim store rather than a 500
if idam returns 401 say when the users token is expired