### PR TITLE
Remove assumptions around IDAM ID type

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/BaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/BaseTest.java
@@ -32,9 +32,9 @@ import java.util.stream.Collectors;
 public abstract class BaseTest {
 
     protected static final Long CLAIM_ID = 1L;
-    protected static final Long SUBMITTER_ID = 123L;
+    protected static final String SUBMITTER_ID = "123";
     protected static final String LETTER_HOLDER_ID = "999";
-    protected static final Long DEFENDANT_ID = 555L;
+    protected static final String DEFENDANT_ID = "555";
     protected static final String REFERENCE_NUMBER = "000MC001";
     protected final Claim claimAfterSavingWithResponse = SampleClaim.getWithDefaultResponse();
 

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/BaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/BaseTest.java
@@ -33,7 +33,7 @@ public abstract class BaseTest {
 
     protected static final Long CLAIM_ID = 1L;
     protected static final Long SUBMITTER_ID = 123L;
-    protected static final Long LETTER_HOLDER_ID = 999L;
+    protected static final String LETTER_HOLDER_ID = "999";
     protected static final Long DEFENDANT_ID = 555L;
     protected static final String REFERENCE_NUMBER = "000MC001";
     protected final Claim claimAfterSavingWithResponse = SampleClaim.getWithDefaultResponse();

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClaimByExternalIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClaimByExternalIdTest.java
@@ -31,14 +31,6 @@ public class GetClaimByExternalIdTest extends BaseTest {
     }
 
     @Test
-    public void shouldReturn404HttpStatusWhenExternalIdParamIsNotValid() throws Exception {
-        webClient
-            .perform(get("/claims/not-a-valid-uuid"))
-            .andExpect(status().isNotFound())
-            .andReturn();
-    }
-
-    @Test
     public void shouldReturn404HttpStatusWhenNoClaimFound() throws Exception {
 
         given(claimRepository.getClaimByExternalId(eq(EXTERNAL_ID))).willReturn(Optional.empty());

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClaimByReferenceNumberTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClaimByReferenceNumberTest.java
@@ -18,7 +18,7 @@ public class GetClaimByReferenceNumberTest extends BaseTest {
     private static final String REFERENCE_NUMBER = "000MC001";
     private static final String EXTERNAL_ID = "9f49d8df-b734-4e86-aeb6-e22f0c2ca78d";
 
-    private final Claim claim = new Claim.Builder().setId(1L).setSubmitterId(2L).setLetterHolderId("3")
+    private final Claim claim = new Claim.Builder().setId(1L).setSubmitterId("2").setLetterHolderId("3")
         .setExternalId(EXTERNAL_ID)
         .setReferenceNumber(REFERENCE_NUMBER)
         .build();

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClaimByReferenceNumberTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClaimByReferenceNumberTest.java
@@ -18,7 +18,7 @@ public class GetClaimByReferenceNumberTest extends BaseTest {
     private static final String REFERENCE_NUMBER = "000MC001";
     private static final String EXTERNAL_ID = "9f49d8df-b734-4e86-aeb6-e22f0c2ca78d";
 
-    private final Claim claim = new Claim.Builder().setId(1L).setSubmitterId(2L).setLetterHolderId(3L)
+    private final Claim claim = new Claim.Builder().setId(1L).setSubmitterId(2L).setLetterHolderId("3")
         .setExternalId(EXTERNAL_ID)
         .setReferenceNumber(REFERENCE_NUMBER)
         .build();

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClaimsByDefendantIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClaimsByDefendantIdTest.java
@@ -71,7 +71,7 @@ public class GetClaimsByDefendantIdTest extends BaseTest {
             .andReturn();
     }
 
-    private Claim newClaim(Long id, Long defendantId) {
+    private Claim newClaim(Long id, String defendantId) {
         return SampleClaim.builder().withClaimId(id).withDefendantId(defendantId).build();
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClaimsByDefendantIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClaimsByDefendantIdTest.java
@@ -22,7 +22,7 @@ public class GetClaimsByDefendantIdTest extends BaseTest {
 
     @Test
     public void shouldReturn200HttpStatusAndClaimListWhenClaimsExist() throws Exception {
-        long defendantId = 1L;
+        String defendantId = "1";
 
         given(claimRepository.getByDefendantId(defendantId))
             .willReturn(Lists.newArrayList(newClaim(1L, defendantId)));
@@ -37,7 +37,7 @@ public class GetClaimsByDefendantIdTest extends BaseTest {
 
     @Test
     public void shouldReturn200HttpStatusAndEmptyClaimListWhenClaimsDoNotExist() throws Exception {
-        long defendantId = 1L;
+        String defendantId = "1";
 
         given(claimRepository.getByDefendantId(defendantId))
             .willReturn(Lists.newArrayList());
@@ -49,18 +49,10 @@ public class GetClaimsByDefendantIdTest extends BaseTest {
 
         assertThat(deserialize(result)).isEmpty();
     }
-
-    @Test
-    public void shouldReturn404HttpStatusWhenDefendantParameterIsNotNumber() throws Exception {
-        webClient
-            .perform(get("/claims/defendant/not-a-number"))
-            .andExpect(status().isNotFound())
-            .andReturn();
-    }
-
+    
     @Test
     public void shouldReturn500HttpStatusWhenFailedToRetrieveClaim() throws Exception {
-        long defendantId = 1L;
+        String defendantId = "1";
 
         given(claimRepository.getByDefendantId(defendantId))
             .willThrow(new UnableToExecuteStatementException("Unexpected error", (StatementContext) null));

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClamsByClaimantIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClamsByClaimantIdTest.java
@@ -20,10 +20,10 @@ import static uk.gov.hmcts.cmc.claimstore.controllers.utils.sampledata.SampleCla
 
 public class GetClamsByClaimantIdTest extends BaseTest {
 
+    private String claimantId = "1";
+
     @Test
     public void shouldReturn200HttpStatusAndClaimListWhenClaimsExist() throws Exception {
-        long claimantId = 1L;
-
         given(claimRepository.getBySubmitterId(claimantId))
             .willReturn(Lists.newArrayList(newClaim(claimantId)));
 
@@ -37,8 +37,6 @@ public class GetClamsByClaimantIdTest extends BaseTest {
 
     @Test
     public void shouldReturn200HttpStatusAndEmptyClaimListWhenClaimsDoNotExist() throws Exception {
-        long claimantId = 1L;
-
         given(claimRepository.getBySubmitterId(claimantId))
             .willReturn(Lists.newArrayList());
 
@@ -51,16 +49,8 @@ public class GetClamsByClaimantIdTest extends BaseTest {
     }
 
     @Test
-    public void shouldReturn404HttpStatusWhenClaimantIdParameterIsNotNumber() throws Exception {
-        webClient
-            .perform(get("/claims/claimant/not-a-number"))
-            .andExpect(status().isNotFound())
-            .andReturn();
-    }
-
-    @Test
     public void shouldReturn500HttpStatusWhenFailedToRetrieveClaim() throws Exception {
-        long claimantId = 1L;
+        String claimantId = "1";
 
         given(claimRepository.getBySubmitterId(claimantId))
             .willThrow(new UnableToExecuteStatementException("Unexpected error", (StatementContext) null));
@@ -71,8 +61,8 @@ public class GetClamsByClaimantIdTest extends BaseTest {
             .andReturn();
     }
 
-    private Claim newClaim(Long claimantId) {
-        return new Claim.Builder().setId(1L).setSubmitterId(claimantId).setLetterHolderId("3").setDefendantId(1L)
+    private Claim newClaim(String claimantId) {
+        return new Claim.Builder().setId(1L).setSubmitterId(claimantId).setLetterHolderId("3").setDefendantId("1")
             .setExternalId("9f49d8df-b734-4e86-aeb6-e22f0c2ca78d").setReferenceNumber("000MC001")
             .setSubmitterEmail(SUBMITTER_EMAIL)
             .build();

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClamsByClaimantIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GetClamsByClaimantIdTest.java
@@ -72,7 +72,7 @@ public class GetClamsByClaimantIdTest extends BaseTest {
     }
 
     private Claim newClaim(Long claimantId) {
-        return new Claim.Builder().setId(1L).setSubmitterId(claimantId).setLetterHolderId(3L).setDefendantId(1L)
+        return new Claim.Builder().setId(1L).setSubmitterId(claimantId).setLetterHolderId("3").setDefendantId(1L)
             .setExternalId("9f49d8df-b734-4e86-aeb6-e22f0c2ca78d").setReferenceNumber("000MC001")
             .setSubmitterEmail(SUBMITTER_EMAIL)
             .build();

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/LinkDefendantToClaimTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/LinkDefendantToClaimTest.java
@@ -20,7 +20,7 @@ public class LinkDefendantToClaimTest extends BaseTest {
     @Test
     public void shouldReturn200HttpStatusAndUpdatedClaimWhenLinkIsSuccessfullySet() throws Exception {
         Long claimId = 1L;
-        Long defendantId = 2L;
+        String defendantId = "2";
 
         given(claimRepository.getById(claimId))
             .willReturn(Optional.of(newClaim(claimId, null)))
@@ -79,7 +79,7 @@ public class LinkDefendantToClaimTest extends BaseTest {
     @Test
     public void shouldReturn500HttpStatusWhenFailedToMakeLink() throws Exception {
         Long claimId = 1L;
-        Long defendantId = 2L;
+        String defendantId = "2";
 
         given(claimRepository.getById(claimId)).willReturn(Optional.of(newClaim(claimId, null)));
         given(claimRepository.linkDefendant(claimId, defendantId))
@@ -91,7 +91,7 @@ public class LinkDefendantToClaimTest extends BaseTest {
             .andReturn();
     }
 
-    private Claim newClaim(long claimId, Long defendantId) {
+    private Claim newClaim(long claimId, String defendantId) {
         return SampleClaim.builder().withClaimId(claimId).withDefendantId(defendantId).build();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/RequestMoreTimeForResponseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/RequestMoreTimeForResponseTest.java
@@ -32,7 +32,7 @@ import static uk.gov.hmcts.cmc.claimstore.utils.VerificationModeUtils.once;
 public class RequestMoreTimeForResponseTest extends BaseTest {
 
     private static final String AUTH_TOKEN = "it's me!";
-    private static final long DEFENDANT_ID = 100L;
+    private static final String DEFENDANT_ID = "100";
     private static final LocalDate RESPONSE_DEADLINE = LocalDate.now().plusDays(10);
 
     private static final UserDetails USER_DETAILS

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/ResendStaffNotificationsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/ResendStaffNotificationsTest.java
@@ -93,7 +93,7 @@ public class ResendStaffNotificationsTest extends BaseTest {
         final Claim claim = sampleClaim(SampleClaimData.submittedByClaimant()).setDefendantId(null).build();
         given(claimRepository.getByClaimReferenceNumber(claimReference)).willReturn(Optional.of(claim));
 
-        final GeneratePinResponse pinResponse = new GeneratePinResponse("pin-123", 333L);
+        final GeneratePinResponse pinResponse = new GeneratePinResponse("pin-123", "333");
         given(userService.generatePin(anyString(), eq("ABC123"))).willReturn(pinResponse);
         given(userService.getUserDetails(anyString())).willReturn(SampleUserDetails.getDefault());
 

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimantClaimTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimantClaimTest.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -37,9 +36,9 @@ import static uk.gov.hmcts.cmc.claimstore.utils.DatesProvider.RESPONSE_DEADLINE;
 public class SaveClaimantClaimTest extends BaseTest {
 
     private static final long CLAIM_ID = 1L;
-    private static final long CLAIMANT_ID = 123L;
+    private static final String CLAIMANT_ID = "123";
     private static final String LETTER_HOLDER_ID = "1";
-    private static final Long DEFENDANT_ID = 2L;
+    private static final String DEFENDANT_ID = "2";
     private static final String REFERENCE_NUMBER = "000MC001";
     private static final String PIN = "my-pin";
     private static final String EXTERNAL_ID = "external-id";
@@ -65,7 +64,7 @@ public class SaveClaimantClaimTest extends BaseTest {
         given(pdfServiceClient.generateFromHtml(any(byte[].class), anyMap()))
             .willReturn(new byte[]{1, 2, 3, 4});
 
-        given(claimRepository.saveSubmittedByClaimant(anyString(), anyLong(), anyString(), any(LocalDate.class),
+        given(claimRepository.saveSubmittedByClaimant(anyString(), anyString(), anyString(), any(LocalDate.class),
             any(LocalDate.class), anyString(), anyString()))
             .willReturn(CLAIM_ID);
 

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimantClaimTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimantClaimTest.java
@@ -38,7 +38,7 @@ public class SaveClaimantClaimTest extends BaseTest {
 
     private static final long CLAIM_ID = 1L;
     private static final long CLAIMANT_ID = 123L;
-    private static final Long LETTER_HOLDER_ID = 1L;
+    private static final String LETTER_HOLDER_ID = "1";
     private static final Long DEFENDANT_ID = 2L;
     private static final String REFERENCE_NUMBER = "000MC001";
     private static final String PIN = "my-pin";
@@ -65,7 +65,7 @@ public class SaveClaimantClaimTest extends BaseTest {
         given(pdfServiceClient.generateFromHtml(any(byte[].class), anyMap()))
             .willReturn(new byte[]{1, 2, 3, 4});
 
-        given(claimRepository.saveSubmittedByClaimant(anyString(), anyLong(), anyLong(), any(LocalDate.class),
+        given(claimRepository.saveSubmittedByClaimant(anyString(), anyLong(), anyString(), any(LocalDate.class),
             any(LocalDate.class), anyString(), anyString()))
             .willReturn(CLAIM_ID);
 

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveCountyCourtJudgmentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveCountyCourtJudgmentTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class SaveCountyCourtJudgmentTest extends BaseTest {
 
     private static final long CLAIM_ID = 1L;
-    private static final long CLAIMANT_ID = 123L;
+    private static final String CLAIMANT_ID = "123";
 
     @Before
     public void setup() {

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveRepresentativeClaimTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveRepresentativeClaimTest.java
@@ -45,7 +45,7 @@ public class SaveRepresentativeClaimTest extends BaseTest {
 
     private static final long CLAIM_ID = 1L;
     private static final long CLAIMANT_ID = 123L;
-    private static final Long LETTER_HOLDER_ID = 1L;
+    private static final String LETTER_HOLDER_ID = "1";
     private static final Long DEFENDANT_ID = 2L;
     private static final String REFERENCE_NUMBER = "000MC001";
     private static final String PIN = "my-pin";

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveRepresentativeClaimTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveRepresentativeClaimTest.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -44,9 +43,9 @@ import static uk.gov.hmcts.cmc.claimstore.utils.DatesProvider.RESPONSE_DEADLINE;
 public class SaveRepresentativeClaimTest extends BaseTest {
 
     private static final long CLAIM_ID = 1L;
-    private static final long CLAIMANT_ID = 123L;
+    private static final String CLAIMANT_ID = "123";
     private static final String LETTER_HOLDER_ID = "1";
-    private static final Long DEFENDANT_ID = 2L;
+    private static final String DEFENDANT_ID = "2";
     private static final String REFERENCE_NUMBER = "000MC001";
     private static final String PIN = "my-pin";
     private static final String EXTERNAL_ID = "external-id";
@@ -80,7 +79,7 @@ public class SaveRepresentativeClaimTest extends BaseTest {
         given(pdfServiceClient.generateFromHtml(any(byte[].class), anyMap()))
             .willReturn(new byte[]{1, 2, 3, 4});
 
-        given(claimRepository.saveRepresented(anyString(), anyLong(), any(LocalDate.class),
+        given(claimRepository.saveRepresented(anyString(), anyString(), any(LocalDate.class),
             any(LocalDate.class), anyString(), anyString()))
             .willReturn(CLAIM_ID);
 

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/StoreDefendantResponseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/StoreDefendantResponseTest.java
@@ -49,7 +49,7 @@ public class StoreDefendantResponseTest extends BaseTest {
     @Before
     public void setup() {
         given(claimRepository.saveRepresented(
-            anyString(), anyLong(), any(LocalDate.class), any(LocalDate.class), anyString(), anyString())
+            anyString(), anyString(), any(LocalDate.class), any(LocalDate.class), anyString(), anyString())
         ).willReturn(CLAIM_ID);
 
         given(claimRepository.getById(CLAIM_ID))
@@ -109,7 +109,7 @@ public class StoreDefendantResponseTest extends BaseTest {
     public void shouldFailAWhenDefendantResponseFailedStoring() throws Exception {
         //when
         willThrow(new DataAccessResourceFailureException("some failure"))
-            .given(defendantResponseRepository).save(anyLong(), anyLong(), anyString(), anyString());
+            .given(defendantResponseRepository).save(anyLong(), anyString(), anyString(), anyString());
 
         final MvcResult result = postDefence(SampleResponseData.validDefaults())
             .andExpect(status().isInternalServerError())

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandlerTest.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.cmc.claimstore.controllers.utils.sampledata.SampleClaim.EXTERNAL_ID;
 
 public class ResourceExceptionHandlerTest extends BaseTest {
-    private static final long CLAIMANT_ID = 123L;
+    private static final String CLAIMANT_ID = "123";
 
     @Before
     public void setup() {
@@ -36,7 +36,7 @@ public class ResourceExceptionHandlerTest extends BaseTest {
         final String errorMessage = "ERROR: duplicate key value violates unique constraint \"external_id_unique\"";
         when(exception.getCause().getMessage()).thenReturn(errorMessage);
 
-        given(claimRepository.saveRepresented(anyString(), anyLong(), any(LocalDate.class),
+        given(claimRepository.saveRepresented(anyString(), anyString(), any(LocalDate.class),
             any(LocalDate.class), anyString(), anyString()))
             .willThrow(exception);
 

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandlerTest.java
@@ -15,7 +15,6 @@ import java.time.LocalDate;
 
 import static java.util.Collections.emptySet;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -63,7 +62,7 @@ public class ResourceExceptionHandlerTest extends BaseTest {
 
     private ResultActions postClaim(ClaimData claimData) throws Exception {
         return webClient
-            .perform(post("/claims/" + (Long) CLAIMANT_ID)
+            .perform(post("/claims/" + CLAIMANT_ID)
                 .header(HttpHeaders.CONTENT_TYPE, "application/json")
                 .header(HttpHeaders.AUTHORIZATION, "token")
                 .content(jsonMapper.toJson(claimData))

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
@@ -45,9 +45,9 @@ public class ClaimController {
         return claimService.getClaimBySubmitterId(submitterId);
     }
 
-    @GetMapping("/letter/{letterHolderId:\\d+}")
+    @GetMapping("/letter/{letterHolderId}")
     @ApiOperation("Fetch user claim for given letter holder id")
-    public Claim getByLetterHolderId(@PathVariable("letterHolderId") final Long letterHolderId) {
+    public Claim getByLetterHolderId(@PathVariable("letterHolderId") final String letterHolderId) {
         return claimService.getClaimByLetterHolderId(letterHolderId);
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
@@ -39,9 +39,9 @@ public class ClaimController {
         this.claimService = claimService;
     }
 
-    @GetMapping("/claimant/{submitterId:\\d+}")
+    @GetMapping("/claimant/{submitterId}")
     @ApiOperation("Fetch user claims for given submitter id")
-    public List<Claim> getBySubmitterId(@PathVariable("submitterId") final Long submitterId) {
+    public List<Claim> getBySubmitterId(@PathVariable("submitterId") final String submitterId) {
         return claimService.getClaimBySubmitterId(submitterId);
     }
 
@@ -57,24 +57,24 @@ public class ClaimController {
         return claimService.getClaimByExternalId(externalId);
     }
 
-    @GetMapping("/defendant/{defendantId:\\d+}")
+    @GetMapping("/defendant/{defendantId}")
     @ApiOperation("Fetch claims linked to given defendant id")
     public List<Claim> getByDefendantId(@PathVariable("defendantId") final Long defendantId) {
         return claimService.getClaimByDefendantId(defendantId);
     }
 
-    @PostMapping(value = "/{submitterId:\\d+}", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @PostMapping(value = "/{submitterId}", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ApiOperation("Creates a new claim")
     public Claim save(@Valid @NotNull @RequestBody final ClaimData claimData,
-                      @PathVariable("submitterId") final Long submitterId,
+                      @PathVariable("submitterId") final String submitterId,
                       @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorisation) {
         return claimService.saveClaim(submitterId, claimData, authorisation);
     }
 
-    @PutMapping("/{claimId:\\d+}/defendant/{defendantId:\\d+}")
+    @PutMapping("/{claimId:\\d+}/defendant/{defendantId}")
     @ApiOperation("Links defendant to existing claim")
     public Claim linkDefendantToClaim(@PathVariable("claimId") final Long claimId,
-                                      @PathVariable("defendantId") final Long defendantId) {
+                                      @PathVariable("defendantId") final String defendantId) {
         claimService.linkDefendantToClaim(claimId, defendantId);
         return claimService.getClaimById(claimId);
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
@@ -59,7 +59,7 @@ public class ClaimController {
 
     @GetMapping("/defendant/{defendantId}")
     @ApiOperation("Fetch claims linked to given defendant id")
-    public List<Claim> getByDefendantId(@PathVariable("defendantId") final Long defendantId) {
+    public List<Claim> getByDefendantId(@PathVariable("defendantId") final String defendantId) {
         return claimService.getClaimByDefendantId(defendantId);
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CountyCourtJudgmentController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CountyCourtJudgmentController.java
@@ -43,7 +43,7 @@ public class CountyCourtJudgmentController {
         @NotNull @RequestBody @Valid final CountyCourtJudgment countyCourtJudgment,
         @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorisation
     ) {
-        final long submitterId = userService.getUserDetails(authorisation).getId();
+        final String submitterId = userService.getUserDetails(authorisation).getId();
         return countyCourtJudgmentService.save(submitterId, countyCourtJudgment, claimId);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/DefendantResponseController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/DefendantResponseController.java
@@ -37,7 +37,7 @@ public class DefendantResponseController {
     @ApiOperation("Creates a new defendant response")
     public Claim save(
         @Valid @NotNull @RequestBody final ResponseData responseData,
-        @PathVariable("defendantId") final Long defendantId,
+        @PathVariable("defendantId") final String defendantId,
         @PathVariable("claimId") final Long claimId,
         @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorization
     ) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/idam/models/GeneratePinResponse.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/idam/models/GeneratePinResponse.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class GeneratePinResponse {
 
     private final String pin;
-    private final Long userId;
+    private final String userId;
 
-    public GeneratePinResponse(@JsonProperty("pin") final String pin, @JsonProperty("userId") final Long userId) {
+    public GeneratePinResponse(@JsonProperty("pin") final String pin, @JsonProperty("userId") final String userId) {
         this.pin = pin;
         this.userId = userId;
     }
@@ -16,7 +16,7 @@ public class GeneratePinResponse {
         return pin;
     }
 
-    public Long getUserId() {
+    public String getUserId() {
         return userId;
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/idam/models/UserDetails.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/idam/models/UserDetails.java
@@ -9,13 +9,13 @@ import java.util.Optional;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UserDetails {
 
-    private final long id;
+    private final String id;
     private final String email;
 
     private final String forename;
     private final String surname;
 
-    public UserDetails(@JsonProperty("id") final long id,
+    public UserDetails(@JsonProperty("id") final String id,
                        @JsonProperty("email") final String email,
                        @JsonProperty("forename") final String forename,
                        @JsonProperty("surname") final String surname
@@ -26,7 +26,7 @@ public class UserDetails {
         this.surname = surname;
     }
 
-    public Long getId() {
+    public String getId() {
         return id;
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/models/Claim.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/models/Claim.java
@@ -16,7 +16,7 @@ public class Claim {
 
     private final Long id;
     private final Long submitterId;
-    private final Long letterHolderId;
+    private final String letterHolderId;
     private final Long defendantId;
     private final String externalId;
     private final String referenceNumber;
@@ -37,7 +37,7 @@ public class Claim {
     public Claim(
         final Long id,
         final Long submitterId,
-        final Long letterHolderId,
+        final String letterHolderId,
         final Long defendantId,
         final String externalId,
         final String referenceNumber,
@@ -80,7 +80,7 @@ public class Claim {
         return submitterId;
     }
 
-    public Long getLetterHolderId() {
+    public String getLetterHolderId() {
         return letterHolderId;
     }
 
@@ -182,7 +182,7 @@ public class Claim {
         private String externalId;
         private Long submitterId;
         private String submitterEmail;
-        private Long letterHolderId;
+        private String letterHolderId;
         private Long defendantId;
         private String referenceNumber;
         private ClaimData claimData;
@@ -216,7 +216,7 @@ public class Claim {
             return this;
         }
 
-        public Builder setLetterHolderId(Long letterHolderId) {
+        public Builder setLetterHolderId(String letterHolderId) {
             this.letterHolderId = letterHolderId;
             return this;
         }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/models/Claim.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/models/Claim.java
@@ -15,9 +15,9 @@ import static uk.gov.hmcts.cmc.claimstore.utils.ToStringStyle.ourStyle;
 public class Claim {
 
     private final Long id;
-    private final Long submitterId;
+    private final String submitterId;
     private final String letterHolderId;
-    private final Long defendantId;
+    private final String defendantId;
     private final String externalId;
     private final String referenceNumber;
     @JsonProperty("claim")
@@ -36,9 +36,9 @@ public class Claim {
     @SuppressWarnings("squid:S00107") // Not sure there's a lot fo be done about removing parameters here
     public Claim(
         final Long id,
-        final Long submitterId,
+        final String submitterId,
         final String letterHolderId,
-        final Long defendantId,
+        final String defendantId,
         final String externalId,
         final String referenceNumber,
         final ClaimData claimData,
@@ -76,7 +76,7 @@ public class Claim {
         return id;
     }
 
-    public Long getSubmitterId() {
+    public String getSubmitterId() {
         return submitterId;
     }
 
@@ -84,7 +84,7 @@ public class Claim {
         return letterHolderId;
     }
 
-    public Long getDefendantId() {
+    public String getDefendantId() {
         return defendantId;
     }
 
@@ -180,10 +180,10 @@ public class Claim {
     public static class Builder {
         private Long id;
         private String externalId;
-        private Long submitterId;
+        private String submitterId;
         private String submitterEmail;
         private String letterHolderId;
-        private Long defendantId;
+        private String defendantId;
         private String referenceNumber;
         private ClaimData claimData;
         private LocalDate issuedOn;
@@ -206,7 +206,7 @@ public class Claim {
             return this;
         }
 
-        public Builder setSubmitterId(Long submitterId) {
+        public Builder setSubmitterId(String submitterId) {
             this.submitterId = submitterId;
             return this;
         }
@@ -221,7 +221,7 @@ public class Claim {
             return this;
         }
 
-        public Builder setDefendantId(Long defendantId) {
+        public Builder setDefendantId(String defendantId) {
             this.defendantId = defendantId;
             return this;
         }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
@@ -28,7 +28,7 @@ public interface ClaimRepository {
 
     @SingleValueResult
     @SqlQuery(SELECT_FROM_STATEMENT + " WHERE claim.letter_holder_id = :letterHolderId")
-    Optional<Claim> getByLetterHolderId(@Bind("letterHolderId") Long letterHolderId);
+    Optional<Claim> getByLetterHolderId(@Bind("letterHolderId") String letterHolderId);
 
     @SingleValueResult
     @SqlQuery(SELECT_FROM_STATEMENT + " WHERE claim.external_id = :externalId")
@@ -97,7 +97,7 @@ public interface ClaimRepository {
     Long saveSubmittedByClaimant(
         @Bind("claim") final String claim,
         @Bind("submitterId") final Long submitterId,
-        @Bind("letterHolderId") final Long letterHolderId,
+        @Bind("letterHolderId") final String letterHolderId,
         @Bind("issuedOn") final LocalDate issuedOn,
         @Bind("responseDeadline") final LocalDate responseDeadline,
         @Bind("externalId") final String externalId,
@@ -109,7 +109,7 @@ public interface ClaimRepository {
     )
     Integer linkLetterHolder(
         @Bind("claimId") final Long claimId,
-        @Bind("letterHolderId") final Long letterHolderId
+        @Bind("letterHolderId") final String letterHolderId
     );
 
     @SqlUpdate(

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
@@ -24,7 +24,7 @@ public interface ClaimRepository {
     String ORDER_BY_ID_DESCENDING  = " ORDER BY claim.id DESC";
 
     @SqlQuery(SELECT_FROM_STATEMENT + " WHERE claim.submitter_id = :submitterId" + ORDER_BY_ID_DESCENDING)
-    List<Claim> getBySubmitterId(@Bind("submitterId") Long submitterId);
+    List<Claim> getBySubmitterId(@Bind("submitterId") String submitterId);
 
     @SingleValueResult
     @SqlQuery(SELECT_FROM_STATEMENT + " WHERE claim.letter_holder_id = :letterHolderId")
@@ -66,7 +66,7 @@ public interface ClaimRepository {
         + ")")
     Long saveRepresented(
         @Bind("claim") final String claim,
-        @Bind("submitterId") final Long submitterId,
+        @Bind("submitterId") final String submitterId,
         @Bind("issuedOn") final LocalDate issuedOn,
         @Bind("responseDeadline") final LocalDate responseDeadline,
         @Bind("externalId") final String externalId,
@@ -96,7 +96,7 @@ public interface ClaimRepository {
         + ")")
     Long saveSubmittedByClaimant(
         @Bind("claim") final String claim,
-        @Bind("submitterId") final Long submitterId,
+        @Bind("submitterId") final String submitterId,
         @Bind("letterHolderId") final String letterHolderId,
         @Bind("issuedOn") final LocalDate issuedOn,
         @Bind("responseDeadline") final LocalDate responseDeadline,
@@ -117,7 +117,7 @@ public interface ClaimRepository {
     )
     Integer linkDefendant(
         @Bind("claimId") final Long claimId,
-        @Bind("defendantId") final Long defendantId
+        @Bind("defendantId") final String defendantId
     );
 
     @SqlUpdate(

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
@@ -35,7 +35,7 @@ public interface ClaimRepository {
     Optional<Claim> getClaimByExternalId(@Bind("externalId") String externalId);
 
     @SqlQuery(SELECT_FROM_STATEMENT + " WHERE claim.defendant_id = :defendantId" + ORDER_BY_ID_DESCENDING)
-    List<Claim> getByDefendantId(@Bind("defendantId") Long defendantId);
+    List<Claim> getByDefendantId(@Bind("defendantId") String defendantId);
 
     @SingleValueResult
     @SqlQuery(SELECT_FROM_STATEMENT + " WHERE claim.reference_number = :claimReferenceNumber")

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/DefendantResponseRepository.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/DefendantResponseRepository.java
@@ -15,7 +15,7 @@ public interface DefendantResponseRepository {
     )
     void save(
         @Bind("claimId") final Long claimId,
-        @Bind("defendantId") final Long defendantId,
+        @Bind("defendantId") final String defendantId,
         @Bind("defendantEmail") final String defendantEmail,
         @Bind("response") final String response
     );

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/ClaimMapper.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/ClaimMapper.java
@@ -22,7 +22,7 @@ public class ClaimMapper implements ResultSetMapper<Claim> {
         return new Claim(
             result.getLong("id"),
             result.getLong("submitter_id"),
-            result.getLong("letter_holder_id"),
+            result.getString("letter_holder_id"),
             toNullableLong((Integer) result.getObject("defendant_id")),
             result.getString("external_id"),
             result.getString("reference_number"),

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/ClaimMapper.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/ClaimMapper.java
@@ -21,9 +21,9 @@ public class ClaimMapper implements ResultSetMapper<Claim> {
     public Claim map(int index, ResultSet result, StatementContext ctx) throws SQLException {
         return new Claim(
             result.getLong("id"),
-            result.getLong("submitter_id"),
+            result.getString("submitter_id"),
             result.getString("letter_holder_id"),
-            toNullableLong((Integer) result.getObject("defendant_id")),
+            result.getString("defendant_id"),
             result.getString("external_id"),
             result.getString("reference_number"),
             toClaimData(result.getString("claim")),
@@ -46,10 +46,6 @@ public class ClaimMapper implements ResultSetMapper<Claim> {
 
     private ResponseData toNullableResponseData(final String input) {
         return input != null ? jsonMapper.fromJson(input, ResponseData.class) : null;
-    }
-
-    private Long toNullableLong(final Integer input) {
-        return input != null ? input.longValue() : null;
     }
 
     private CountyCourtJudgment toNullableCountyCourtJudgment(final String input) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
@@ -58,7 +58,7 @@ public class ClaimService {
         return claimRepository.getBySubmitterId(submitterId);
     }
 
-    public Claim getClaimByLetterHolderId(final long id) {
+    public Claim getClaimByLetterHolderId(final String id) {
         return claimRepository
             .getByLetterHolderId(id)
             .orElseThrow(() -> new NotFoundException("Claim not found for letter holder id " + id));
@@ -94,7 +94,7 @@ public class ClaimService {
             pinResponse = Optional.of(userService.generatePin(claimData.getDefendant().getName(), authorisation));
         }
 
-        final Optional<Long> letterHolderId = pinResponse.map(GeneratePinResponse::getUserId);
+        final Optional<String> letterHolderId = pinResponse.map(GeneratePinResponse::getUserId);
         final LocalDate issuedOn = issueDateCalculator.calculateIssueDay(now);
         final LocalDate responseDeadline = responseDeadlineCalculator.calculateResponseDeadline(issuedOn);
         final UserDetails userDetails = userService.getUserDetails(authorisation);

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
@@ -75,7 +75,7 @@ public class ClaimService {
             .getByClaimReferenceNumber(reference);
     }
 
-    public List<Claim> getClaimByDefendantId(final long id) {
+    public List<Claim> getClaimByDefendantId(final String id) {
         return claimRepository.getByDefendantId(id);
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
@@ -54,7 +54,7 @@ public class ClaimService {
             .orElseThrow(() -> new NotFoundException("Claim not found by id " + claimId));
     }
 
-    public List<Claim> getClaimBySubmitterId(final long submitterId) {
+    public List<Claim> getClaimBySubmitterId(final String submitterId) {
         return claimRepository.getBySubmitterId(submitterId);
     }
 
@@ -80,7 +80,7 @@ public class ClaimService {
     }
 
     @Transactional
-    public Claim saveClaim(final long submitterId, final ClaimData claimData, final String authorisation) {
+    public Claim saveClaim(final String submitterId, final ClaimData claimData, final String authorisation) {
         final String externalId = claimData.getExternalId().toString();
 
         claimRepository.getClaimByExternalId(externalId).ifPresent(claim -> {
@@ -150,7 +150,7 @@ public class ClaimService {
         return claim;
     }
 
-    public void linkDefendantToClaim(Long claimId, Long defendantId) {
+    public void linkDefendantToClaim(Long claimId, String defendantId) {
         final Claim claim = claimRepository.getById(claimId)
             .orElseThrow(() -> new NotFoundException("Claim not found by id: " + claimId));
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentService.java
@@ -46,7 +46,7 @@ public class CountyCourtJudgmentService {
     }
 
     @Transactional
-    public Claim save(final long submitterId, final CountyCourtJudgment countyCourtJudgment, final long claimId) {
+    public Claim save(final String submitterId, final CountyCourtJudgment countyCourtJudgment, final long claimId) {
 
         Claim claim = getClaim(claimId);
 
@@ -85,7 +85,7 @@ public class CountyCourtJudgmentService {
         return null != claim.getRespondedAt();
     }
 
-    private boolean isClaimSubmittedByUser(final Claim claim, final long submitterId) {
+    private boolean isClaimSubmittedByUser(final Claim claim, final String submitterId) {
         return claim.getSubmitterId().equals(submitterId);
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseService.java
@@ -35,7 +35,7 @@ public class DefendantResponseService {
     @Transactional
     public Claim save(
         final long claimId,
-        final long defendantId,
+        final String defendantId,
         final ResponseData responseData,
         final String authorization
     ) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/AmountContent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/AmountContent.java
@@ -1,5 +1,9 @@
 package uk.gov.hmcts.cmc.claimstore.services.staff.content.countycourtjudgment;
 
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+
+import static uk.gov.hmcts.cmc.claimstore.utils.ToStringStyle.ourStyle;
+
 public class AmountContent {
 
     private String totalAmount;
@@ -47,5 +51,10 @@ public class AmountContent {
 
     public String getRemainingAmount() {
         return remainingAmount;
+    }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this, ourStyle());
     }
 }

--- a/src/main/resources/db/migration/V2017_10_17_1100__Change_idam_ids_to_text.sql
+++ b/src/main/resources/db/migration/V2017_10_17_1100__Change_idam_ids_to_text.sql
@@ -1,0 +1,4 @@
+ALTER TABLE claim
+  ALTER COLUMN submitter_id TYPE TEXT USING submitter_id :: TEXT,
+  ALTER COLUMN letter_holder_id TYPE TEXT USING letter_holder_id :: TEXT,
+  ALTER COLUMN defendant_id TYPE TEXT USING defendant_id :: TEXT;

--- a/src/main/resources/db/migration/V2017_10_17_1100__Change_letter_holder_id_to_text.sql
+++ b/src/main/resources/db/migration/V2017_10_17_1100__Change_letter_holder_id_to_text.sql
@@ -1,0 +1,2 @@
+ALTER TABLE claim
+  ALTER COLUMN letter_holder_id TYPE TEXT USING letter_holder_id :: TEXT;

--- a/src/main/resources/db/migration/V2017_10_17_1100__Change_letter_holder_id_to_text.sql
+++ b/src/main/resources/db/migration/V2017_10_17_1100__Change_letter_holder_id_to_text.sql
@@ -1,2 +1,0 @@
-ALTER TABLE claim
-  ALTER COLUMN letter_holder_id TYPE TEXT USING letter_holder_id :: TEXT;

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/clients/IdamClientTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/clients/IdamClientTest.java
@@ -25,7 +25,7 @@ public class IdamClientTest {
     private static final String IDAM_API_URL = "idam-api-url";
     private static final String PIN_ENDPOINT = "/pin";
     private static final String PIN = "my-pin-generated";
-    private static final Long LETTER_HOLDER_ID = 1L;
+    private static final String LETTER_HOLDER_ID = "1";
     private static final String AUTHORISATION = "Bearer: token";
     private static final GeneratePinRequest request = new GeneratePinRequest("a b");
     private static final GeneratePinResponse expResponseBody = new GeneratePinResponse(PIN, LETTER_HOLDER_ID);

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/utils/sampledata/SampleClaim.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/utils/sampledata/SampleClaim.java
@@ -19,9 +19,9 @@ import static uk.gov.hmcts.cmc.claimstore.utils.DatesProvider.RESPONSE_DEADLINE;
 
 public final class SampleClaim {
 
-    public static final Long USER_ID = 1L;
+    public static final String USER_ID = "1";
     public static final String LETTER_HOLDER_ID = "2";
-    public static final Long DEFENDANT_ID = 4L;
+    public static final String DEFENDANT_ID = "4";
     public static final Long CLAIM_ID = 3L;
     public static final String REFERENCE_NUMBER = "000CM001";
     public static final String EXTERNAL_ID = UUID.randomUUID().toString();
@@ -30,9 +30,9 @@ public final class SampleClaim {
     public static final String SUBMITTER_EMAIL = "claimant@mail.com";
     public static final String DEFENDANT_EMAIL = SampleTheirDetails.DEFENDANT_EMAIL;
 
-    private Long submitterId = USER_ID;
+    private String submitterId = USER_ID;
     private String letterHolderId = LETTER_HOLDER_ID;
-    private Long defendantId = DEFENDANT_ID;
+    private String defendantId = DEFENDANT_ID;
     private Long claimId = CLAIM_ID;
     private String referenceNumber = REFERENCE_NUMBER;
     private String externalId = EXTERNAL_ID;
@@ -146,7 +146,7 @@ public final class SampleClaim {
             countyCourtJudgmentRequestedAt);
     }
 
-    public SampleClaim withSubmitterId(Long userId) {
+    public SampleClaim withSubmitterId(String userId) {
         this.submitterId = userId;
         return this;
     }
@@ -156,7 +156,7 @@ public final class SampleClaim {
         return this;
     }
 
-    public SampleClaim withDefendantId(Long defendantId) {
+    public SampleClaim withDefendantId(String defendantId) {
         this.defendantId = defendantId;
         return this;
     }

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/utils/sampledata/SampleClaim.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/utils/sampledata/SampleClaim.java
@@ -20,7 +20,7 @@ import static uk.gov.hmcts.cmc.claimstore.utils.DatesProvider.RESPONSE_DEADLINE;
 public final class SampleClaim {
 
     public static final Long USER_ID = 1L;
-    public static final Long LETTER_HOLDER_ID = 2L;
+    public static final String LETTER_HOLDER_ID = "2";
     public static final Long DEFENDANT_ID = 4L;
     public static final Long CLAIM_ID = 3L;
     public static final String REFERENCE_NUMBER = "000CM001";
@@ -31,7 +31,7 @@ public final class SampleClaim {
     public static final String DEFENDANT_EMAIL = SampleTheirDetails.DEFENDANT_EMAIL;
 
     private Long submitterId = USER_ID;
-    private Long letterHolderId = LETTER_HOLDER_ID;
+    private String letterHolderId = LETTER_HOLDER_ID;
     private Long defendantId = DEFENDANT_ID;
     private Long claimId = CLAIM_ID;
     private String referenceNumber = REFERENCE_NUMBER;
@@ -151,7 +151,7 @@ public final class SampleClaim {
         return this;
     }
 
-    public SampleClaim withLetterHolderId(Long letterHolderId) {
+    public SampleClaim withLetterHolderId(String letterHolderId) {
         this.letterHolderId = letterHolderId;
         return this;
     }

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/models/ClaimTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/models/ClaimTest.java
@@ -59,9 +59,9 @@ public class ClaimTest {
     private static Claim customCreatedAt(final LocalDateTime createdAt) {
         return new Claim(
             1L,
-            2L,
             "3",
-            4L,
+            "3",
+            "4",
             "external-id",
             "ref number",
             null,

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/models/ClaimTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/models/ClaimTest.java
@@ -60,7 +60,7 @@ public class ClaimTest {
         return new Claim(
             1L,
             2L,
-            3L,
+            "3",
             4L,
             "external-id",
             "ref number",

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
@@ -112,7 +112,7 @@ public class ClaimServiceTest {
     @Test
     public void getClaimByLetterHolderIdShouldCallRepositoryWhenValidClaimIsReturned() {
 
-        Long letterHolderId = 1L;
+        String letterHolderId = "1";
         Claim claim = createClaimModel(VALID_APP, letterHolderId);
         Optional<Claim> result = Optional.of(claim);
 
@@ -126,7 +126,7 @@ public class ClaimServiceTest {
     public void getClaimByLetterHolderIdShouldThrowExceptionWhenClaimDoesNotExist() {
 
         Optional<Claim> result = Optional.empty();
-        Long letterHolderId = 0L;
+        String letterHolderId = "0";
 
         when(claimRepository.getByLetterHolderId(eq(letterHolderId))).thenReturn(result);
 
@@ -235,7 +235,7 @@ public class ClaimServiceTest {
         claimService.requestMoreTimeForResponse(CLAIM_ID, VALID_DEFENDANT_TOKEN);
     }
 
-    private static Claim createClaimModel(ClaimData claimData, Long letterHolderId) {
+    private static Claim createClaimModel(ClaimData claimData, String letterHolderId) {
         return new Claim(
             CLAIM_ID,
             USER_ID,

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
@@ -56,10 +56,10 @@ public class ClaimServiceTest {
         = SampleUserDetails.builder().withUserId(DEFENDANT_ID).withMail(DEFENDANT_EMAIL).build();
 
     private static final UserDetails invalidDefendant
-        = SampleUserDetails.builder().withUserId(-1L).withMail(DEFENDANT_EMAIL).build();
+        = SampleUserDetails.builder().withUserId("-1").withMail(DEFENDANT_EMAIL).build();
 
     private static final UserDetails claimantDetails
-        = SampleUserDetails.builder().withUserId(11L).withMail(SUBMITTER_EMAIL).build();
+        = SampleUserDetails.builder().withUserId("11").withMail(SUBMITTER_EMAIL).build();
 
     private ClaimService claimService;
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentServiceTest.java
@@ -94,7 +94,7 @@ public class CountyCourtJudgmentServiceTest {
     @Test(expected = ForbiddenActionException.class)
     public void saveThrowsForbiddenActionExceptionWhenClaimWasSubmittedBySomeoneElse() {
 
-        final long differentUser = -865564L;
+        final String differentUser = "34234234";
 
         Claim claim = SampleClaim.getDefault();
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/fixtures/SampleUserDetails.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/fixtures/SampleUserDetails.java
@@ -7,7 +7,7 @@ import static uk.gov.hmcts.cmc.claimstore.events.utils.sampledata.SampleClaimIss
 import static uk.gov.hmcts.cmc.claimstore.events.utils.sampledata.SampleClaimIssuedEvent.SUBMITTER_SURNAME;
 
 public final class SampleUserDetails {
-    private Long userId = USER_ID;
+    private String userId = USER_ID;
     private String userEmail = "user@example.com";
     private String forename = SUBMITTER_FORENAME;
     private String surname = SUBMITTER_SURNAME;
@@ -22,7 +22,7 @@ public final class SampleUserDetails {
         return this;
     }
 
-    public SampleUserDetails withUserId(final Long userId) {
+    public SampleUserDetails withUserId(final String userId) {
         this.userId = userId;
         return this;
     }


### PR DESCRIPTION
The type for the IDAM identifier was an implementation detail and should
not have been assumed.

The type is changing soon, to enable testing of the new solution we need
to remove our assumption on the type