### PR TITLE
Use Alpine images in Dockerfiles and integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 COPY build/install/claim-store /opt/app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:8-jre-alpine
 
+RUN apk add --no-cache curl
+
 COPY build/install/claim-store /opt/app/
 
 WORKDIR /opt/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM openjdk:8-jre-alpine
 
-RUN apk add --no-cache curl
-
 COPY build/install/claim-store /opt/app/
 
 WORKDIR /opt/app
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy="" curl --silent --fail http://localhost:4400/health
+HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy="" wget -q http://localhost:4400/health || exit 1
 
 EXPOSE 4400
 

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.6
+FROM postgres:9.6-alpine
 
 COPY init-db.sh /docker-entrypoint-initdb.d
 

--- a/src/integrationTest/resources/environment.properties
+++ b/src/integrationTest/resources/environment.properties
@@ -1,5 +1,5 @@
 database.driverClassName=org.testcontainers.jdbc.ContainerDatabaseDriver
-database.url=jdbc:tc:postgresql:9.6://localhost/claimstore
+database.url=jdbc:tc:postgresql:9.6-alpine://localhost/claimstore
 
 pdfService.baseUrl = http://some-test-host/api/v1/pdf-generator
 staff-notifications.sender = sender@example.com


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Use Alpine images in Dockerfiles and integration tests. That will speedup build process by tiny bit in case local cache is empty.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```