### PR TITLE
Remove final arguments

### DIFF
--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/CCDPartyType.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/CCDPartyType.java
@@ -8,7 +8,7 @@ public enum CCDPartyType {
 
     private String value;
 
-    CCDPartyType(final String value) {
+    CCDPartyType(String value) {
         this.value = value;
     }
 

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/AmountMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/AmountMapper.java
@@ -15,9 +15,9 @@ import static uk.gov.hmcts.cmc.ccd.domain.AmountType.RANGE;
 @Component
 public class AmountMapper implements Mapper<CCDAmount, Amount> {
 
-    private AmountRangeMapper amountRangeMapper;
+    private final AmountRangeMapper amountRangeMapper;
 
-    public AmountMapper(final AmountRangeMapper amountRangeMapper) {
+    public AmountMapper(AmountRangeMapper amountRangeMapper) {
         this.amountRangeMapper = amountRangeMapper;
     }
 

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/AmountRangeMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/AmountRangeMapper.java
@@ -9,7 +9,7 @@ public class AmountRangeMapper implements Mapper<CCDAmountRange, AmountRange> {
 
     @Override
     public CCDAmountRange to(AmountRange amountRange) {
-        final CCDAmountRange.CCDAmountRangeBuilder builder = CCDAmountRange.builder();
+        CCDAmountRange.CCDAmountRangeBuilder builder = CCDAmountRange.builder();
         amountRange.getLowerValue().ifPresent(builder::lowerValue);
         return builder.higherValue(amountRange.getHigherValue()).build();
     }

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapper.java
@@ -15,7 +15,7 @@ public class CaseMapper implements Mapper<CCDCase, Claim> {
 
     private final ClaimMapper claimMapper;
 
-    public CaseMapper(final ClaimMapper claimMapper) {
+    public CaseMapper(ClaimMapper claimMapper) {
         this.claimMapper = claimMapper;
     }
 

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/ClaimMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/ClaimMapper.java
@@ -23,12 +23,12 @@ public class ClaimMapper implements Mapper<CCDClaim, ClaimData> {
     private final AmountMapper amountMapper;
 
     @Autowired
-    public ClaimMapper(final PersonalInjuryMapper personalInjuryMapper,
-                       final HousingDisrepairMapper housingDisrepairMapper,
-                       final StatementOfTruthMapper statementOfTruthMapper,
-                       final PartyMapper partyMapper,
-                       final TheirDetailsMapper theirDetailsMapper,
-                       final AmountMapper amountMapper) {
+    public ClaimMapper(PersonalInjuryMapper personalInjuryMapper,
+                       HousingDisrepairMapper housingDisrepairMapper,
+                       StatementOfTruthMapper statementOfTruthMapper,
+                       PartyMapper partyMapper,
+                       TheirDetailsMapper theirDetailsMapper,
+                       AmountMapper amountMapper) {
 
         this.personalInjuryMapper = personalInjuryMapper;
         this.housingDisrepairMapper = housingDisrepairMapper;
@@ -41,7 +41,7 @@ public class ClaimMapper implements Mapper<CCDClaim, ClaimData> {
     @Override
     public CCDClaim to(ClaimData claimData) {
         Objects.requireNonNull(claimData, "claimData must not be null");
-        final CCDClaim.CCDClaimBuilder builder = CCDClaim.builder();
+        CCDClaim.CCDClaimBuilder builder = CCDClaim.builder();
         claimData.getFeeCode().ifPresent(builder::feeCode);
         claimData.getFeeAccountNumber().ifPresent(builder::feeAccountNumber);
         claimData.getExternalReferenceNumber().ifPresent(builder::externalReferenceNumber);

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/ClaimMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/ClaimMapper.java
@@ -76,7 +76,7 @@ public class ClaimMapper implements Mapper<CCDClaim, ClaimData> {
             .build();
     }
 
-    private Map<String, CCDParty> mapToValue(final CCDParty ccdParty) {
+    private Map<String, CCDParty> mapToValue(CCDParty ccdParty) {
         return Collections.singletonMap(COLLECTION_KEY_NAME, ccdParty);
     }
 
@@ -115,7 +115,7 @@ public class ClaimMapper implements Mapper<CCDClaim, ClaimData> {
             ccdClaim.getFeeCode());
     }
 
-    private CCDParty valueFromMap(final Map<String, CCDParty> value) {
+    private CCDParty valueFromMap(Map<String, CCDParty> value) {
         return value.get(COLLECTION_KEY_NAME);
     }
 }

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CompanyMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CompanyMapper.java
@@ -12,7 +12,7 @@ public class CompanyMapper implements Mapper<CCDCompany, Company> {
     private final RepresentativeMapper representativeMapper;
 
     @Autowired
-    public CompanyMapper(final AddressMapper addressMapper, final RepresentativeMapper representativeMapper) {
+    public CompanyMapper(AddressMapper addressMapper, RepresentativeMapper representativeMapper) {
         this.addressMapper = addressMapper;
         this.representativeMapper = representativeMapper;
     }
@@ -20,7 +20,7 @@ public class CompanyMapper implements Mapper<CCDCompany, Company> {
     @Override
     public CCDCompany to(Company company) {
 
-        final CCDCompany.CCDCompanyBuilder builder = CCDCompany.builder();
+        CCDCompany.CCDCompanyBuilder builder = CCDCompany.builder();
         company.getMobilePhone().ifPresent(builder::mobilePhone);
         company.getContactPerson().ifPresent(builder::contactPerson);
 

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/ContactDetailsMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/ContactDetailsMapper.java
@@ -10,7 +10,7 @@ public class ContactDetailsMapper implements Mapper<CCDContactDetails, ContactDe
     @Override
     public CCDContactDetails to(ContactDetails contactDetails) {
 
-        final CCDContactDetails.CCDContactDetailsBuilder builder = CCDContactDetails.builder();
+        CCDContactDetails.CCDContactDetailsBuilder builder = CCDContactDetails.builder();
         contactDetails.getEmail().ifPresent(builder::email);
         contactDetails.getPhone().ifPresent(builder::phone);
         contactDetails.getDxAddress().ifPresent(builder::dxAddress);

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/IndividualMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/IndividualMapper.java
@@ -15,7 +15,7 @@ public class IndividualMapper implements Mapper<CCDIndividual, Individual> {
     private final RepresentativeMapper representativeMapper;
 
     @Autowired
-    public IndividualMapper(final AddressMapper addressMapper, final RepresentativeMapper representativeMapper) {
+    public IndividualMapper(AddressMapper addressMapper, RepresentativeMapper representativeMapper) {
         this.addressMapper = addressMapper;
         this.representativeMapper = representativeMapper;
     }
@@ -23,7 +23,7 @@ public class IndividualMapper implements Mapper<CCDIndividual, Individual> {
     @Override
     public CCDIndividual to(Individual individual) {
 
-        final CCDIndividual.CCDIndividualBuilder builder = CCDIndividual.builder();
+        CCDIndividual.CCDIndividualBuilder builder = CCDIndividual.builder();
         individual.getTitle().ifPresent(builder::title);
         individual.getMobilePhone().ifPresent(builder::mobilePhone);
 

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/OrganisationMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/OrganisationMapper.java
@@ -12,7 +12,7 @@ public class OrganisationMapper implements Mapper<CCDOrganisation, Organisation>
     private final RepresentativeMapper representativeMapper;
 
     @Autowired
-    public OrganisationMapper(final AddressMapper addressMapper, final RepresentativeMapper representativeMapper) {
+    public OrganisationMapper(AddressMapper addressMapper, RepresentativeMapper representativeMapper) {
         this.addressMapper = addressMapper;
         this.representativeMapper = representativeMapper;
     }
@@ -20,7 +20,7 @@ public class OrganisationMapper implements Mapper<CCDOrganisation, Organisation>
     @Override
     public CCDOrganisation to(Organisation organisation) {
 
-        final CCDOrganisation.CCDOrganisationBuilder builder = CCDOrganisation.builder();
+        CCDOrganisation.CCDOrganisationBuilder builder = CCDOrganisation.builder();
         organisation.getCorrespondenceAddress()
             .ifPresent(address -> builder.correspondenceAddress(addressMapper.to(address)));
         organisation.getRepresentative()

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/PartyMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/PartyMapper.java
@@ -29,12 +29,12 @@ public class PartyMapper implements Mapper<CCDParty, Party> {
     private final RepresentativeMapper representativeMapper;
 
     @Autowired
-    public PartyMapper(final IndividualMapper individualMapper,
-                       final CompanyMapper companyMapper,
-                       final OrganisationMapper organisationMapper,
-                       final SoleTraderMapper soleTraderMapper,
-                       final AddressMapper addressMapper,
-                       final RepresentativeMapper representativeMapper) {
+    public PartyMapper(IndividualMapper individualMapper,
+                       CompanyMapper companyMapper,
+                       OrganisationMapper organisationMapper,
+                       SoleTraderMapper soleTraderMapper,
+                       AddressMapper addressMapper,
+                       RepresentativeMapper representativeMapper) {
 
         this.individualMapper = individualMapper;
         this.companyMapper = companyMapper;
@@ -46,7 +46,7 @@ public class PartyMapper implements Mapper<CCDParty, Party> {
 
     @Override
     public CCDParty to(Party party) {
-        final CCDParty.CCDPartyBuilder builder = CCDParty.builder();
+        CCDParty.CCDPartyBuilder builder = CCDParty.builder();
 
         if (party instanceof Individual) {
             builder.type(CCDPartyType.INDIVIDUAL);
@@ -73,25 +73,25 @@ public class PartyMapper implements Mapper<CCDParty, Party> {
     public Party from(CCDParty ccdParty) {
         switch (ccdParty.getType()) {
             case COMPANY:
-                final CCDCompany ccdCompany = ccdParty.getCompany();
+                CCDCompany ccdCompany = ccdParty.getCompany();
                 return new Company(ccdCompany.getName(), addressMapper.from(ccdCompany.getAddress()),
                     addressMapper.from(ccdCompany.getCorrespondenceAddress()),
                     ccdCompany.getMobilePhone(), representativeMapper.from(ccdCompany.getRepresentative()),
                     ccdCompany.getContactPerson());
             case INDIVIDUAL:
-                final CCDIndividual ccdIndividual = ccdParty.getIndividual();
+                CCDIndividual ccdIndividual = ccdParty.getIndividual();
                 return new Individual(ccdIndividual.getName(), addressMapper.from(ccdIndividual.getAddress()),
                     addressMapper.from(ccdIndividual.getCorrespondenceAddress()), ccdIndividual.getMobilePhone(),
                     representativeMapper.from(ccdIndividual.getRepresentative()), ccdIndividual.getTitle(),
                     LocalDate.parse(ccdIndividual.getDateOfBirth(), DateTimeFormatter.ISO_DATE));
             case SOLE_TRADER:
-                final CCDSoleTrader ccdSoleTrader = ccdParty.getSoleTrader();
+                CCDSoleTrader ccdSoleTrader = ccdParty.getSoleTrader();
                 return new SoleTrader(ccdSoleTrader.getName(), addressMapper.from(ccdSoleTrader.getAddress()),
                     addressMapper.from(ccdSoleTrader.getCorrespondenceAddress()), ccdSoleTrader.getMobilePhone(),
                     representativeMapper.from(ccdSoleTrader.getRepresentative()), ccdSoleTrader.getTitle(),
                     ccdSoleTrader.getBusinessName());
             case ORGANISATION:
-                final CCDOrganisation ccdOrganisation = ccdParty.getOrganisation();
+                CCDOrganisation ccdOrganisation = ccdParty.getOrganisation();
                 return new Organisation(ccdOrganisation.getName(), addressMapper.from(ccdOrganisation.getAddress()),
                     addressMapper.from(ccdOrganisation.getCorrespondenceAddress()), ccdOrganisation.getMobilePhone(),
                     representativeMapper.from(ccdOrganisation.getRepresentative()), ccdOrganisation.getContactPerson(),

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/RepresentativeMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/RepresentativeMapper.java
@@ -16,7 +16,7 @@ public class RepresentativeMapper implements Mapper<CCDRepresentative, Represent
     private final ContactDetailsMapper contactDetailsMapper;
 
     @Autowired
-    public RepresentativeMapper(final AddressMapper addressMapper, final ContactDetailsMapper contactDetailsMapper) {
+    public RepresentativeMapper(AddressMapper addressMapper, ContactDetailsMapper contactDetailsMapper) {
         this.addressMapper = addressMapper;
         this.contactDetailsMapper = contactDetailsMapper;
     }
@@ -24,7 +24,7 @@ public class RepresentativeMapper implements Mapper<CCDRepresentative, Represent
     @Override
     public CCDRepresentative to(Representative representative) {
 
-        final CCDRepresentative.CCDRepresentativeBuilder builder = CCDRepresentative.builder();
+        CCDRepresentative.CCDRepresentativeBuilder builder = CCDRepresentative.builder();
         representative.getOrganisationContactDetails()
             .ifPresent(organisationContactDetails -> builder.organisationContactDetails(
                 contactDetailsMapper.to(organisationContactDetails))
@@ -38,9 +38,9 @@ public class RepresentativeMapper implements Mapper<CCDRepresentative, Represent
 
     @Override
     public Representative from(CCDRepresentative representative) {
-        final Optional<CCDContactDetails> organisationContactDetailsOptional =
+        Optional<CCDContactDetails> organisationContactDetailsOptional =
             representative.getOrganisationContactDetails();
-        final ContactDetails organisationContactDetails =
+        ContactDetails organisationContactDetails =
             organisationContactDetailsOptional
                 .isPresent() ? contactDetailsMapper.from(organisationContactDetailsOptional.get()) : null;
 

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/SoleTraderMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/SoleTraderMapper.java
@@ -12,7 +12,7 @@ public class SoleTraderMapper implements Mapper<CCDSoleTrader, SoleTrader> {
     private final RepresentativeMapper representativeMapper;
 
     @Autowired
-    public SoleTraderMapper(final AddressMapper addressMapper, final RepresentativeMapper representativeMapper) {
+    public SoleTraderMapper(AddressMapper addressMapper, RepresentativeMapper representativeMapper) {
         this.addressMapper = addressMapper;
         this.representativeMapper = representativeMapper;
     }
@@ -20,7 +20,7 @@ public class SoleTraderMapper implements Mapper<CCDSoleTrader, SoleTrader> {
     @Override
     public CCDSoleTrader to(SoleTrader soleTrader) {
 
-        final CCDSoleTrader.CCDSoleTraderBuilder builder = CCDSoleTrader.builder();
+        CCDSoleTrader.CCDSoleTraderBuilder builder = CCDSoleTrader.builder();
         soleTrader.getTitle().ifPresent(builder::title);
         soleTrader.getMobilePhone().ifPresent(builder::mobilePhone);
         soleTrader.getBusinessName().ifPresent(builder::businessName);

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/TheirDetailsMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/TheirDetailsMapper.java
@@ -35,12 +35,12 @@ public class TheirDetailsMapper implements Mapper<CCDParty, TheirDetails> {
     private final AddressMapper addressMapper;
     private final RepresentativeMapper representativeMapper;
 
-    public TheirDetailsMapper(final IndividualDetailsMapper individualDetailsMapper,
-                              final CompanyDetailsMapper companyDetailsMapper,
-                              final OrganisationDetailsMapper organisationDetailsMapper,
-                              final SoleTraderDetailsMapper soleTraderDetailsMapper,
-                              final AddressMapper addressMapper,
-                              final RepresentativeMapper representativeMapper) {
+    public TheirDetailsMapper(IndividualDetailsMapper individualDetailsMapper,
+                              CompanyDetailsMapper companyDetailsMapper,
+                              OrganisationDetailsMapper organisationDetailsMapper,
+                              SoleTraderDetailsMapper soleTraderDetailsMapper,
+                              AddressMapper addressMapper,
+                              RepresentativeMapper representativeMapper) {
 
         this.individualDetailsMapper = individualDetailsMapper;
         this.companyDetailsMapper = companyDetailsMapper;
@@ -52,7 +52,7 @@ public class TheirDetailsMapper implements Mapper<CCDParty, TheirDetails> {
 
     @Override
     public CCDParty to(TheirDetails theirDetails) {
-        final CCDParty.CCDPartyBuilder builder = CCDParty.builder();
+        CCDParty.CCDPartyBuilder builder = CCDParty.builder();
 
         if (theirDetails instanceof IndividualDetails) {
             builder.type(INDIVIDUAL);
@@ -92,14 +92,14 @@ public class TheirDetailsMapper implements Mapper<CCDParty, TheirDetails> {
     }
 
     private TheirDetails getCompany(CCDParty ccdParty) {
-        final CCDCompany ccdCompany = ccdParty.getCompany();
+        CCDCompany ccdCompany = ccdParty.getCompany();
         return new CompanyDetails(ccdCompany.getName(), addressMapper.from(ccdCompany.getAddress()),
             ccdCompany.getEmail(), representativeMapper.from(ccdCompany.getRepresentative()),
             addressMapper.from(ccdCompany.getCorrespondenceAddress()), ccdCompany.getContactPerson());
     }
 
     private TheirDetails getIndividual(CCDParty ccdParty) {
-        final CCDIndividual ccdIndividual = ccdParty.getIndividual();
+        CCDIndividual ccdIndividual = ccdParty.getIndividual();
         return new IndividualDetails(ccdIndividual.getName(), addressMapper.from(ccdIndividual.getAddress()),
             ccdIndividual.getEmail(), representativeMapper.from(ccdIndividual.getRepresentative()),
             addressMapper.from(ccdIndividual.getCorrespondenceAddress()), ccdIndividual.getTitle(),
@@ -107,7 +107,7 @@ public class TheirDetailsMapper implements Mapper<CCDParty, TheirDetails> {
     }
 
     private TheirDetails getSoleTrader(CCDParty ccdParty) {
-        final CCDSoleTrader ccdSoleTrader = ccdParty.getSoleTrader();
+        CCDSoleTrader ccdSoleTrader = ccdParty.getSoleTrader();
         return new SoleTraderDetails(ccdSoleTrader.getName(), addressMapper.from(ccdSoleTrader.getAddress()),
             ccdSoleTrader.getEmail(), representativeMapper.from(ccdSoleTrader.getRepresentative()),
             addressMapper.from(ccdSoleTrader.getCorrespondenceAddress()), ccdSoleTrader.getTitle(),
@@ -115,7 +115,7 @@ public class TheirDetailsMapper implements Mapper<CCDParty, TheirDetails> {
     }
 
     private TheirDetails getOrganisation(CCDParty ccdParty) {
-        final CCDOrganisation ccdOrganisation = ccdParty.getOrganisation();
+        CCDOrganisation ccdOrganisation = ccdParty.getOrganisation();
         return new OrganisationDetails(ccdOrganisation.getName(),
             addressMapper.from(ccdOrganisation.getAddress()), ccdOrganisation.getEmail(),
             representativeMapper.from(ccdOrganisation.getRepresentative()),

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/CompanyDetailsMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/CompanyDetailsMapper.java
@@ -15,7 +15,7 @@ public class CompanyDetailsMapper implements Mapper<CCDCompany, CompanyDetails> 
     private final RepresentativeMapper representativeMapper;
 
     @Autowired
-    public CompanyDetailsMapper(final AddressMapper addressMapper, final RepresentativeMapper representativeMapper) {
+    public CompanyDetailsMapper(AddressMapper addressMapper, RepresentativeMapper representativeMapper) {
         this.addressMapper = addressMapper;
         this.representativeMapper = representativeMapper;
     }
@@ -23,7 +23,7 @@ public class CompanyDetailsMapper implements Mapper<CCDCompany, CompanyDetails> 
     @Override
     public CCDCompany to(CompanyDetails company) {
 
-        final CCDCompany.CCDCompanyBuilder builder = CCDCompany.builder();
+        CCDCompany.CCDCompanyBuilder builder = CCDCompany.builder();
         company.getContactPerson().ifPresent(builder::contactPerson);
         company.getEmail().ifPresent(builder::email);
 

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/IndividualDetailsMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/IndividualDetailsMapper.java
@@ -19,7 +19,7 @@ public class IndividualDetailsMapper implements Mapper<CCDIndividual, Individual
     private final RepresentativeMapper representativeMapper;
 
     @Autowired
-    public IndividualDetailsMapper(final AddressMapper addressMapper, final RepresentativeMapper representativeMapper) {
+    public IndividualDetailsMapper(AddressMapper addressMapper, RepresentativeMapper representativeMapper) {
         this.addressMapper = addressMapper;
         this.representativeMapper = representativeMapper;
     }
@@ -27,7 +27,7 @@ public class IndividualDetailsMapper implements Mapper<CCDIndividual, Individual
     @Override
     public CCDIndividual to(IndividualDetails individual) {
 
-        final CCDIndividual.CCDIndividualBuilder builder = CCDIndividual.builder();
+        CCDIndividual.CCDIndividualBuilder builder = CCDIndividual.builder();
         individual.getTitle().ifPresent(builder::title);
         individual.getEmail().ifPresent(builder::email);
 

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/OrganisationDetailsMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/OrganisationDetailsMapper.java
@@ -15,8 +15,8 @@ public class OrganisationDetailsMapper implements Mapper<CCDOrganisation, Organi
     private final RepresentativeMapper representativeMapper;
 
     @Autowired
-    public OrganisationDetailsMapper(final AddressMapper addressMapper,
-                                     final RepresentativeMapper representativeMapper) {
+    public OrganisationDetailsMapper(AddressMapper addressMapper,
+                                     RepresentativeMapper representativeMapper) {
         this.addressMapper = addressMapper;
         this.representativeMapper = representativeMapper;
     }
@@ -24,7 +24,7 @@ public class OrganisationDetailsMapper implements Mapper<CCDOrganisation, Organi
     @Override
     public CCDOrganisation to(OrganisationDetails organisation) {
 
-        final CCDOrganisation.CCDOrganisationBuilder builder = CCDOrganisation.builder();
+        CCDOrganisation.CCDOrganisationBuilder builder = CCDOrganisation.builder();
         organisation.getServiceAddress()
             .ifPresent(address -> builder.correspondenceAddress(addressMapper.to(address)));
         organisation.getRepresentative()

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/SoleTraderDetailsMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/SoleTraderDetailsMapper.java
@@ -15,7 +15,7 @@ public class SoleTraderDetailsMapper implements Mapper<CCDSoleTrader, SoleTrader
     private final RepresentativeMapper representativeMapper;
 
     @Autowired
-    public SoleTraderDetailsMapper(final AddressMapper addressMapper, final RepresentativeMapper representativeMapper) {
+    public SoleTraderDetailsMapper(AddressMapper addressMapper, RepresentativeMapper representativeMapper) {
         this.addressMapper = addressMapper;
         this.representativeMapper = representativeMapper;
     }
@@ -23,7 +23,7 @@ public class SoleTraderDetailsMapper implements Mapper<CCDSoleTrader, SoleTrader
     @Override
     public CCDSoleTrader to(SoleTraderDetails soleTrader) {
 
-        final CCDSoleTrader.CCDSoleTraderBuilder builder = CCDSoleTrader.builder();
+        CCDSoleTrader.CCDSoleTraderBuilder builder = CCDSoleTrader.builder();
         soleTrader.getTitle().ifPresent(builder::title);
         soleTrader.getEmail().ifPresent(builder::email);
         soleTrader.getBusinessName().ifPresent(builder::businessName);

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/assertion/ContactDetailsAssert.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/assertion/ContactDetailsAssert.java
@@ -15,22 +15,22 @@ public class ContactDetailsAssert extends AbstractAssert<ContactDetailsAssert, C
     public ContactDetailsAssert isEqualTo(CCDContactDetails ccdContactDetails) {
         isNotNull();
 
-        final String phoneActual = actual.getPhone().orElse(null);
-        final String phone = ccdContactDetails.getPhone().orElse(null);
+        String phoneActual = actual.getPhone().orElse(null);
+        String phone = ccdContactDetails.getPhone().orElse(null);
         if (!Objects.equals(phoneActual, phone)) {
             failWithMessage("Expected ContactDetails.phone to be <%s> but was <%s>",
                 phone, phoneActual);
         }
 
-        final String emailActual = actual.getEmail().orElse(null);
-        final String email = ccdContactDetails.getEmail().orElse(null);
+        String emailActual = actual.getEmail().orElse(null);
+        String email = ccdContactDetails.getEmail().orElse(null);
         if (!Objects.equals(emailActual, email)) {
             failWithMessage("Expected ContactDetails.email to be <%s> but was <%s>",
                 email, emailActual);
         }
 
-        final String dxAddressActual = actual.getDxAddress().orElse(null);
-        final String dxAddress = ccdContactDetails.getDxAddress().orElse(null);
+        String dxAddressActual = actual.getDxAddress().orElse(null);
+        String dxAddress = ccdContactDetails.getDxAddress().orElse(null);
         if (!Objects.equals(dxAddressActual, dxAddress)) {
             failWithMessage("Expected ContactDetails.dxAddress to be <%s> but was <%s>",
                 dxAddress, dxAddressActual);

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/assertion/IndividualAssert.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/assertion/IndividualAssert.java
@@ -31,7 +31,7 @@ public class IndividualAssert extends AbstractAssert<IndividualAssert, Individua
                 ccdIndividual.getMobilePhone(), actual.getMobilePhone().orElse(null));
         }
 
-        final String dateOfBirth = actual.getDateOfBirth().format(DateTimeFormatter.ISO_DATE);
+        String dateOfBirth = actual.getDateOfBirth().format(DateTimeFormatter.ISO_DATE);
         if (!Objects.equals(dateOfBirth, ccdIndividual.getDateOfBirth())) {
             failWithMessage("Expected CCDIndividual.dateOfBirth to be <%s> but was <%s>",
                 ccdIndividual.getDateOfBirth(), dateOfBirth);

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/RepresentativeMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/RepresentativeMapperTest.java
@@ -38,12 +38,12 @@ public class RepresentativeMapperTest {
     @Test
     public void shouldMapRepresentativeToCMC() {
         //given
-        final CCDContactDetails contactDetails = CCDContactDetails.builder()
+        CCDContactDetails contactDetails = CCDContactDetails.builder()
             .phone("07987654321")
             .email(",my@email.com")
             .dxAddress("dx123")
             .build();
-        final CCDAddress address = CCDAddress.builder()
+        CCDAddress address = CCDAddress.builder()
             .line1("line 1")
             .line2("line 2")
             .city("city")

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/SoleTraderMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/SoleTraderMapperTest.java
@@ -37,7 +37,7 @@ public class SoleTraderMapperTest {
     @Test
     public void sholdMapSoleTraderFromCCD() {
         //given
-        final CCDSoleTrader ccdSoleTrader = getCCDSoleTrader();
+        CCDSoleTrader ccdSoleTrader = getCCDSoleTrader();
 
         //when
         SoleTrader soleTrader = soleTraderMapper.from(ccdSoleTrader);

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/CompanyDetailsMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/CompanyDetailsMapperTest.java
@@ -39,13 +39,13 @@ public class CompanyDetailsMapperTest {
     @Test
     public void sholdMapCompanyFromCCD() {
         //given
-        final CCDAddress ccdAddress = CCDAddress.builder()
+        CCDAddress ccdAddress = CCDAddress.builder()
             .line1("line1")
             .line2("line1")
             .city("city")
             .postcode("postcode")
             .build();
-        final CCDContactDetails ccdContactDetails = CCDContactDetails.builder()
+        CCDContactDetails ccdContactDetails = CCDContactDetails.builder()
             .phone("07987654321")
             .email(",my@email.com")
             .dxAddress("dx123")

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/IndividualDetailsMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/IndividualDetailsMapperTest.java
@@ -39,13 +39,13 @@ public class IndividualDetailsMapperTest {
     @Test
     public void sholdMapIndividualDetailsFromCCD() {
         //given
-        final CCDAddress ccdAddress = CCDAddress.builder()
+        CCDAddress ccdAddress = CCDAddress.builder()
             .line1("line1")
             .line2("line1")
             .city("city")
             .postcode("postcode")
             .build();
-        final CCDContactDetails ccdContactDetails = CCDContactDetails.builder()
+        CCDContactDetails ccdContactDetails = CCDContactDetails.builder()
             .phone("07987654321")
             .email(",my@email.com")
             .dxAddress("dx123")

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/OrganisationDetailsMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/OrganisationDetailsMapperTest.java
@@ -39,13 +39,13 @@ public class OrganisationDetailsMapperTest {
     @Test
     public void sholdMapOrganisationDetailsFromCCD() {
         //given
-        final CCDAddress ccdAddress = CCDAddress.builder()
+        CCDAddress ccdAddress = CCDAddress.builder()
             .line1("line1")
             .line2("line1")
             .city("city")
             .postcode("postcode")
             .build();
-        final CCDContactDetails ccdContactDetails = CCDContactDetails.builder()
+        CCDContactDetails ccdContactDetails = CCDContactDetails.builder()
             .phone("07987654321")
             .email(",my@email.com")
             .dxAddress("dx123")

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/SoleTraderDetailsMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/defendant/SoleTraderDetailsMapperTest.java
@@ -39,13 +39,13 @@ public class SoleTraderDetailsMapperTest {
     @Test
     public void sholdMapSoleTraderDetailsFromCCD() {
         //given
-        final CCDAddress ccdAddress = CCDAddress.builder()
+        CCDAddress ccdAddress = CCDAddress.builder()
             .line1("line1")
             .line2("line1")
             .city("city")
             .postcode("postcode")
             .build();
-        final CCDContactDetails ccdContactDetails = CCDContactDetails.builder()
+        CCDContactDetails ccdContactDetails = CCDContactDetails.builder()
             .phone("07987654321")
             .email(",my@email.com")
             .dxAddress("dx123")

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/util/SampleData.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/util/SampleData.java
@@ -35,9 +35,9 @@ public class SampleData {
     }
 
     public static CCDIndividual getCCDIndividual() {
-        final CCDAddress ccdAddress = getCCDAddress();
-        final CCDContactDetails ccdContactDetails = getCCDContactDetails();
-        final CCDRepresentative ccdRepresentative = getCCDRepresentative(ccdAddress, ccdContactDetails);
+        CCDAddress ccdAddress = getCCDAddress();
+        CCDContactDetails ccdContactDetails = getCCDContactDetails();
+        CCDRepresentative ccdRepresentative = getCCDRepresentative(ccdAddress, ccdContactDetails);
 
         return CCDIndividual.builder()
             .title("Mr.")
@@ -68,9 +68,9 @@ public class SampleData {
     }
 
     public static CCDCompany getCCDCompany() {
-        final CCDAddress ccdAddress = getCCDAddress();
-        final CCDContactDetails ccdContactDetails = getCCDContactDetails();
-        final CCDRepresentative ccdRepresentative = getCCDRepresentative(ccdAddress, ccdContactDetails);
+        CCDAddress ccdAddress = getCCDAddress();
+        CCDContactDetails ccdContactDetails = getCCDContactDetails();
+        CCDRepresentative ccdRepresentative = getCCDRepresentative(ccdAddress, ccdContactDetails);
         return CCDCompany.builder()
             .name("Abc Ltd")
             .address(ccdAddress)
@@ -164,9 +164,9 @@ public class SampleData {
     }
 
     public static CCDOrganisation getCCDOrganisation() {
-        final CCDAddress ccdAddress = getCCDAddress();
-        final CCDContactDetails ccdContactDetails = getCCDContactDetails();
-        final CCDRepresentative ccdRepresentative = getCCDRepresentative(ccdAddress, ccdContactDetails);
+        CCDAddress ccdAddress = getCCDAddress();
+        CCDContactDetails ccdContactDetails = getCCDContactDetails();
+        CCDRepresentative ccdRepresentative = getCCDRepresentative(ccdAddress, ccdContactDetails);
         return CCDOrganisation.builder()
             .name("Xyz & Co")
             .address(ccdAddress)
@@ -179,9 +179,9 @@ public class SampleData {
     }
 
     public static CCDSoleTrader getCCDSoleTrader() {
-        final CCDAddress ccdAddress = getCCDAddress();
-        final CCDContactDetails ccdContactDetails = getCCDContactDetails();
-        final CCDRepresentative ccdRepresentative = getCCDRepresentative(ccdAddress, ccdContactDetails);
+        CCDAddress ccdAddress = getCCDAddress();
+        CCDContactDetails ccdContactDetails = getCCDContactDetails();
+        CCDRepresentative ccdRepresentative = getCCDRepresentative(ccdAddress, ccdContactDetails);
         return CCDSoleTrader.builder()
             .title("Mr.")
             .name("Individual")

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -236,5 +236,6 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
+        <module name="ParameterAssignment"/>
     </module>
 </module>

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/AgeRangeConstraintValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/AgeRangeConstraintValidator.java
@@ -28,7 +28,7 @@ public class AgeRangeConstraintValidator implements ConstraintValidator<AgeRange
         return years >= minYears && years <= maxYears;
     }
 
-    private long getAge(final LocalDate localDate) {
+    private long getAge(LocalDate localDate) {
         return ChronoUnit.YEARS.between(localDate, LocalDate.now());
     }
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/InterDependentFieldsConstraintValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/InterDependentFieldsConstraintValidator.java
@@ -81,10 +81,10 @@ public class InterDependentFieldsConstraintValidator implements ConstraintValida
         }
     }
 
-    private boolean validateRate(final Object validateThis,
-                                 final ConstraintValidatorContext ctx,
-                                 final Field fieldObj,
-                                 final Field dependentFieldObj) throws IllegalAccessException {
+    private boolean validateRate(Object validateThis,
+                                 ConstraintValidatorContext ctx,
+                                 Field fieldObj,
+                                 Field dependentFieldObj) throws IllegalAccessException {
         BigDecimal rate = (BigDecimal) fieldObj.get(validateThis);
         Interest.InterestType type = (Interest.InterestType) dependentFieldObj.get(validateThis);
         if ((type == null || !interestTypeIsNoInterest(type)) && rate == null) {
@@ -99,10 +99,10 @@ public class InterDependentFieldsConstraintValidator implements ConstraintValida
         return true;
     }
 
-    private boolean validateReason(final Object validateThis,
-                                   final ConstraintValidatorContext ctx,
-                                   final Field fieldObj,
-                                   final Field dependentFieldObj) throws IllegalAccessException {
+    private boolean validateReason(Object validateThis,
+                                   ConstraintValidatorContext ctx,
+                                   Field fieldObj,
+                                   Field dependentFieldObj) throws IllegalAccessException {
         String reason = (String) fieldObj.get(validateThis);
         InterestDate.InterestDateType type = getInterestDateType(validateThis, dependentFieldObj);
         if ((type == null || !interestDateTypeIsSubmission(type)) && isBlank(reason)) {
@@ -117,17 +117,17 @@ public class InterDependentFieldsConstraintValidator implements ConstraintValida
         return true;
     }
 
-    private InterestDate.InterestDateType getInterestDateType(final Object validateThis, final Field dependentFieldObj)
+    private InterestDate.InterestDateType getInterestDateType(Object validateThis, Field dependentFieldObj)
         throws IllegalAccessException {
         return dependentFieldObj.get(validateThis) != null
             ? (InterestDate.InterestDateType) dependentFieldObj.get(validateThis)
             : null;
     }
 
-    private boolean validateInputDate(final Object validateThis,
-                                      final ConstraintValidatorContext ctx,
-                                      final Field fieldObj,
-                                      final Field dependentFieldObj) throws IllegalAccessException {
+    private boolean validateInputDate(Object validateThis,
+                                      ConstraintValidatorContext ctx,
+                                      Field fieldObj,
+                                      Field dependentFieldObj) throws IllegalAccessException {
         LocalDate inputDate = (LocalDate) fieldObj.get(validateThis);
         InterestDate.InterestDateType type = getInterestDateType(validateThis, dependentFieldObj);
         if (type == null || !interestDateTypeIsSubmission(type)) {
@@ -148,14 +148,14 @@ public class InterDependentFieldsConstraintValidator implements ConstraintValida
     }
 
 
-    private boolean interestDateTypeIsSubmission(final InterestDate.InterestDateType type) {
+    private boolean interestDateTypeIsSubmission(InterestDate.InterestDateType type) {
         return SUBMISSION.equals(type);
     }
 
-    private boolean validateInterestDate(final Object validateThis,
-                                         final ConstraintValidatorContext ctx,
-                                         final Field fieldObj,
-                                         final Field dependentFieldObj) throws IllegalAccessException {
+    private boolean validateInterestDate(Object validateThis,
+                                         ConstraintValidatorContext ctx,
+                                         Field fieldObj,
+                                         Field dependentFieldObj) throws IllegalAccessException {
         InterestDate interestDate = (InterestDate) fieldObj.get(validateThis);
         Interest interest = (Interest) dependentFieldObj.get(validateThis);
         if (interest != null && !interestTypeIsNoInterest(interest.getType())) {
@@ -172,8 +172,8 @@ public class InterDependentFieldsConstraintValidator implements ConstraintValida
         return true;
     }
 
-    private String getViolationMessages(final Set<ConstraintViolation<Object>> violations,
-                                        final ConstraintValidatorContext ctx) {
+    private String getViolationMessages(Set<ConstraintViolation<Object>> violations,
+                                        ConstraintValidatorContext ctx) {
         return violations.stream()
             .map(v -> v.getPropertyPath() + " : " + v.getMessage())
             .sorted(String::compareTo)
@@ -186,7 +186,7 @@ public class InterDependentFieldsConstraintValidator implements ConstraintValida
         return factory.getValidator();
     }
 
-    private boolean interestTypeIsNoInterest(final Interest.InterestType type) {
+    private boolean interestTypeIsNoInterest(Interest.InterestType type) {
         return type.equals(NO_INTEREST);
     }
 

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/MobilePhoneNumberConstraintValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/MobilePhoneNumberConstraintValidator.java
@@ -6,12 +6,12 @@ import javax.validation.ConstraintValidatorContext;
 public class MobilePhoneNumberConstraintValidator implements ConstraintValidator<MobilePhoneNumber, String> {
 
     @Override
-    public void initialize(final MobilePhoneNumber validator) {
+    public void initialize(MobilePhoneNumber validator) {
         // NO-OP
     }
 
     @Override
-    public boolean isValid(final String value, final ConstraintValidatorContext cxt) {
+    public boolean isValid(String value, ConstraintValidatorContext cxt) {
         if (value == null) {
             return true;
         }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/PhoneNumberConstraintValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/PhoneNumberConstraintValidator.java
@@ -23,7 +23,7 @@ public class PhoneNumberConstraintValidator implements ConstraintValidator<Phone
             && isWithInLengthLimit(normalized);
     }
 
-    private boolean isWithInLengthLimit(final String normalized) {
+    private boolean isWithInLengthLimit(String normalized) {
         return normalized.length() == 10 || normalized.length() == 9 || normalized.length() == 7;
     }
 

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/ValidCountyCourtJudgmentValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/ValidCountyCourtJudgmentValidator.java
@@ -24,9 +24,9 @@ public class ValidCountyCourtJudgmentValidator
             return true;
         }
 
-        final PaymentOption type = ccj.getPaymentOption();
-        final boolean payByDateIsPopulated = ccj.getPayBySetDate().isPresent();
-        final boolean repaymentPlanIsPopulated = ccj.getRepaymentPlan().isPresent();
+        PaymentOption type = ccj.getPaymentOption();
+        boolean payByDateIsPopulated = ccj.getPayBySetDate().isPresent();
+        boolean repaymentPlanIsPopulated = ccj.getRepaymentPlan().isPresent();
 
         boolean isValidImmediately = type.equals(IMMEDIATELY) && !payByDateIsPopulated && !repaymentPlanIsPopulated;
         boolean isValidFull = type.equals(FULL_BY_SPECIFIED_DATE) && payByDateIsPopulated && !repaymentPlanIsPopulated;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/exceptions/NotificationException.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/exceptions/NotificationException.java
@@ -2,11 +2,11 @@ package uk.gov.hmcts.cmc.domain.exceptions;
 
 public class NotificationException extends RuntimeException {
 
-    public NotificationException(final String message) {
+    public NotificationException(String message) {
         super(message);
     }
 
-    public NotificationException(final Exception cause) {
+    public NotificationException(Exception cause) {
         super(cause);
     }
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Address.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Address.java
@@ -24,10 +24,10 @@ public class Address {
     @Size(max = 8, message = "Postcode should not be longer than {max} characters")
     private final String postcode;
 
-    public Address(final String line1,
-                   final String line2,
-                   final String city,
-                   final String postcode) {
+    public Address(String line1,
+                   String line2,
+                   String city,
+                   String postcode) {
         this.line1 = line1;
         this.line2 = line2;
         this.city = city;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/AmountRow.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/AmountRow.java
@@ -17,7 +17,7 @@ public class AmountRow {
     @DecimalMin(value = "0.01")
     private final BigDecimal amount;
 
-    public AmountRow(final String reason, final BigDecimal amount) {
+    public AmountRow(String reason, BigDecimal amount) {
         this.reason = reason;
         this.amount = amount;
     }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Claim.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Claim.java
@@ -39,26 +39,26 @@ public class Claim {
 
     @SuppressWarnings("squid:S00107") // Not sure there's a lot fo be done about removing parameters here
     public Claim(
-        final Long id,
-        final String submitterId,
-        final String letterHolderId,
-        final String defendantId,
-        final String externalId,
-        final String referenceNumber,
-        final ClaimData claimData,
-        final LocalDateTime createdAt,
-        final LocalDate issuedOn,
-        final LocalDate responseDeadline,
-        final boolean moreTimeRequested,
-        final String submitterEmail,
-        final LocalDateTime respondedAt,
-        final Response response,
-        final String defendantEmail,
-        final CountyCourtJudgment countyCourtJudgment,
-        final LocalDateTime countyCourtJudgmentRequestedAt,
-        final Settlement settlement,
-        final LocalDateTime settlementReachedAt,
-        final String sealedClaimDocumentSelfPath
+        Long id,
+        String submitterId,
+        String letterHolderId,
+        String defendantId,
+        String externalId,
+        String referenceNumber,
+        ClaimData claimData,
+        LocalDateTime createdAt,
+        LocalDate issuedOn,
+        LocalDate responseDeadline,
+        boolean moreTimeRequested,
+        String submitterEmail,
+        LocalDateTime respondedAt,
+        Response response,
+        String defendantEmail,
+        CountyCourtJudgment countyCourtJudgment,
+        LocalDateTime countyCourtJudgmentRequestedAt,
+        Settlement settlement,
+        LocalDateTime settlementReachedAt,
+        String sealedClaimDocumentSelfPath
     ) {
         this.id = id;
         this.submitterId = submitterId;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/ClaimData.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/ClaimData.java
@@ -93,22 +93,22 @@ public class ClaimData {
 
     @SuppressWarnings("squid:S00107") // Number of method parameters
     public ClaimData(
-        final UUID externalId,
-        final List<Party> claimants,
-        final List<TheirDetails> defendants,
-        final Payment payment,
-        final Amount amount,
-        final BigInteger feeAmountInPennies,
-        final Interest interest,
-        final InterestDate interestDate,
-        final PersonalInjury personalInjury,
-        final HousingDisrepair housingDisrepair,
-        final String reason,
-        final StatementOfTruth statementOfTruth,
-        final String feeAccountNumber,
-        final String externalReferenceNumber,
-        final String preferredCourt,
-        final String feeCode) {
+        UUID externalId,
+        List<Party> claimants,
+        List<TheirDetails> defendants,
+        Payment payment,
+        Amount amount,
+        BigInteger feeAmountInPennies,
+        Interest interest,
+        InterestDate interestDate,
+        PersonalInjury personalInjury,
+        HousingDisrepair housingDisrepair,
+        String reason,
+        StatementOfTruth statementOfTruth,
+        String feeAccountNumber,
+        String externalReferenceNumber,
+        String preferredCourt,
+        String feeCode) {
 
         this.externalId = externalId != null ? externalId : UUID.randomUUID();
         this.claimants = claimants;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/CountyCourtJudgment.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/CountyCourtJudgment.java
@@ -44,12 +44,12 @@ public class CountyCourtJudgment {
     private final StatementOfTruth statementOfTruth;
 
     public CountyCourtJudgment(
-        final LocalDate defendantDateOfBirth,
-        final PaymentOption paymentOption,
-        final BigDecimal paidAmount,
-        final RepaymentPlan repaymentPlan,
-        final LocalDate payBySetDate,
-        final StatementOfTruth statementOfTruth
+        LocalDate defendantDateOfBirth,
+        PaymentOption paymentOption,
+        BigDecimal paidAmount,
+        RepaymentPlan repaymentPlan,
+        LocalDate payBySetDate,
+        StatementOfTruth statementOfTruth
     ) {
         this.defendantDateOfBirth = defendantDateOfBirth;
         this.paymentOption = paymentOption;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/DefendantLinkStatus.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/DefendantLinkStatus.java
@@ -10,7 +10,7 @@ public class DefendantLinkStatus {
 
     private final boolean linked;
 
-    public DefendantLinkStatus(final boolean linked) {
+    public DefendantLinkStatus(boolean linked) {
         this.linked = linked;
     }
 

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Interest.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Interest.java
@@ -30,9 +30,9 @@ public class Interest {
 
     private final String reason;
 
-    public Interest(final InterestType type,
-                    final BigDecimal rate,
-                    final String reason) {
+    public Interest(InterestType type,
+                    BigDecimal rate,
+                    String reason) {
         this.type = type;
         this.rate = rate;
         this.reason = reason;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/InterestDate.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/InterestDate.java
@@ -24,13 +24,13 @@ public class InterestDate {
     }
 
     @NotNull
-    private InterestDateType type;
+    private final InterestDateType type;
 
     @JsonUnwrapped
     @DateNotInTheFuture
-    private LocalDate date;
+    private final LocalDate date;
 
-    private String reason;
+    private final String reason;
 
     public InterestDate(InterestDateType type, LocalDate date, String reason) {
         this.type = type;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/InterestDate.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/InterestDate.java
@@ -24,13 +24,13 @@ public class InterestDate {
     }
 
     @NotNull
-    private final InterestDateType type;
+    private InterestDateType type;
 
     @JsonUnwrapped
     @DateNotInTheFuture
-    private final LocalDate date;
+    private LocalDate date;
 
-    private final String reason;
+    private String reason;
 
     public InterestDate(InterestDateType type, LocalDate date, String reason) {
         this.type = type;
@@ -56,14 +56,14 @@ public class InterestDate {
     }
 
     @Override
-    public boolean equals(final Object other) {
+    public boolean equals(Object other) {
         if (this == other) {
             return true;
         }
         if (other == null || getClass() != other.getClass()) {
             return false;
         }
-        final InterestDate that = (InterestDate) other;
+        InterestDate that = (InterestDate) other;
         return Objects.equals(type, that.type)
             && Objects.equals(date, that.date)
             && Objects.equals(reason, that.reason);

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
@@ -28,12 +28,12 @@ public class Payment {
     @Valid
     private final PaymentState state;
 
-    public Payment(final String id,
-                   final BigDecimal amount,
-                   final String reference,
-                   final String description,
-                   final String dateCreated,
-                   final PaymentState state) {
+    public Payment(String id,
+                   BigDecimal amount,
+                   String reference,
+                   String description,
+                   String dateCreated,
+                   PaymentState state) {
         this.id = id;
         this.amount = amount;
         this.reference = reference;
@@ -73,14 +73,14 @@ public class Payment {
 
     @Override
     @SuppressWarnings("squid:S1067") // Its generated code for equals sonar
-    public boolean equals(final Object other) {
+    public boolean equals(Object other) {
         if (this == other) {
             return true;
         }
         if (other == null || getClass() != other.getClass()) {
             return false;
         }
-        final Payment payment = (Payment) other;
+        Payment payment = (Payment) other;
         return Objects.equals(id, payment.id)
             && Objects.equals(amount, payment.amount)
             && Objects.equals(reference, payment.reference)

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/PaymentState.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/PaymentState.java
@@ -12,7 +12,7 @@ public class PaymentState {
     @NotNull
     private final boolean finished;
 
-    public PaymentState(final String status, final boolean finished) {
+    public PaymentState(String status, boolean finished) {
         this.status = status;
         this.finished = finished;
     }
@@ -26,14 +26,14 @@ public class PaymentState {
     }
 
     @Override
-    public boolean equals(final Object other) {
+    public boolean equals(Object other) {
         if (this == other) {
             return true;
         }
         if (other == null || getClass() != other.getClass()) {
             return false;
         }
-        final PaymentState that = (PaymentState) other;
+        PaymentState that = (PaymentState) other;
         return finished == that.finished
             && Objects.equals(status, that.status);
     }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Response.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Response.java
@@ -52,10 +52,10 @@ public abstract class Response {
     private final StatementOfTruth statementOfTruth;
 
     public Response(
-            final FreeMediationOption freeMediation,
-            final MoreTimeNeededOption moreTimeNeeded,
-            final Party defendant,
-            final StatementOfTruth statementOfTruth
+            FreeMediationOption freeMediation,
+            MoreTimeNeededOption moreTimeNeeded,
+            Party defendant,
+            StatementOfTruth statementOfTruth
     ) {
         this.freeMediation = freeMediation;
         this.moreTimeNeeded = moreTimeNeeded;
@@ -81,7 +81,7 @@ public abstract class Response {
 
     @Override
     @SuppressWarnings("squid:S1067") // Its generated code for equals sonar
-    public boolean equals(final Object other) {
+    public boolean equals(Object other) {
         if (this == other) {
             return true;
         }
@@ -90,7 +90,7 @@ public abstract class Response {
             return false;
         }
 
-        final Response that = (Response) other;
+        Response that = (Response) other;
         return Objects.equals(freeMediation, that.freeMediation)
             && Objects.equals(moreTimeNeeded, that.moreTimeNeeded)
             && Objects.equals(defendant, that.defendant)

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountBreakDown.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountBreakDown.java
@@ -17,7 +17,7 @@ public class AmountBreakDown implements Amount {
     @MinTotalAmount("0.01")
     private final List<AmountRow> rows;
 
-    public AmountBreakDown(final List<AmountRow> rows) {
+    public AmountBreakDown(List<AmountRow> rows) {
         this.rows = rows;
     }
 

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountRange.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountRange.java
@@ -22,7 +22,7 @@ public class AmountRange implements Amount {
     @DecimalMin(value = "0.01")
     private final BigDecimal higherValue;
 
-    public AmountRange(final BigDecimal lowerValue, final BigDecimal higherValue) {
+    public AmountRange(BigDecimal lowerValue, BigDecimal higherValue) {
         this.lowerValue = lowerValue;
         this.higherValue = higherValue;
     }
@@ -36,14 +36,14 @@ public class AmountRange implements Amount {
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final AmountRange that = (AmountRange) obj;
+        AmountRange that = (AmountRange) obj;
         return Objects.equals(lowerValue, that.lowerValue)
             && Objects.equals(higherValue, that.higherValue);
     }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/ccj/RepaymentPlan.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/ccj/RepaymentPlan.java
@@ -32,10 +32,10 @@ public class RepaymentPlan {
     private final PaymentSchedule paymentSchedule;
 
     public RepaymentPlan(
-        final BigDecimal firstPayment,
-        final BigDecimal instalmentAmount,
-        final LocalDate firstPaymentDate,
-        final PaymentSchedule paymentSchedule
+        BigDecimal firstPayment,
+        BigDecimal instalmentAmount,
+        LocalDate firstPaymentDate,
+        PaymentSchedule paymentSchedule
     ) {
 
         this.firstPayment = firstPayment;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/Offer.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/Offer.java
@@ -17,11 +17,11 @@ public class Offer {
 
     @NotBlank
     @Size(max = CONTENT_LENGTH_LIMIT, message = "may not be longer than {max} characters")
-    private String content;
+    private final String content;
 
     @NotNull
     @FutureDate
-    private LocalDate completionDate;
+    private final LocalDate completionDate;
 
     public Offer(String content, LocalDate completionDate) {
         this.content = content;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/Settlement.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/Settlement.java
@@ -14,7 +14,7 @@ import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 public class Settlement {
 
     private static final String NO_STATEMENTS_MADE = "No statements have yet been made during that settlement";
-    private List<PartyStatement> partyStatements = new ArrayList<>();
+    private final List<PartyStatement> partyStatements = new ArrayList<>();
 
     public void makeOffer(Offer offer, MadeBy party) {
         assertOfferCanBeMadeBy(party);

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/CompanyDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/CompanyDetails.java
@@ -13,12 +13,12 @@ public class CompanyDetails extends TheirDetails {
     private final String contactPerson;
 
     public CompanyDetails(
-        final String name,
-        final Address address,
-        final String email,
-        final Representative representative,
-        final Address serviceAddress,
-        final String contactPerson
+        String name,
+        Address address,
+        String email,
+        Representative representative,
+        Address serviceAddress,
+        String contactPerson
     ) {
         super(name, address, email, representative, serviceAddress);
         this.contactPerson = contactPerson;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/IndividualDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/IndividualDetails.java
@@ -19,13 +19,13 @@ public class IndividualDetails extends TheirDetails implements TitledParty {
     private final LocalDate dateOfBirth;
 
     public IndividualDetails(
-        final String name,
-        final Address address,
-        final String email,
-        final Representative representative,
-        final Address serviceAddress,
-        final String title,
-        final LocalDate dateOfBirth
+        String name,
+        Address address,
+        String email,
+        Representative representative,
+        Address serviceAddress,
+        String title,
+        LocalDate dateOfBirth
     ) {
         super(name, address, email, representative, serviceAddress);
         this.title = title;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/OrganisationDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/OrganisationDetails.java
@@ -14,13 +14,13 @@ public class OrganisationDetails extends TheirDetails {
     private final String companiesHouseNumber;
 
     public OrganisationDetails(
-        final String name,
-        final Address address,
-        final String email,
-        final Representative representative,
-        final Address serviceAddress,
-        final String contactPerson,
-        final String companiesHouseNumber
+        String name,
+        Address address,
+        String email,
+        Representative representative,
+        Address serviceAddress,
+        String contactPerson,
+        String companiesHouseNumber
     ) {
         super(name, address, email, representative, serviceAddress);
         this.contactPerson = contactPerson;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/SoleTraderDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/SoleTraderDetails.java
@@ -17,13 +17,13 @@ public class SoleTraderDetails extends TheirDetails implements TitledParty {
     private final String businessName;
 
     public SoleTraderDetails(
-        final String name,
-        final Address address,
-        final String email,
-        final Representative representative,
-        final Address serviceAddress,
-        final String title,
-        final String businessName
+        String name,
+        Address address,
+        String email,
+        Representative representative,
+        Address serviceAddress,
+        String title,
+        String businessName
     ) {
         super(name, address, email, representative, serviceAddress);
         this.title = title;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/TheirDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/TheirDetails.java
@@ -53,11 +53,11 @@ public abstract class TheirDetails implements NamedParty {
     private final Address serviceAddress;
 
     public TheirDetails(
-        final String name,
-        final Address address,
-        final String email,
-        final Representative representative,
-        final Address serviceAddress
+        String name,
+        Address address,
+        String email,
+        Representative representative,
+        Address serviceAddress
     ) {
         this.name = name;
         this.address = address;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Company.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Company.java
@@ -13,12 +13,12 @@ public class Company extends Party {
     private final String contactPerson;
 
     public Company(
-        final String name,
-        final Address address,
-        final Address correspondenceAddress,
-        final String mobilePhone,
-        final Representative representative,
-        final String contactPerson
+        String name,
+        Address address,
+        Address correspondenceAddress,
+        String mobilePhone,
+        Representative representative,
+        String contactPerson
     ) {
         super(name, address, correspondenceAddress, mobilePhone, representative);
         this.contactPerson = contactPerson;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Individual.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Individual.java
@@ -22,13 +22,13 @@ public class Individual extends Party implements TitledParty {
     private final LocalDate dateOfBirth;
 
     public Individual(
-        final String name,
-        final Address address,
-        final Address correspondenceAddress,
-        final String mobilePhone,
-        final Representative representative,
-        final String title,
-        final LocalDate dateOfBirth
+        String name,
+        Address address,
+        Address correspondenceAddress,
+        String mobilePhone,
+        Representative representative,
+        String title,
+        LocalDate dateOfBirth
     ) {
         super(name, address, correspondenceAddress, mobilePhone, representative);
         this.title = title;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Organisation.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Organisation.java
@@ -14,13 +14,13 @@ public class Organisation extends Party {
     private final String companiesHouseNumber;
 
     public Organisation(
-        final String name,
-        final Address address,
-        final Address correspondenceAddress,
-        final String mobilePhone,
-        final Representative representative,
-        final String contactPerson,
-        final String companiesHouseNumber
+        String name,
+        Address address,
+        Address correspondenceAddress,
+        String mobilePhone,
+        Representative representative,
+        String contactPerson,
+        String companiesHouseNumber
     ) {
         super(name, address, correspondenceAddress, mobilePhone, representative);
         this.contactPerson = contactPerson;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Party.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Party.java
@@ -52,11 +52,11 @@ public abstract class Party implements NamedParty {
     private final Representative representative;
 
     public Party(
-        final String name,
-        final Address address,
-        final Address correspondenceAddress,
-        final String mobilePhone,
-        final Representative representative
+        String name,
+        Address address,
+        Address correspondenceAddress,
+        String mobilePhone,
+        Representative representative
     ) {
         this.name = name;
         this.address = address;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/SoleTrader.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/SoleTrader.java
@@ -19,13 +19,13 @@ public class SoleTrader extends Party implements TitledParty {
     private final String businessName;
 
     public SoleTrader(
-        final String name,
-        final Address address,
-        final Address correspondenceAddress,
-        final String mobilePhone,
-        final Representative representative,
-        final String title,
-        final String businessName
+        String name,
+        Address address,
+        Address correspondenceAddress,
+        String mobilePhone,
+        Representative representative,
+        String title,
+        String businessName
     ) {
         super(name, address, correspondenceAddress, mobilePhone, representative);
         this.title = title;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/utils/BeanValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/utils/BeanValidator.java
@@ -20,7 +20,7 @@ public class BeanValidator {
         return getMessages(factory.getValidator().validate(bean));
     }
 
-    private static <T> Set<String> getMessages(final Set<ConstraintViolation<T>> response) {
+    private static <T> Set<String> getMessages(Set<ConstraintViolation<T>> response) {
         return response.stream()
             .map(BeanValidator::prepareMessage)
             .collect(Collectors.toSet());

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/utils/PartyUtils.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/utils/PartyUtils.java
@@ -25,7 +25,7 @@ public class PartyUtils {
         // utility class, no instances
     }
 
-    public static String getType(final Party party) {
+    public static String getType(Party party) {
         if (party instanceof Individual) {
             return INDIVIDUAL;
         } else if (party instanceof SoleTrader) {
@@ -39,7 +39,7 @@ public class PartyUtils {
         }
     }
 
-    public static String getType(final TheirDetails party) {
+    public static String getType(TheirDetails party) {
         if (party instanceof IndividualDetails) {
             return INDIVIDUAL;
         } else if (party instanceof SoleTraderDetails) {
@@ -53,7 +53,7 @@ public class PartyUtils {
         }
     }
 
-    public static Optional<String> getContactPerson(final Party party) {
+    public static Optional<String> getContactPerson(Party party) {
         if (party instanceof Company) {
             return ((Company) party).getContactPerson();
         } else if (party instanceof Organisation) {
@@ -62,7 +62,7 @@ public class PartyUtils {
         return Optional.empty();
     }
 
-    public static Optional<String> getContactPerson(final TheirDetails party) {
+    public static Optional<String> getContactPerson(TheirDetails party) {
         if (party instanceof CompanyDetails)  {
             return ((CompanyDetails) party).getContactPerson();
         } else if (party instanceof OrganisationDetails) {
@@ -71,14 +71,14 @@ public class PartyUtils {
         return Optional.empty();
     }
 
-    public static Optional<String> getBusinessName(final Party party) {
+    public static Optional<String> getBusinessName(Party party) {
         if (party instanceof SoleTrader) {
             return ((SoleTrader) party).getBusinessName();
         }
         return Optional.empty();
     }
 
-    public static Optional<String> getBusinessName(final TheirDetails party) {
+    public static Optional<String> getBusinessName(TheirDetails party) {
         if (party instanceof SoleTraderDetails) {
             return ((SoleTraderDetails) party).getBusinessName();
         }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/utils/ResourceReader.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/utils/ResourceReader.java
@@ -12,10 +12,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ResourceReader {
 
-    public String read(final String input) {
+    public String read(String input) {
         try {
-            final URL resource = getClass().getResource(input);
-            final URI url = resource.toURI();
+            URL resource = getClass().getResource(input);
+            URI url = resource.toURI();
             return new String(Files.readAllBytes(Paths.get(url)), UTF_8);
         } catch (NoSuchFileException e) {
             throw new RuntimeException("no file found with the link '" + input + "'", e);

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/AmountRangeTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/AmountRangeTest.java
@@ -14,7 +14,7 @@ public class AmountRangeTest {
     @Test
     public void shouldBeSuccessfulValidationForValidAmountDetails() {
         //given
-        final AmountRange amountRow = SampleAmountRange.validDefaults();
+        AmountRange amountRow = SampleAmountRange.validDefaults();
         //when
         Set<String> errors = validate(amountRow);
         //then
@@ -24,7 +24,7 @@ public class AmountRangeTest {
     @Test
     public void shouldBeSuccessfulValidationForMaximumValue() {
         //given
-        final AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(9999999.99))
+        AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(9999999.99))
             .withLowerValue(valueOf(9999999.99)).build();
 
         //when
@@ -36,7 +36,7 @@ public class AmountRangeTest {
     @Test
     public void shouldBeSuccessfulValidationForMinimum() {
         //given
-        final AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(0.01))
+        AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(0.01))
             .withLowerValue(valueOf(0.01)).build();
 
         //when
@@ -48,7 +48,7 @@ public class AmountRangeTest {
     @Test
     public void shouldHaveErrorsForValueHigherThanMaximum() {
         //given
-        final AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(10000000)).build();
+        AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(10000000)).build();
         //when
         Set<String> errors = validate(amountRow);
         //then
@@ -58,14 +58,14 @@ public class AmountRangeTest {
     @Test
     public void shouldHaveErrorsForValueLowerThanMinimum() {
         //given
-        final AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(0))
+        AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(0))
             .withLowerValue(valueOf(0)).build();
 
         //when
         Set<String> errors = validate(amountRow);
         //then
 
-        final String[] expectedErroMessages = {"higherValue : must be greater than or equal to 0.01",
+        String[] expectedErroMessages = {"higherValue : must be greater than or equal to 0.01",
             "lowerValue : must be greater than or equal to 0.01"};
 
         assertThat(errors).containsExactly(expectedErroMessages);

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/ClaimTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/ClaimTest.java
@@ -56,7 +56,7 @@ public class ClaimTest {
         return customCreatedAt(NOW_IN_LOCAL_ZONE);
     }
 
-    private static Claim customCreatedAt(final LocalDateTime createdAt) {
+    private static Claim customCreatedAt(LocalDateTime createdAt) {
         return new Claim(
             1L,
             "3",

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/ResponseTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/ResponseTest.java
@@ -71,7 +71,7 @@ public class ResponseTest {
     @Test
     public void shouldHaveValidationMessagesWhenDefenceExceedsSizeLimit() {
         //given
-        final String defence = new ResourceReader().read("/defence_exceeding_size_limit.text");
+        String defence = new ResourceReader().read("/defence_exceeding_size_limit.text");
 
         Response response = SampleResponse.FullDefence.builder()
             .withDefence(defence)

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/SettlementTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/SettlementTest.java
@@ -20,7 +20,7 @@ public class SettlementTest {
     private PartyStatement partyStatement;
 
     private Settlement settlement;
-    private static Offer offer = SampleOffer.validDefaults();
+    private static final Offer offer = SampleOffer.validDefaults();
 
     @Before
     public void beforeEachTest() {

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/SettlementTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/SettlementTest.java
@@ -16,11 +16,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SettlementTest {
 
     private static final String COUNTER_OFFER = "Get me a new roof instead";
+    private static final Offer offer = SampleOffer.validDefaults();
+
     @Mock
     private PartyStatement partyStatement;
 
     private Settlement settlement;
-    private static final Offer offer = SampleOffer.validDefaults();
 
     @Before
     public void beforeEachTest() {

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/SettlementTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/SettlementTest.java
@@ -20,7 +20,7 @@ public class SettlementTest {
     private PartyStatement partyStatement;
 
     private Settlement settlement;
-    private static final Offer offer = SampleOffer.validDefaults();
+    private static Offer offer = SampleOffer.validDefaults();
 
     @Before
     public void beforeEachTest() {

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/serialization/CountyCourtJudgmentSerializationTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/serialization/CountyCourtJudgmentSerializationTest.java
@@ -36,8 +36,8 @@ public class CountyCourtJudgmentSerializationTest {
         assertThat(expected).isEqualTo(other);
     }
 
-    private static CountyCourtJudgment jsonToModel(final String path) throws IOException {
-        final String json = new ResourceReader().read(path);
+    private static CountyCourtJudgment jsonToModel(String path) throws IOException {
+        String json = new ResourceReader().read(path);
         return mapper.readValue(json, CountyCourtJudgment.class);
     }
 }

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/serialization/PartyStatementSerializationTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/serialization/PartyStatementSerializationTest.java
@@ -49,8 +49,8 @@ public class PartyStatementSerializationTest {
         assertThat(other.getOffer().isPresent()).isEqualTo(false);
     }
 
-    private static PartyStatement jsonToModel(final String path) throws IOException {
-        final String json = new ResourceReader().read(path);
+    private static PartyStatement jsonToModel(String path) throws IOException {
+        String json = new ResourceReader().read(path);
         return mapper.readValue(json, PartyStatement.class);
     }
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleAddress.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleAddress.java
@@ -17,22 +17,22 @@ public class SampleAddress {
         return builder().build();
     }
 
-    public SampleAddress withLine1(final String line1) {
+    public SampleAddress withLine1(String line1) {
         this.line1 = line1;
         return this;
     }
 
-    public SampleAddress withLine2(final String line2) {
+    public SampleAddress withLine2(String line2) {
         this.line2 = line2;
         return this;
     }
 
-    public SampleAddress withCity(final String city) {
+    public SampleAddress withCity(String city) {
         this.city = city;
         return this;
     }
 
-    public SampleAddress withPostcode(final String postcode) {
+    public SampleAddress withPostcode(String postcode) {
         this.postcode = postcode;
         return this;
     }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleClaim.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleClaim.java
@@ -66,7 +66,7 @@ public final class SampleClaim {
         return getWithResponse(SampleResponse.validDefaults());
     }
 
-    public static Claim getWithResponse(final Response response) {
+    public static Claim getWithResponse(Response response) {
         return builder()
             .withClaimData(SampleClaimData.validDefaults())
             .withResponse(response)
@@ -230,27 +230,27 @@ public final class SampleClaim {
         return this;
     }
 
-    public SampleClaim withResponse(final Response response) {
+    public SampleClaim withResponse(Response response) {
         this.response = response;
         return this;
     }
 
-    public SampleClaim withDefendantEmail(final String defendantEmail) {
+    public SampleClaim withDefendantEmail(String defendantEmail) {
         this.defendantEmail = defendantEmail;
         return this;
     }
 
-    public SampleClaim withSettlement(final Settlement settlement) {
+    public SampleClaim withSettlement(Settlement settlement) {
         this.settlement = settlement;
         return this;
     }
 
-    public SampleClaim withSettlementReachedAt(final LocalDateTime settlementReachedAt) {
+    public SampleClaim withSettlementReachedAt(LocalDateTime settlementReachedAt) {
         this.settlementReachedAt = settlementReachedAt;
         return this;
     }
 
-    public SampleClaim withSealedClaimDocumentSelfPath(final String sealedClaimDocumentSelfPath) {
+    public SampleClaim withSealedClaimDocumentSelfPath(String sealedClaimDocumentSelfPath) {
         this.sealedClaimDocumentSelfPath = sealedClaimDocumentSelfPath;
         return this;
     }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleResponse.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleResponse.java
@@ -15,12 +15,12 @@ public abstract class SampleResponse<T extends SampleResponse<T>> {
             return new FullDefence();
         }
 
-        public FullDefence withDefenceType(final FullDefenceResponse.DefenceType defenceType) {
+        public FullDefence withDefenceType(FullDefenceResponse.DefenceType defenceType) {
             this.defenceType = defenceType;
             return this;
         }
 
-        public FullDefence withDefence(final String defence) {
+        public FullDefence withDefence(String defence) {
             this.defence = defence;
             return this;
         }
@@ -42,17 +42,17 @@ public abstract class SampleResponse<T extends SampleResponse<T>> {
         return FullDefence.builder().build();
     }
 
-    public T withMediation(final Response.FreeMediationOption freeMediationOption) {
+    public T withMediation(Response.FreeMediationOption freeMediationOption) {
         this.freeMediationOption = freeMediationOption;
         return (T)this;
     }
 
-    public T withDefendantDetails(final Party sampleDefendantDetails) {
+    public T withDefendantDetails(Party sampleDefendantDetails) {
         this.defendantDetails = sampleDefendantDetails;
         return (T)this;
     }
 
-    public T withStatementOfTruth(final String signerName, final String signerRole) {
+    public T withStatementOfTruth(String signerName, String signerRole) {
         this.statementOfTruth = new StatementOfTruth(signerName,signerRole);
         return (T)this;
     }

--- a/email-client/src/main/java/uk/gov/hmcts/cmc/email/EmailAttachment.java
+++ b/email-client/src/main/java/uk/gov/hmcts/cmc/email/EmailAttachment.java
@@ -11,7 +11,7 @@ public class EmailAttachment {
     private final String contentType;
     private final String filename;
 
-    public EmailAttachment(final InputStreamSource data, final String contentType, final String filename) {
+    public EmailAttachment(InputStreamSource data, String contentType, String filename) {
         requireNonNull(data);
         requireNonNull(contentType);
         requireNonNull(filename);

--- a/email-client/src/main/java/uk/gov/hmcts/cmc/email/EmailData.java
+++ b/email-client/src/main/java/uk/gov/hmcts/cmc/email/EmailData.java
@@ -13,10 +13,10 @@ public class EmailData {
 
     private final List<EmailAttachment> attachments;
 
-    public EmailData(final String to,
-                     final String subject,
-                     final String message,
-                     final List<EmailAttachment> attachments) {
+    public EmailData(String to,
+                     String subject,
+                     String message,
+                     List<EmailAttachment> attachments) {
 
         this.to = to;
         this.subject = subject;

--- a/email-client/src/main/java/uk/gov/hmcts/cmc/email/EmailService.java
+++ b/email-client/src/main/java/uk/gov/hmcts/cmc/email/EmailService.java
@@ -22,15 +22,15 @@ public class EmailService {
     private final JavaMailSender sender;
 
     @Autowired
-    public EmailService(final JavaMailSender sender) {
+    public EmailService(JavaMailSender sender) {
         this.sender = sender;
     }
 
     @Retryable(value = EmailSendFailedException.class, backoff = @Backoff(delay = 100, maxDelay = 500))
-    public void sendEmail(final String from, final EmailData emailData) {
+    public void sendEmail(String from, EmailData emailData) {
         try {
-            final MimeMessage message = sender.createMimeMessage();
-            final MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(message, true);
+            MimeMessage message = sender.createMimeMessage();
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(message, true);
 
             mimeMessageHelper.setFrom(from);
             mimeMessageHelper.setTo(emailData.getTo());
@@ -50,8 +50,8 @@ public class EmailService {
     }
 
     @Recover
-    public void logSendMessageWithAttachmentFailure(final RuntimeException exception, final EmailData emailData) {
-        final String errorMessage = String.format(
+    public void logSendMessageWithAttachmentFailure(RuntimeException exception, EmailData emailData) {
+        String errorMessage = String.format(
             "sendEmail failure:  failed to send email with details: %s due to %s",
             emailData.toString(), exception.getMessage()
         );

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/AcceptOrRejectOfferTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/AcceptOrRejectOfferTest.java
@@ -102,7 +102,7 @@ public class AcceptOrRejectOfferTest extends BaseIntegrationTest {
     }
 
     private void runTestAndVerifyNotificationsAreSentWhenEverythingIsOkForResponse(
-        final String action
+        String action
     ) throws Exception {
         given(notificationClient.sendEmail(any(), any(), any(), any()))
             .willReturn(null);
@@ -126,7 +126,7 @@ public class AcceptOrRejectOfferTest extends BaseIntegrationTest {
             );
     }
 
-    private ResultActions postRequestTo(final String endpoint) throws Exception {
+    private ResultActions postRequestTo(String endpoint) throws Exception {
         return webClient
             .perform(
                 post(format("/claims/%d/offers/%s/%s", claim.getId(), MadeBy.CLAIMANT.name(), endpoint))

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/RequestMoreTimeForResponseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/RequestMoreTimeForResponseTest.java
@@ -30,12 +30,12 @@ public class RequestMoreTimeForResponseTest extends BaseIntegrationTest {
     private static final String AUTH_TOKEN = "it's me!";
     private static final String DEFENDANT_ID = "100";
 
-    private static UserDetails USER_DETAILS = SampleUserDetails.builder()
+    private static final UserDetails USER_DETAILS = SampleUserDetails.builder()
         .withUserId(DEFENDANT_ID)
         .withMail("defendant@example.com")
         .build();
 
-    private static UserDetails OTHER_USER_DETAILS = SampleUserDetails.builder()
+    private static final UserDetails OTHER_USER_DETAILS = SampleUserDetails.builder()
         .withUserId(SUBMITTER_ID)
         .withMail("submitter@example.com")
         .build();

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/RequestMoreTimeForResponseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/RequestMoreTimeForResponseTest.java
@@ -30,12 +30,12 @@ public class RequestMoreTimeForResponseTest extends BaseIntegrationTest {
     private static final String AUTH_TOKEN = "it's me!";
     private static final String DEFENDANT_ID = "100";
 
-    private static final UserDetails USER_DETAILS = SampleUserDetails.builder()
+    private static UserDetails USER_DETAILS = SampleUserDetails.builder()
         .withUserId(DEFENDANT_ID)
         .withMail("defendant@example.com")
         .build();
 
-    private static final UserDetails OTHER_USER_DETAILS = SampleUserDetails.builder()
+    private static UserDetails OTHER_USER_DETAILS = SampleUserDetails.builder()
         .withUserId(SUBMITTER_ID)
         .withMail("submitter@example.com")
         .build();
@@ -143,11 +143,11 @@ public class RequestMoreTimeForResponseTest extends BaseIntegrationTest {
             .andExpect(status().isBadRequest());
     }
 
-    private ResultActions makeRequest(final long claimId) throws Exception {
+    private ResultActions makeRequest(long claimId) throws Exception {
         return makeRequest(claimId, Maps.newHashMap(HttpHeaders.AUTHORIZATION, AUTH_TOKEN));
     }
 
-    private ResultActions makeRequest(final long claimId, Map<String, String> headers) throws Exception {
+    private ResultActions makeRequest(long claimId, Map<String, String> headers) throws Exception {
         MockHttpServletRequestBuilder builder = post("/claims/" + claimId + "/request-more-time");
 
         for (Map.Entry<String, String> header : headers.entrySet()) {

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/ResendStaffNotificationsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/ResendStaffNotificationsTest.java
@@ -41,8 +41,8 @@ public class ResendStaffNotificationsTest extends BaseIntegrationTest {
 
     @Test
     public void shouldRespond404WhenClaimDoesNotExist() throws Exception {
-        final String nonExistingClaimReference = "something";
-        final String event = "claim-issue";
+        String nonExistingClaimReference = "something";
+        String event = "claim-issue";
 
         makeRequest(nonExistingClaimReference, event)
             .andExpect(status().isNotFound());
@@ -50,7 +50,7 @@ public class ResendStaffNotificationsTest extends BaseIntegrationTest {
 
     @Test
     public void shouldRespond404WhenEventIsNotSupported() throws Exception {
-        final String nonExistingEvent = "some-event";
+        String nonExistingEvent = "some-event";
 
         Claim claim = claimStore.saveClaim(SampleClaimData.builder().build());
 
@@ -60,7 +60,7 @@ public class ResendStaffNotificationsTest extends BaseIntegrationTest {
 
     @Test
     public void shouldRespond409AndNotProceedForClaimIssuedEventWhenClaimIsLinkedToDefendant() throws Exception {
-        final String event = "claim-issued";
+        String event = "claim-issued";
 
         Claim claim = claimStore.saveClaim(SampleClaimData.builder().build());
         claimRepository.linkDefendant(claim.getId(), "2");
@@ -73,11 +73,11 @@ public class ResendStaffNotificationsTest extends BaseIntegrationTest {
 
     @Test
     public void shouldRespond200AndSendNotificationsForClaimIssuedEvent() throws Exception {
-        final String event = "claim-issued";
+        String event = "claim-issued";
 
         Claim claim = claimStore.saveClaim(SampleClaimData.submittedByClaimant());
 
-        final GeneratePinResponse pinResponse = new GeneratePinResponse("pin-123", "333");
+        GeneratePinResponse pinResponse = new GeneratePinResponse("pin-123", "333");
         given(userService.generatePin(anyString(), eq("ABC123"))).willReturn(pinResponse);
         given(userService.getUserDetails(anyString())).willReturn(SampleUserDetails.getDefault());
 
@@ -94,7 +94,7 @@ public class ResendStaffNotificationsTest extends BaseIntegrationTest {
 
     @Test
     public void shouldRespond409AndNotProceedForMoreTimeRequestedEventWhenMoreTimeNotRequested() throws Exception {
-        final String event = "more-time-requested";
+        String event = "more-time-requested";
 
         Claim claim = claimStore.saveClaim(SampleClaimData.builder().build());
 
@@ -106,7 +106,7 @@ public class ResendStaffNotificationsTest extends BaseIntegrationTest {
 
     @Test
     public void shouldRespond200AndSendNotificationsForMoreTimeRequestedEvent() throws Exception {
-        final String event = "more-time-requested";
+        String event = "more-time-requested";
 
         Claim claim = claimStore.saveClaim(SampleClaimData.builder().build());
         claimRepository.requestMoreTime(claim.getId(), LocalDate.now());
@@ -120,7 +120,7 @@ public class ResendStaffNotificationsTest extends BaseIntegrationTest {
 
     @Test
     public void shouldRespond409AndNotProceedForResponseSubmittedEventWhenResponseNotSubmitted() throws Exception {
-        final String event = "response-submitted";
+        String event = "response-submitted";
 
         Claim claim = claimStore.saveClaim(SampleClaimData.builder().build());
 
@@ -132,7 +132,7 @@ public class ResendStaffNotificationsTest extends BaseIntegrationTest {
 
     @Test
     public void shouldRespond200AndSendNotificationsForResponseSubmittedEvent() throws Exception {
-        final String event = "response-submitted";
+        String event = "response-submitted";
 
         Claim claim = claimStore.saveClaim(SampleClaimData.builder().build());
         claimStore.saveResponse(

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimWithCoreCaseDataStoreTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimWithCoreCaseDataStoreTest.java
@@ -35,7 +35,7 @@ public class SaveClaimWithCoreCaseDataStoreTest extends BaseSaveTest {
 
     @Test
     public void shouldStoreNonRepresentedClaimIntoCCDStore() throws Exception {
-        final ClaimData claimData = SampleClaimData.submittedByLegalRepresentative();
+        ClaimData claimData = SampleClaimData.submittedByLegalRepresentative();
 
         given(coreCaseDataApi.start(
             eq(AUTHORISATION_TOKEN),
@@ -91,7 +91,7 @@ public class SaveClaimWithCoreCaseDataStoreTest extends BaseSaveTest {
 
     @Test
     public void shouldIssueClaimEvenWhenCCDStoreFailsToStartEvent() throws Exception {
-        final ClaimData claimData = SampleClaimData.submittedByLegalRepresentative();
+        ClaimData claimData = SampleClaimData.submittedByLegalRepresentative();
         given(coreCaseDataApi.start(
             eq(AUTHORISATION_TOKEN),
             eq(SERVICE_TOKEN),
@@ -115,7 +115,7 @@ public class SaveClaimWithCoreCaseDataStoreTest extends BaseSaveTest {
 
     @Test
     public void shouldIssueClaimEvenWhenCCDStoreFailsToSubmitEvent() throws Exception {
-        final ClaimData claimData = SampleClaimData.submittedByLegalRepresentative();
+        ClaimData claimData = SampleClaimData.submittedByLegalRepresentative();
         given(coreCaseDataApi.start(
             eq(AUTHORISATION_TOKEN),
             eq(SERVICE_TOKEN),
@@ -150,7 +150,7 @@ public class SaveClaimWithCoreCaseDataStoreTest extends BaseSaveTest {
 
     @Test
     public void shouldIssueClaimEvenWhenS2STokenGenerationFails() throws Exception {
-        final ClaimData claimData = SampleClaimData.submittedByLegalRepresentative();
+        ClaimData claimData = SampleClaimData.submittedByLegalRepresentative();
 
         given(serviceAuthorisationApi.serviceToken(anyString(), anyString())).willThrow(FeignException.class);
 

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveDefendantResponseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveDefendantResponseTest.java
@@ -50,7 +50,7 @@ public class SaveDefendantResponseTest extends BaseIntegrationTest {
         claimRepository.linkDefendant(claim.getId(), DEFENDANT_ID);
         Response response = SampleResponse.validDefaults();
 
-        final MvcResult result = makeRequest(claim.getId(), DEFENDANT_ID, response)
+        MvcResult result = makeRequest(claim.getId(), DEFENDANT_ID, response)
             .andExpect(status().isOk())
             .andReturn();
 
@@ -108,7 +108,7 @@ public class SaveDefendantResponseTest extends BaseIntegrationTest {
             .withDefence("")
             .build();
 
-        final MvcResult result = makeRequest(anyClaimId, anyDefendantId, response)
+        MvcResult result = makeRequest(anyClaimId, anyDefendantId, response)
             .andExpect(status().isBadRequest())
             .andReturn();
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/NotificationsConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/NotificationsConfiguration.java
@@ -13,7 +13,7 @@ import uk.gov.service.notify.NotificationClient;
 public class NotificationsConfiguration {
 
     @Bean
-    public NotificationClient notificationClient(final NotificationsProperties notificationsProperties) {
+    public NotificationClient notificationClient(NotificationsProperties notificationsProperties) {
         return new NotificationClient(notificationsProperties.getGovNotifyApiKey());
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/ServiceTokenGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/ServiceTokenGeneratorConfiguration.java
@@ -15,12 +15,12 @@ public class ServiceTokenGeneratorConfiguration {
 
     @Bean
     public AuthTokenGenerator authTokenGenerator(
-        @Value("${idam.s2s-auth.totp_secret}") final String secret,
-        @Value("${idam.s2s-auth.microservice}") final String microService,
-        @Value("${idam.s2s-auth.tokenTimeToLiveInSeconds:14400}") final int ttl,
-        final ServiceAuthorisationApi serviceAuthorisationApi) {
+        @Value("${idam.s2s-auth.totp_secret}") String secret,
+        @Value("${idam.s2s-auth.microservice}") String microService,
+        @Value("${idam.s2s-auth.tokenTimeToLiveInSeconds:14400}") int ttl,
+        ServiceAuthorisationApi serviceAuthorisationApi) {
 
-        final AuthTokenGenerator serviceAuthTokenGenerator
+        AuthTokenGenerator serviceAuthTokenGenerator
             = new ServiceAuthTokenGenerator(secret, microService, serviceAuthorisationApi);
 
         return new CachedServiceAuthTokenGenerator(serviceAuthTokenGenerator, ttl);

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/properties/emails/StaffEmailTemplates.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/properties/emails/StaffEmailTemplates.java
@@ -41,14 +41,14 @@ public class StaffEmailTemplates {
         return readString("/staff/templates/email/settlementAgreement/subject.txt");
     }
 
-    private String readString(final String resourcePath) {
+    private String readString(String resourcePath) {
         return new String(
             readBytes(resourcePath),
             Charset.forName("UTF-8")
         );
     }
 
-    private byte[] readBytes(final String resourcePath) {
+    private byte[] readBytes(String resourcePath) {
         try (InputStream inputStream = getClass().getResourceAsStream(resourcePath)) {
             return IOUtils.toByteArray(inputStream);
         } catch (IOException e) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/properties/notifications/EmailTemplates.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/properties/notifications/EmailTemplates.java
@@ -122,7 +122,7 @@ public class EmailTemplates {
         return representativeClaimIssued;
     }
 
-    public void setRepresentativeClaimIssued(final String representativeClaimIssued) {
+    public void setRepresentativeClaimIssued(String representativeClaimIssued) {
         this.representativeClaimIssued = representativeClaimIssued;
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/properties/pdf/DocumentTemplates.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/properties/pdf/DocumentTemplates.java
@@ -41,7 +41,7 @@ public class DocumentTemplates {
         return readBytes("/staff/templates/document/settlementAgreement.html");
     }
 
-    private byte[] readBytes(final String resourcePath) {
+    private byte[] readBytes(String resourcePath) {
         try (InputStream inputStream = getClass().getResourceAsStream(resourcePath)) {
             return IOUtils.toByteArray(inputStream);
         } catch (IOException e) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
@@ -38,32 +38,32 @@ public class ClaimController {
     private final ClaimService claimService;
 
     @Autowired
-    public ClaimController(final ClaimService claimService) {
+    public ClaimController(ClaimService claimService) {
         this.claimService = claimService;
     }
 
     @GetMapping("/claimant/{submitterId}")
     @ApiOperation("Fetch user claims for given submitter id")
-    public List<Claim> getBySubmitterId(@PathVariable("submitterId") final String submitterId) {
+    public List<Claim> getBySubmitterId(@PathVariable("submitterId") String submitterId) {
         return claimService.getClaimBySubmitterId(submitterId);
     }
 
     @GetMapping("/letter/{letterHolderId}")
     @ApiOperation("Fetch user claim for given letter holder id")
-    public Claim getByLetterHolderId(@PathVariable("letterHolderId") final String letterHolderId) {
+    public Claim getByLetterHolderId(@PathVariable("letterHolderId") String letterHolderId) {
         return claimService.getClaimByLetterHolderId(letterHolderId);
     }
 
     @GetMapping("/{externalId:" + UUID_PATTERN + "}")
     @ApiOperation("Fetch claim for given external id")
-    public Claim getByExternalId(@PathVariable("externalId") final String externalId) {
+    public Claim getByExternalId(@PathVariable("externalId") String externalId) {
         return claimService.getClaimByExternalId(externalId);
     }
 
     @GetMapping("/{claimReference:" + CLAIM_REFERENCE_PATTERN + "}")
     @ApiOperation("Fetch claim for given claim reference")
-    public Claim getByClaimReference(@PathVariable("claimReference") final String claimReference,
-                                     @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorisation) {
+    public Claim getByClaimReference(@PathVariable("claimReference") String claimReference,
+                                     @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation) {
 
         return claimService.getClaimByReference(claimReference, authorisation)
             .orElseThrow(() -> new NotFoundException("Claim not found by claim reference " + claimReference));
@@ -72,44 +72,44 @@ public class ClaimController {
     @GetMapping("/representative/{externalReference}")
     @ApiOperation("Fetch user claims for given external reference number")
     public List<Claim> getClaimByExternalReference(
-        @PathVariable("externalReference") final String externalReference,
-        @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorisation) {
+        @PathVariable("externalReference") String externalReference,
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation) {
 
         return claimService.getClaimByExternalReference(externalReference, authorisation);
     }
 
     @GetMapping("/defendant/{defendantId}")
     @ApiOperation("Fetch claims linked to given defendant id")
-    public List<Claim> getByDefendantId(@PathVariable("defendantId") final String defendantId) {
+    public List<Claim> getByDefendantId(@PathVariable("defendantId") String defendantId) {
         return claimService.getClaimByDefendantId(defendantId);
     }
 
     @PostMapping(value = "/{submitterId}", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ApiOperation("Creates a new claim")
-    public Claim save(@Valid @NotNull @RequestBody final ClaimData claimData,
-                      @PathVariable("submitterId") final String submitterId,
-                      @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorisation) {
+    public Claim save(@Valid @NotNull @RequestBody ClaimData claimData,
+                      @PathVariable("submitterId") String submitterId,
+                      @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation) {
         return claimService.saveClaim(submitterId, claimData, authorisation);
     }
 
     @PutMapping("/{claimId:\\d+}/defendant/{defendantId}")
     @ApiOperation("Links defendant to existing claim")
-    public Claim linkDefendantToClaim(@PathVariable("claimId") final Long claimId,
-                                      @PathVariable("defendantId") final String defendantId) {
+    public Claim linkDefendantToClaim(@PathVariable("claimId") Long claimId,
+                                      @PathVariable("defendantId") String defendantId) {
         claimService.linkDefendantToClaim(claimId, defendantId);
         return claimService.getClaimById(claimId);
     }
 
     @PostMapping(value = "/{claimId:\\d+}/request-more-time")
     @ApiOperation("Updates response deadline. Can be called only once per each claim")
-    public Claim requestMoreTimeToRespond(@PathVariable("claimId") final Long claimId,
-                                          @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorisation) {
+    public Claim requestMoreTimeToRespond(@PathVariable("claimId") Long claimId,
+                                          @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation) {
         return claimService.requestMoreTimeForResponse(claimId, authorisation);
     }
 
     @GetMapping("/{caseReference}/defendant-link-status")
     @ApiOperation("Check whether a claim is linked to a defendant")
-    public DefendantLinkStatus isDefendantLinked(@PathVariable("caseReference") final String caseReference) {
+    public DefendantLinkStatus isDefendantLinked(@PathVariable("caseReference") String caseReference) {
         Boolean linked = claimService.getClaimByReference(caseReference)
             .filter(claim -> claim.getDefendantId() != null)
             .isPresent();

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CountyCourtJudgmentController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CountyCourtJudgmentController.java
@@ -31,7 +31,7 @@ public class CountyCourtJudgmentController {
 
     @Autowired
     public CountyCourtJudgmentController(
-        final CountyCourtJudgmentService countyCourtJudgmentService, final UserService userService) {
+        CountyCourtJudgmentService countyCourtJudgmentService, UserService userService) {
         this.countyCourtJudgmentService = countyCourtJudgmentService;
         this.userService = userService;
     }
@@ -39,11 +39,11 @@ public class CountyCourtJudgmentController {
     @PostMapping("/{claimId:\\d+}/county-court-judgment")
     @ApiOperation("Save County Court Judgment")
     public Claim save(
-        @PathVariable("claimId") final Long claimId,
-        @NotNull @RequestBody @Valid final CountyCourtJudgment countyCourtJudgment,
-        @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorisation
+        @PathVariable("claimId") Long claimId,
+        @NotNull @RequestBody @Valid CountyCourtJudgment countyCourtJudgment,
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation
     ) {
-        final String submitterId = userService.getUserDetails(authorisation).getId();
+        String submitterId = userService.getUserDetails(authorisation).getId();
         return countyCourtJudgmentService.save(submitterId, countyCourtJudgment, claimId);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/DefendantResponseController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/DefendantResponseController.java
@@ -27,7 +27,7 @@ public class DefendantResponseController {
     private final DefendantResponseService defendantResponseService;
 
     @Autowired
-    public DefendantResponseController(final DefendantResponseService defendantResponseService) {
+    public DefendantResponseController(DefendantResponseService defendantResponseService) {
         this.defendantResponseService = defendantResponseService;
     }
 
@@ -36,10 +36,10 @@ public class DefendantResponseController {
         consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ApiOperation("Creates a new defendant response")
     public Claim save(
-        @Valid @NotNull @RequestBody final Response response,
-        @PathVariable("defendantId") final String defendantId,
-        @PathVariable("claimId") final Long claimId,
-        @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorization
+        @Valid @NotNull @RequestBody Response response,
+        @PathVariable("defendantId") String defendantId,
+        @PathVariable("claimId") Long claimId,
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization
     ) {
         return defendantResponseService.save(claimId, defendantId, response, authorization);
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/DocumentsController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/DocumentsController.java
@@ -24,7 +24,7 @@ public class DocumentsController {
     private final DocumentsService documentsService;
 
     @Autowired
-    public DocumentsController(final DocumentsService documentsService) {
+    public DocumentsController(DocumentsService documentsService) {
         this.documentsService = documentsService;
     }
 
@@ -37,7 +37,7 @@ public class DocumentsController {
         @ApiParam("Claim external id")
         @PathVariable("externalId") @NotBlank String externalId
     ) {
-        final byte[] pdfDocument = documentsService.generateDefendantResponseCopy(externalId);
+        byte[] pdfDocument = documentsService.generateDefendantResponseCopy(externalId);
 
         return ResponseEntity
             .ok()
@@ -53,9 +53,9 @@ public class DocumentsController {
     public ResponseEntity<ByteArrayResource> legalSealedClaim(
         @ApiParam("Claim external id")
         @PathVariable("externalId") @NotBlank String externalId,
-        @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorisation
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation
     ) {
-        final byte[] pdfDocument = documentsService.getLegalSealedClaim(externalId, authorisation);
+        byte[] pdfDocument = documentsService.getLegalSealedClaim(externalId, authorisation);
 
         return ResponseEntity
             .ok()
@@ -72,7 +72,7 @@ public class DocumentsController {
         @ApiParam("Claim external id")
         @PathVariable("externalId") @NotBlank String externalId
     ) {
-        final byte[] pdfDocument = documentsService.generateCountyCourtJudgement(externalId);
+        byte[] pdfDocument = documentsService.generateCountyCourtJudgement(externalId);
 
         return ResponseEntity
             .ok()
@@ -89,7 +89,7 @@ public class DocumentsController {
         @ApiParam("Claim external id")
         @PathVariable("externalId") @NotBlank String externalId
     ) {
-        final byte[] pdfDocument = documentsService.generateSettlementAgreement(externalId);
+        byte[] pdfDocument = documentsService.generateSettlementAgreement(externalId);
 
         return ResponseEntity
             .ok()
@@ -106,7 +106,7 @@ public class DocumentsController {
         @ApiParam("Claim external id")
         @PathVariable("externalId") @NotBlank String externalId
     ) {
-        final byte[] pdfDocument = documentsService.generateDefendantResponseReceipt(externalId);
+        byte[] pdfDocument = documentsService.generateDefendantResponseReceipt(externalId);
 
         return ResponseEntity
             .ok()
@@ -123,7 +123,7 @@ public class DocumentsController {
         @ApiParam("Claim external id")
         @PathVariable("externalId") @NotBlank String externalId
     ) {
-        final byte[] pdfDocument = documentsService.generateClaimIssueReceipt(externalId);
+        byte[] pdfDocument = documentsService.generateClaimIssueReceipt(externalId);
 
         return ResponseEntity
             .ok()

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/IntegrationTestSupportController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/IntegrationTestSupportController.java
@@ -36,7 +36,7 @@ public class IntegrationTestSupportController {
     @GetMapping("/claims/{claimReferenceNumber}")
     @ApiOperation("Fetch user claim for given reference number")
     public Claim getByClaimReferenceNumber(
-        @PathVariable("claimReferenceNumber") final String claimReferenceNumber
+        @PathVariable("claimReferenceNumber") String claimReferenceNumber
     ) {
         return claimRepository.getByClaimReferenceNumber(claimReferenceNumber)
             .orElseThrow(() -> new NotFoundException("Claim not found by ref no: " + claimReferenceNumber));
@@ -45,8 +45,8 @@ public class IntegrationTestSupportController {
     @PutMapping("/claims/{claimReferenceNumber}/response-deadline/{newDeadline}")
     @ApiOperation("Manipulate the respond by date of a claim")
     public Claim updateRespondByDate(
-        @PathVariable("claimReferenceNumber") final String claimReferenceNumber,
-        @PathVariable("newDeadline") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate newDeadline
+        @PathVariable("claimReferenceNumber") String claimReferenceNumber,
+        @PathVariable("newDeadline") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate newDeadline
     ) {
         Claim claim = getByClaimReferenceNumber(claimReferenceNumber);
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/SupportController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/SupportController.java
@@ -44,13 +44,13 @@ public class SupportController {
 
     @Autowired
     public SupportController(
-        final ClaimService claimService,
-        final UserService userService,
-        final DocumentGenerator documentGenerator,
-        final MoreTimeRequestedStaffNotificationHandler moreTimeRequestedStaffNotificationHandler,
-        final DefendantResponseStaffNotificationHandler defendantResponseStaffNotificationHandler,
-        final CCJStaffNotificationHandler ccjStaffNotificationHandler,
-        final OfferAcceptedStaffNotificationHandler offerAcceptedStaffNotificationHandler
+        ClaimService claimService,
+        UserService userService,
+        DocumentGenerator documentGenerator,
+        MoreTimeRequestedStaffNotificationHandler moreTimeRequestedStaffNotificationHandler,
+        DefendantResponseStaffNotificationHandler defendantResponseStaffNotificationHandler,
+        CCJStaffNotificationHandler ccjStaffNotificationHandler,
+        OfferAcceptedStaffNotificationHandler offerAcceptedStaffNotificationHandler
     ) {
         this.claimService = claimService;
         this.userService = userService;
@@ -64,9 +64,9 @@ public class SupportController {
     @PutMapping("/claim/{referenceNumber}/event/{event}/resend-staff-notifications")
     @ApiOperation("Resend staff notifications associated with provided event")
     public void resendStaffNotifications(
-        @PathVariable("referenceNumber") final String referenceNumber,
-        @PathVariable("event") final String event,
-        @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) final String authorisation
+        @PathVariable("referenceNumber") String referenceNumber,
+        @PathVariable("event") String event,
+        @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorisation
     ) throws ServletRequestBindingException {
 
         Claim claim = claimService.getClaimByReference(referenceNumber)
@@ -93,7 +93,7 @@ public class SupportController {
         }
     }
 
-    private void validateAuthorisationPresentWhenRequired(final String authorisation)
+    private void validateAuthorisationPresentWhenRequired(String authorisation)
         throws ServletRequestBindingException {
         if (StringUtils.isBlank(authorisation)) {
             throw new ServletRequestBindingException(
@@ -102,13 +102,13 @@ public class SupportController {
         }
     }
 
-    private void resendStaffNotificationCCJRequestSubmitted(final Claim claim) {
+    private void resendStaffNotificationCCJRequestSubmitted(Claim claim) {
         this.ccjStaffNotificationHandler.onDefaultJudgmentRequestSubmitted(
             new CountyCourtJudgmentRequestedEvent(claim)
         );
     }
 
-    private void resendStaffNotificationsOnClaimIssued(final Claim claim, final String authorisation)
+    private void resendStaffNotificationsOnClaimIssued(Claim claim, String authorisation)
         throws ServletRequestBindingException {
         if (claim.getDefendantId() != null) {
             throw new ConflictException("Claim has already been linked to defendant - cannot send notification");
@@ -122,13 +122,13 @@ public class SupportController {
 
             claimService.linkLetterHolder(claim.getId(), pinResponse.getUserId());
 
-            final String fullName = userService.getUserDetails(authorisation).getFullName();
+            String fullName = userService.getUserDetails(authorisation).getFullName();
 
             documentGenerator.generateForNonRepresentedClaim(
                 new ClaimIssuedEvent(claim, pinResponse.getPin(), fullName, authorisation)
             );
         } else {
-            final UserDetails userDetails = userService.getUserDetails(authorisation);
+            UserDetails userDetails = userService.getUserDetails(authorisation);
 
             documentGenerator.generateForRepresentedClaim(
                 new RepresentedClaimIssuedEvent(claim, userDetails.getFullName(), authorisation)
@@ -137,7 +137,7 @@ public class SupportController {
 
     }
 
-    private void resendStaffNotificationOnMoreTimeRequested(final Claim claim) {
+    private void resendStaffNotificationOnMoreTimeRequested(Claim claim) {
         if (!claim.isMoreTimeRequested()) {
             throw new ConflictException("More time has not been requested yet - cannot send notification");
         }
@@ -147,19 +147,19 @@ public class SupportController {
         moreTimeRequestedStaffNotificationHandler.sendNotifications(event);
     }
 
-    private void resendStaffNotificationOnDefendantResponseSubmitted(final Claim claim) {
+    private void resendStaffNotificationOnDefendantResponseSubmitted(Claim claim) {
         if (!claim.getResponse().isPresent()) {
             throw new ConflictException(CLAIM + claim.getId() + " does not have associated response");
         }
-        final DefendantResponseEvent event = new DefendantResponseEvent(claim);
+        DefendantResponseEvent event = new DefendantResponseEvent(claim);
         defendantResponseStaffNotificationHandler.onDefendantResponseSubmitted(event);
     }
 
-    private void resendStaffNotificationOnOfferAccepted(final Claim claim) {
+    private void resendStaffNotificationOnOfferAccepted(Claim claim) {
         if (claim.getSettlementReachedAt() == null) {
             throw new ConflictException(CLAIM + claim.getId() + " does not have a settlement");
         }
-        final OfferAcceptedEvent event = new OfferAcceptedEvent(claim, null);
+        OfferAcceptedEvent event = new OfferAcceptedEvent(claim, null);
         offerAcceptedStaffNotificationHandler.onOfferAccepted(event);
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandler.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 
 @ControllerAdvice
 public class ResourceExceptionHandler {
-    private static Logger logger = LoggerFactory.getLogger(ResourceExceptionHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(ResourceExceptionHandler.class);
     private static final CharSequence UNIQUE_CONSTRAINT_MESSAGE = "duplicate key value violates unique constraint";
 
     @ExceptionHandler(value = Exception.class)

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/advices/ResourceExceptionHandler.java
@@ -43,11 +43,11 @@ public class ResourceExceptionHandler {
     public ResponseEntity<Object> unableToExecuteStatement(UnableToExecuteStatementException exception) {
         logger.error(exception.getMessage(), exception);
 
-        final Optional<Throwable> cause = Optional.ofNullable(Throwables.getRootCause(exception))
+        Optional<Throwable> cause = Optional.ofNullable(Throwables.getRootCause(exception))
             .filter(c -> c != exception);
 
-        final Optional<String> exceptionName = cause.map(c -> c.getClass().getName());
-        final Optional<String> message = cause.map(Throwable::getMessage);
+        Optional<String> exceptionName = cause.map(c -> c.getClass().getName());
+        Optional<String> message = cause.map(Throwable::getMessage);
 
         if (exceptionName.isPresent() && exceptionName.get().contains(PSQLException.class.getName())
             && message.isPresent() && message.get().contains(UNIQUE_CONSTRAINT_MESSAGE)) {
@@ -101,7 +101,7 @@ public class ResourceExceptionHandler {
     public ResponseEntity<Object> validatedMethod(MethodArgumentNotValidException exception) {
         logger.error(exception.getMessage(), exception);
 
-        final BindingResult result = exception.getBindingResult();
+        BindingResult result = exception.getBindingResult();
         StringBuilder builder = new StringBuilder();
         List<FieldError> errors = result.getFieldErrors();
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/CitizenSealedClaimPdfService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/CitizenSealedClaimPdfService.java
@@ -17,16 +17,16 @@ public class CitizenSealedClaimPdfService {
 
     @Autowired
     public CitizenSealedClaimPdfService(
-        final DocumentTemplates documentTemplates,
-        final PDFServiceClient pdfServiceClient,
-        final ClaimContentProvider claimContentProvider
+        DocumentTemplates documentTemplates,
+        PDFServiceClient pdfServiceClient,
+        ClaimContentProvider claimContentProvider
     ) {
         this.documentTemplates = documentTemplates;
         this.pdfServiceClient = pdfServiceClient;
         this.claimContentProvider = claimContentProvider;
     }
 
-    public byte[] createPdf(final Claim claim) {
+    public byte[] createPdf(Claim claim) {
         requireNonNull(claim);
 
         return pdfServiceClient.generateFromHtml(

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimContentProvider.java
@@ -24,16 +24,16 @@ public class ClaimContentProvider {
 
     @Autowired
     public ClaimContentProvider(
-        final ClaimantContentProvider claimantContentProvider,
-        final PersonContentProvider personContentProvider,
-        final ClaimDataContentProvider claimDataContentProvider
+        ClaimantContentProvider claimantContentProvider,
+        PersonContentProvider personContentProvider,
+        ClaimDataContentProvider claimDataContentProvider
     ) {
         this.claimantContentProvider = claimantContentProvider;
         this.personContentProvider = personContentProvider;
         this.claimDataContentProvider = claimDataContentProvider;
     }
 
-    public Map<String, Object> createContent(final Claim claim) {
+    public Map<String, Object> createContent(Claim claim) {
         requireNonNull(claim);
 
         Map<String, Object> map = new HashMap<>();

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimIssueReceiptService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimIssueReceiptService.java
@@ -17,16 +17,16 @@ public class ClaimIssueReceiptService {
 
     @Autowired
     public ClaimIssueReceiptService(
-        final DocumentTemplates documentTemplates,
-        final PDFServiceClient pdfServiceClient,
-        final ClaimContentProvider claimContentProvider
+        DocumentTemplates documentTemplates,
+        PDFServiceClient pdfServiceClient,
+        ClaimContentProvider claimContentProvider
     ) {
         this.documentTemplates = documentTemplates;
         this.pdfServiceClient = pdfServiceClient;
         this.claimContentProvider = claimContentProvider;
     }
 
-    public byte[] createPdf(final Claim claim) {
+    public byte[] createPdf(Claim claim) {
         requireNonNull(claim);
 
         return pdfServiceClient.generateFromHtml(

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/CountyCourtJudgmentPdfService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/CountyCourtJudgmentPdfService.java
@@ -18,16 +18,16 @@ public class CountyCourtJudgmentPdfService {
 
     @Autowired
     public CountyCourtJudgmentPdfService(
-        final DocumentTemplates documentTemplates,
-        final PDFServiceClient pdfServiceClient,
-        final ContentProvider contentProvider
+        DocumentTemplates documentTemplates,
+        PDFServiceClient pdfServiceClient,
+        ContentProvider contentProvider
     ) {
         this.documentTemplates = documentTemplates;
         this.pdfServiceClient = pdfServiceClient;
         this.contentProvider = contentProvider;
     }
 
-    public byte[] createPdf(final Claim claim) {
+    public byte[] createPdf(Claim claim) {
         requireNonNull(claim);
 
         return pdfServiceClient.generateFromHtml(

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantPinLetterPdfService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantPinLetterPdfService.java
@@ -18,16 +18,16 @@ public class DefendantPinLetterPdfService {
 
     @Autowired
     public DefendantPinLetterPdfService(
-        final DocumentTemplates documentTemplates,
-        final PDFServiceClient pdfServiceClient,
-        final DefendantPinLetterContentProvider defendantPinLetterContentProvider
+        DocumentTemplates documentTemplates,
+        PDFServiceClient pdfServiceClient,
+        DefendantPinLetterContentProvider defendantPinLetterContentProvider
     ) {
         this.documentTemplates = documentTemplates;
         this.pdfServiceClient = pdfServiceClient;
         this.defendantPinLetterContentProvider = defendantPinLetterContentProvider;
     }
 
-    public byte[] createPdf(final Claim claim, final String defendantPin) {
+    public byte[] createPdf(Claim claim, String defendantPin) {
         requireNonNull(claim);
         requireNonNull(defendantPin);
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantResponseCopyService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantResponseCopyService.java
@@ -18,16 +18,16 @@ public class DefendantResponseCopyService {
 
     @Autowired
     public DefendantResponseCopyService(
-        final DefendantResponseContentProvider contentProvider,
-        final DocumentTemplates documentTemplates,
-        final PDFServiceClient pdfServiceClient
+        DefendantResponseContentProvider contentProvider,
+        DocumentTemplates documentTemplates,
+        PDFServiceClient pdfServiceClient
     ) {
         this.contentProvider = contentProvider;
         this.documentTemplates = documentTemplates;
         this.pdfServiceClient = pdfServiceClient;
     }
 
-    public byte[] createPdf(final Claim claim) {
+    public byte[] createPdf(Claim claim) {
         requireNonNull(claim);
         return pdfServiceClient.generateFromHtml(
             documentTemplates.getDefendantResponseCopy(),

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantResponseReceiptService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantResponseReceiptService.java
@@ -18,16 +18,16 @@ public class DefendantResponseReceiptService {
 
     @Autowired
     public DefendantResponseReceiptService(
-        final DefendantResponseContentProvider contentProvider,
-        final DocumentTemplates documentTemplates,
-        final PDFServiceClient pdfServiceClient
+        DefendantResponseContentProvider contentProvider,
+        DocumentTemplates documentTemplates,
+        PDFServiceClient pdfServiceClient
     ) {
         this.contentProvider = contentProvider;
         this.documentTemplates = documentTemplates;
         this.pdfServiceClient = pdfServiceClient;
     }
 
-    public byte[] createPdf(final Claim claim) {
+    public byte[] createPdf(Claim claim) {
         requireNonNull(claim);
         return pdfServiceClient.generateFromHtml(
             documentTemplates.getDefendantResponseReceipt(),

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DocumentUploader.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DocumentUploader.java
@@ -19,8 +19,8 @@ public class DocumentUploader {
     private final ClaimService claimService;
 
     @Autowired
-    public DocumentUploader(final DocumentManagementService documentManagementService,
-                            final ClaimService claimService) {
+    public DocumentUploader(DocumentManagementService documentManagementService,
+                            ClaimService claimService) {
         this.documentManagementService = documentManagementService;
         this.claimService = claimService;
     }
@@ -28,7 +28,7 @@ public class DocumentUploader {
     @EventListener
     public void uploadIntoDocumentManagementStore(DocumentGeneratedEvent event) {
         event.getDocuments().forEach(document -> {
-            final String documentSelfPath = this.documentManagementService.uploadDocument(event.getAuthorisation(),
+            String documentSelfPath = this.documentManagementService.uploadDocument(event.getAuthorisation(),
                 document.getFilename(), document.getBytes(), PDF.CONTENT_TYPE);
 
             if (isSealedClaim(document.getFilename())) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/LegalSealedClaimPdfService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/LegalSealedClaimPdfService.java
@@ -18,9 +18,9 @@ public class LegalSealedClaimPdfService {
 
     @Autowired
     public LegalSealedClaimPdfService(
-        final DocumentTemplates documentTemplates,
-        final PDFServiceClient pdfServiceClient,
-        final LegalSealedClaimContentProvider legalSealedClaimContentProvider
+        DocumentTemplates documentTemplates,
+        PDFServiceClient pdfServiceClient,
+        LegalSealedClaimContentProvider legalSealedClaimContentProvider
     ) {
         this.documentTemplates = documentTemplates;
         this.pdfServiceClient = pdfServiceClient;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/DefendantResponseContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/DefendantResponseContentProvider.java
@@ -24,16 +24,16 @@ public class DefendantResponseContentProvider {
     private final NotificationsProperties notificationsProperties;
 
     public DefendantResponseContentProvider(
-        final PartyDetailsContentProvider partyDetailsContentProvider,
-        final ClaimDataContentProvider claimDataContentProvider,
-        final NotificationsProperties notificationsProperties
+        PartyDetailsContentProvider partyDetailsContentProvider,
+        ClaimDataContentProvider claimDataContentProvider,
+        NotificationsProperties notificationsProperties
     ) {
         this.partyDetailsContentProvider = partyDetailsContentProvider;
         this.claimDataContentProvider = claimDataContentProvider;
         this.notificationsProperties = notificationsProperties;
     }
 
-    public Map<String, Object> createContent(final Claim claim) {
+    public Map<String, Object> createContent(Claim claim) {
         requireNonNull(claim);
         Response defendantResponse = claim.getResponse().orElseThrow(IllegalStateException::new);
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/LegalSealedClaimContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/LegalSealedClaimContentProvider.java
@@ -21,13 +21,13 @@ public class LegalSealedClaimContentProvider {
     private final boolean watermarkPdf;
 
     @Autowired
-    public LegalSealedClaimContentProvider(final StatementOfValueProvider statementOfValueProvider,
-        @Value("${feature_toggles.watermark_pdf}") final boolean watermarkPdf) {
+    public LegalSealedClaimContentProvider(StatementOfValueProvider statementOfValueProvider,
+        @Value("${feature_toggles.watermark_pdf}") boolean watermarkPdf) {
         this.statementOfValueProvider = statementOfValueProvider;
         this.watermarkPdf = watermarkPdf;
     }
 
-    public Map<String, Object> createContent(final Claim claim) {
+    public Map<String, Object> createContent(Claim claim) {
         requireNonNull(claim);
 
         Map<String, Object> content = new HashMap<>();
@@ -42,13 +42,13 @@ public class LegalSealedClaimContentProvider {
         content.put("claimSummary", claim.getClaimData().getReason());
         content.put("externalReferenceNumber", claim.getClaimData().getExternalReferenceNumber());
 
-        final Representative legalRepresentative = claim.getClaimData().getClaimants().stream()
+        Representative legalRepresentative = claim.getClaimData().getClaimants().stream()
             .findFirst().orElseThrow(IllegalArgumentException::new)
             .getRepresentative().orElseThrow(IllegalArgumentException::new);
 
         content.put("preferredCourt", claim.getClaimData().getPreferredCourt());
         content.put("feePaid", formatMoney(claim.getClaimData().getFeesPaidInPound()));
-        final StatementOfTruth statementOfTruth = claim.getClaimData()
+        StatementOfTruth statementOfTruth = claim.getClaimData()
             .getStatementOfTruth()
             .orElseThrow(IllegalArgumentException::new);
         content.put("signerName", statementOfTruth.getSignerName());

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/StatementOfValueProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/StatementOfValueProvider.java
@@ -34,13 +34,13 @@ public class StatementOfValueProvider {
         + "an order for the landlord to carry out work. ";
 
 
-    public StatementOfValueContent create(final Claim claim) {
+    public StatementOfValueContent create(Claim claim) {
 
         StringBuilder personalInjuryContent = new StringBuilder();
         StringBuilder housingDisprepairContent = new StringBuilder();
         StringBuilder claimValueContent = new StringBuilder();
 
-        final Optional<PersonalInjury> personalInjuryOptional = claim.getClaimData().getPersonalInjury();
+        Optional<PersonalInjury> personalInjuryOptional = claim.getClaimData().getPersonalInjury();
         personalInjuryOptional.ifPresent(personalInjury -> personalInjuryContent.append(PERSONAL_INJURY)
             .append(String.format(PERSONAL_INJURY_DAMAGES,
                 personalInjury.getGeneralDamages().getDisplayValue()))
@@ -65,10 +65,10 @@ public class StatementOfValueProvider {
         if (claimValue instanceof NotKnown) {
             claimValueContent.append(CAN_NOT_STATE);
         } else if (claimValue instanceof AmountRange) {
-            final AmountRange amountRange = (AmountRange) claimValue;
-            final Optional<BigDecimal> lowerValueOptional = amountRange.getLowerValue();
+            AmountRange amountRange = (AmountRange) claimValue;
+            Optional<BigDecimal> lowerValueOptional = amountRange.getLowerValue();
             if (lowerValueOptional.isPresent()) {
-                final BigDecimal lowerValue = lowerValueOptional.get();
+                BigDecimal lowerValue = lowerValueOptional.get();
                 claimValueContent.append(
                     String.format(RECOVER_UP_TO + WORTH_MORE_THAN,
                         formatMoney(amountRange.getHigherValue()),

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/models/StatementOfValueContent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/models/StatementOfValueContent.java
@@ -2,9 +2,9 @@ package uk.gov.hmcts.cmc.claimstore.documents.content.models;
 
 public class StatementOfValueContent {
 
-    private String personalInjury;
-    private String housingDisrepair;
-    private String claimValue;
+    private final String personalInjury;
+    private final String housingDisrepair;
+    private final String claimValue;
 
     public StatementOfValueContent(String personalInjury, String housingDisrepair, String claimValue) {
         this.personalInjury = personalInjury;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/models/StatementOfValueContent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/models/StatementOfValueContent.java
@@ -2,9 +2,9 @@ package uk.gov.hmcts.cmc.claimstore.documents.content.models;
 
 public class StatementOfValueContent {
 
-    private final String personalInjury;
-    private final String housingDisrepair;
-    private final String claimValue;
+    private String personalInjury;
+    private String housingDisrepair;
+    private String claimValue;
 
     public StatementOfValueContent(String personalInjury, String housingDisrepair, String claimValue) {
         this.personalInjury = personalInjury;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/settlementagreement/SettlementAgreementEmailContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/settlementagreement/SettlementAgreementEmailContentProvider.java
@@ -13,8 +13,8 @@ import static org.apache.commons.lang3.Validate.notEmpty;
 @Component
 public class SettlementAgreementEmailContentProvider implements EmailContentProvider<Map<String, Object>> {
 
-    private TemplateService templateService;
-    private StaffEmailTemplates staffEmailTemplates;
+    private final TemplateService templateService;
+    private final StaffEmailTemplates staffEmailTemplates;
 
     public SettlementAgreementEmailContentProvider(
         TemplateService templateService,

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/settlementagreement/SettlementAgreementEmailContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/settlementagreement/SettlementAgreementEmailContentProvider.java
@@ -13,12 +13,12 @@ import static org.apache.commons.lang3.Validate.notEmpty;
 @Component
 public class SettlementAgreementEmailContentProvider implements EmailContentProvider<Map<String, Object>> {
 
-    private final TemplateService templateService;
-    private final StaffEmailTemplates staffEmailTemplates;
+    private TemplateService templateService;
+    private StaffEmailTemplates staffEmailTemplates;
 
     public SettlementAgreementEmailContentProvider(
-        final TemplateService templateService,
-        final StaffEmailTemplates staffEmailTemplates
+        TemplateService templateService,
+        StaffEmailTemplates staffEmailTemplates
     ) {
         this.templateService = templateService;
         this.staffEmailTemplates = staffEmailTemplates;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/settlementagreement/SettlementAgreementPDFContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/settlementagreement/SettlementAgreementPDFContentProvider.java
@@ -18,12 +18,12 @@ public class SettlementAgreementPDFContentProvider {
     private final PartyDetailsContentProvider partyDetailsContentProvider;
 
     public SettlementAgreementPDFContentProvider(
-        final PartyDetailsContentProvider partyDetailsContentProvider
+        PartyDetailsContentProvider partyDetailsContentProvider
     ) {
         this.partyDetailsContentProvider = partyDetailsContentProvider;
     }
 
-    public Map<String, Object> createContent(final Claim claim) {
+    public Map<String, Object> createContent(Claim claim) {
         requireNonNull(claim);
 
         Offer acceptedOffer = claim.getSettlement().orElseThrow(IllegalArgumentException::new)

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/output/PDF.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/output/PDF.java
@@ -9,7 +9,7 @@ public class PDF {
     private final String fileBaseName;
     private final byte[] bytes;
 
-    public PDF(final String fileBaseName, final byte[] bytes) {
+    public PDF(String fileBaseName, byte[] bytes) {
         this.fileBaseName = fileBaseName;
         this.bytes = bytes;
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/DocumentGeneratedEvent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/DocumentGeneratedEvent.java
@@ -12,11 +12,11 @@ public class DocumentGeneratedEvent {
     private final String authorization;
     private final List<PDF> documents;
 
-    public DocumentGeneratedEvent(final Claim claim, String authorization, PDF... documents) {
+    public DocumentGeneratedEvent(Claim claim, String authorization, PDF... documents) {
         this(claim, authorization, newArrayList(documents));
     }
 
-    public DocumentGeneratedEvent(final Claim claim, String authorization, final List<PDF> documents) {
+    public DocumentGeneratedEvent(Claim claim, String authorization, List<PDF> documents) {
         this.claim = claim;
         this.authorization = authorization;
         this.documents = documents;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/EventProducer.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/EventProducer.java
@@ -17,7 +17,7 @@ import java.time.LocalDate;
 
 @Component
 public class EventProducer {
-    private ApplicationEventPublisher publisher;
+    private final ApplicationEventPublisher publisher;
 
     public EventProducer(ApplicationEventPublisher publisher) {
         this.publisher = publisher;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/EventProducer.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/EventProducer.java
@@ -17,14 +17,14 @@ import java.time.LocalDate;
 
 @Component
 public class EventProducer {
-    private final ApplicationEventPublisher publisher;
+    private ApplicationEventPublisher publisher;
 
-    public EventProducer(final ApplicationEventPublisher publisher) {
+    public EventProducer(ApplicationEventPublisher publisher) {
         this.publisher = publisher;
     }
 
-    public void createClaimIssuedEvent(final Claim claim, final String pin,
-                                       final String submitterName, final String authorisation) {
+    public void createClaimIssuedEvent(Claim claim, String pin,
+                                       String submitterName, String authorisation) {
 
         if (claim.getClaimData().isClaimantRepresented()) {
             publisher.publishEvent(new RepresentedClaimIssuedEvent(claim, submitterName, authorisation));
@@ -33,28 +33,28 @@ public class EventProducer {
         }
     }
 
-    public void createDefendantResponseEvent(final Claim claim) {
+    public void createDefendantResponseEvent(Claim claim) {
         publisher.publishEvent(new DefendantResponseEvent(claim));
     }
 
     public void createMoreTimeForResponseRequestedEvent(
-        final Claim claim, final LocalDate newResponseDeadline, final String defendantEmail) {
+        Claim claim, LocalDate newResponseDeadline, String defendantEmail) {
         publisher.publishEvent(new MoreTimeRequestedEvent(claim, newResponseDeadline, defendantEmail));
     }
 
-    public void createCountyCourtJudgmentRequestedEvent(final Claim claim) {
+    public void createCountyCourtJudgmentRequestedEvent(Claim claim) {
         publisher.publishEvent(new CountyCourtJudgmentRequestedEvent(claim));
     }
 
-    public void createOfferMadeEvent(final Claim claim) {
+    public void createOfferMadeEvent(Claim claim) {
         publisher.publishEvent(new OfferMadeEvent(claim));
     }
 
-    public void createOfferAcceptedEvent(final Claim claim, final MadeBy party) {
+    public void createOfferAcceptedEvent(Claim claim, MadeBy party) {
         publisher.publishEvent(new OfferAcceptedEvent(claim, party));
     }
 
-    public void createOfferRejectedEvent(final Claim claim, final MadeBy party) {
+    public void createOfferRejectedEvent(Claim claim, MadeBy party) {
         publisher.publishEvent(new OfferRejectedEvent(claim, party));
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/ccd/CoreCaseDataUploader.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/ccd/CoreCaseDataUploader.java
@@ -17,7 +17,7 @@ public class CoreCaseDataUploader {
     private final CoreCaseDataService coreCaseDataService;
 
     @Autowired
-    public CoreCaseDataUploader(final CoreCaseDataService coreCaseDataService) {
+    public CoreCaseDataUploader(CoreCaseDataService coreCaseDataService) {
         this.coreCaseDataService = coreCaseDataService;
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/ccj/CCJRequestedCitizenActionsHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/ccj/CCJRequestedCitizenActionsHandler.java
@@ -12,14 +12,14 @@ public class CCJRequestedCitizenActionsHandler {
 
     @Autowired
     public CCJRequestedCitizenActionsHandler(
-        final CCJRequestedNotificationService ccjRequestedNotificationService
+        CCJRequestedNotificationService ccjRequestedNotificationService
     ) {
         this.ccjRequestedNotificationService = ccjRequestedNotificationService;
     }
 
     @EventListener
-    public void sendClaimantNotification(final CountyCourtJudgmentRequestedEvent event) {
-        final Claim claim = event.getClaim();
+    public void sendClaimantNotification(CountyCourtJudgmentRequestedEvent event) {
+        Claim claim = event.getClaim();
 
         ccjRequestedNotificationService.notifyClaimant(claim);
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/ccj/CCJStaffNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/ccj/CCJStaffNotificationHandler.java
@@ -11,12 +11,12 @@ public class CCJStaffNotificationHandler {
     private final CCJStaffNotificationService ccjStaffNotificationService;
 
     @Autowired
-    public CCJStaffNotificationHandler(final CCJStaffNotificationService ccjStaffNotificationService) {
+    public CCJStaffNotificationHandler(CCJStaffNotificationService ccjStaffNotificationService) {
         this.ccjStaffNotificationService = ccjStaffNotificationService;
     }
 
     @EventListener
-    public void onDefaultJudgmentRequestSubmitted(final CountyCourtJudgmentRequestedEvent event) {
+    public void onDefaultJudgmentRequestSubmitted(CountyCourtJudgmentRequestedEvent event) {
         this.ccjStaffNotificationService.notifyStaffCCJRequestSubmitted(
             event.getClaim()
         );

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/ccj/CountyCourtJudgmentRequestedEvent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/ccj/CountyCourtJudgmentRequestedEvent.java
@@ -11,7 +11,7 @@ public class CountyCourtJudgmentRequestedEvent {
 
     private final Claim claim;
 
-    public CountyCourtJudgmentRequestedEvent(final Claim claim) {
+    public CountyCourtJudgmentRequestedEvent(Claim claim) {
         this.claim = claim;
     }
 
@@ -20,7 +20,7 @@ public class CountyCourtJudgmentRequestedEvent {
     }
 
     @Override
-    public boolean equals(final Object other) {
+    public boolean equals(Object other) {
         if (this == other) {
             return true;
         }
@@ -29,7 +29,7 @@ public class CountyCourtJudgmentRequestedEvent {
             return false;
         }
 
-        final CountyCourtJudgmentRequestedEvent that = (CountyCourtJudgmentRequestedEvent) other;
+        CountyCourtJudgmentRequestedEvent that = (CountyCourtJudgmentRequestedEvent) other;
         return Objects.equals(claim, that.claim);
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/claim/ClaimIssuedCitizenActionsHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/claim/ClaimIssuedCitizenActionsHandler.java
@@ -17,16 +17,16 @@ public class ClaimIssuedCitizenActionsHandler {
 
     @Autowired
     public ClaimIssuedCitizenActionsHandler(
-        final ClaimIssuedNotificationService claimIssuedNotificationService,
-        final NotificationsProperties notificationsProperties
+        ClaimIssuedNotificationService claimIssuedNotificationService,
+        NotificationsProperties notificationsProperties
     ) {
         this.claimIssuedNotificationService = claimIssuedNotificationService;
         this.notificationsProperties = notificationsProperties;
     }
 
     @EventListener
-    public void sendClaimantNotification(final ClaimIssuedEvent event) {
-        final Claim claim = event.getClaim();
+    public void sendClaimantNotification(ClaimIssuedEvent event) {
+        Claim claim = event.getClaim();
 
         claimIssuedNotificationService.sendMail(
             claim,
@@ -39,8 +39,8 @@ public class ClaimIssuedCitizenActionsHandler {
     }
 
     @EventListener
-    public void sendDefendantNotification(final ClaimIssuedEvent event) {
-        final Claim claim = event.getClaim();
+    public void sendDefendantNotification(ClaimIssuedEvent event) {
+        Claim claim = event.getClaim();
 
         if (!claim.getClaimData().isClaimantRepresented()) {
             claim.getClaimData().getDefendant().getEmail()
@@ -57,7 +57,7 @@ public class ClaimIssuedCitizenActionsHandler {
     }
 
     private EmailTemplates getEmailTemplates() {
-        final NotificationTemplates templates = notificationsProperties.getTemplates();
+        NotificationTemplates templates = notificationsProperties.getTemplates();
         return templates.getEmail();
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/claim/ClaimIssuedEvent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/claim/ClaimIssuedEvent.java
@@ -14,10 +14,10 @@ public class ClaimIssuedEvent {
     private final String submitterName;
     private final String authorisation;
 
-    public ClaimIssuedEvent(final Claim claim,
-                            final String pin,
-                            final String submitterName,
-                            final String authorisation
+    public ClaimIssuedEvent(Claim claim,
+                            String pin,
+                            String submitterName,
+                            String authorisation
     ) {
         this.claim = claim;
         this.pin = pin;
@@ -43,7 +43,7 @@ public class ClaimIssuedEvent {
 
     @Override
     @SuppressWarnings("squid:S1067") // Its generated code for equals sonar
-    public boolean equals(final Object other) {
+    public boolean equals(Object other) {
         if (this == other) {
             return true;
         }
@@ -52,7 +52,7 @@ public class ClaimIssuedEvent {
             return false;
         }
 
-        final ClaimIssuedEvent that = (ClaimIssuedEvent) other;
+        ClaimIssuedEvent that = (ClaimIssuedEvent) other;
 
         return Objects.equals(claim, that.claim)
             && Objects.equals(pin, that.pin)

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/claim/DocumentGenerator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/claim/DocumentGenerator.java
@@ -24,10 +24,10 @@ public class DocumentGenerator {
 
     @Autowired
     public DocumentGenerator(
-        final CitizenSealedClaimPdfService citizenSealedClaimPdfService,
-        final DefendantPinLetterPdfService defendantPinLetterPdfService,
-        final LegalSealedClaimPdfService legalSealedClaimPdfService,
-        final ApplicationEventPublisher publisher
+        CitizenSealedClaimPdfService citizenSealedClaimPdfService,
+        DefendantPinLetterPdfService defendantPinLetterPdfService,
+        LegalSealedClaimPdfService legalSealedClaimPdfService,
+        ApplicationEventPublisher publisher
     ) {
         this.citizenSealedClaimPdfService = citizenSealedClaimPdfService;
         this.defendantPinLetterPdfService = defendantPinLetterPdfService;
@@ -36,7 +36,7 @@ public class DocumentGenerator {
     }
 
     @EventListener
-    public void generateForNonRepresentedClaim(final ClaimIssuedEvent event) {
+    public void generateForNonRepresentedClaim(ClaimIssuedEvent event) {
         PDF sealedClaim = new PDF(buildSealedClaimFileBaseName(event.getClaim().getReferenceNumber()),
             citizenSealedClaimPdfService.createPdf(event.getClaim()));
         PDF defendantLetter = new PDF(buildDefendantLetterFileBaseName(event.getClaim().getReferenceNumber()),
@@ -48,7 +48,7 @@ public class DocumentGenerator {
     }
 
     @EventListener
-    public void generateForRepresentedClaim(final RepresentedClaimIssuedEvent event) {
+    public void generateForRepresentedClaim(RepresentedClaimIssuedEvent event) {
         PDF sealedClaim = new PDF(buildSealedClaimFileBaseName(event.getClaim().getReferenceNumber()),
             legalSealedClaimPdfService.createPdf(event.getClaim()));
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferAcceptedEvent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferAcceptedEvent.java
@@ -5,7 +5,7 @@ import uk.gov.hmcts.cmc.domain.models.offers.MadeBy;
 
 public class OfferAcceptedEvent extends OfferRespondedEvent {
 
-    public OfferAcceptedEvent(final Claim claim, final MadeBy party) {
+    public OfferAcceptedEvent(Claim claim, MadeBy party) {
         this.claim = claim;
         this.party = party;
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferAcceptedStaffNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferAcceptedStaffNotificationHandler.java
@@ -17,7 +17,7 @@ public class OfferAcceptedStaffNotificationHandler {
     }
 
     @EventListener
-    public void onOfferAccepted(final OfferAcceptedEvent event) {
+    public void onOfferAccepted(OfferAcceptedEvent event) {
         notificationService.notifyOfferAccepted(
             event.getClaim()
         );

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferMadeCitizenActionsHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferMadeCitizenActionsHandler.java
@@ -28,9 +28,9 @@ public class OfferMadeCitizenActionsHandler {
 
     @Autowired
     public OfferMadeCitizenActionsHandler(
-        final OfferMadeNotificationService offerMadeNotificationService,
-        final OfferResponseDeadlineCalculator offerResponseDeadlineCalculator,
-        final NotificationsProperties notificationsProperties
+        OfferMadeNotificationService offerMadeNotificationService,
+        OfferResponseDeadlineCalculator offerResponseDeadlineCalculator,
+        NotificationsProperties notificationsProperties
     ) {
         this.offerMadeNotificationService = offerMadeNotificationService;
         this.offerResponseDeadlineCalculator = offerResponseDeadlineCalculator;
@@ -38,8 +38,8 @@ public class OfferMadeCitizenActionsHandler {
     }
 
     @EventListener
-    public void sendClaimantNotification(final OfferMadeEvent event) {
-        final Claim claim = event.getClaim();
+    public void sendClaimantNotification(OfferMadeEvent event) {
+        Claim claim = event.getClaim();
 
         offerMadeNotificationService.sendNotificationEmail(
             claim.getSubmitterEmail(),
@@ -50,8 +50,8 @@ public class OfferMadeCitizenActionsHandler {
     }
 
     @EventListener
-    public void sendDefendantNotification(final OfferMadeEvent event) {
-        final Claim claim = event.getClaim();
+    public void sendDefendantNotification(OfferMadeEvent event) {
+        Claim claim = event.getClaim();
 
         offerMadeNotificationService.sendNotificationEmail(
             claim.getDefendantEmail(),
@@ -61,7 +61,7 @@ public class OfferMadeCitizenActionsHandler {
         );
     }
 
-    private Map<String, String> aggregateParams(final Claim claim) {
+    private Map<String, String> aggregateParams(Claim claim) {
 
         HashMap<String, String> parameters = new HashMap<>();
         parameters.put(CLAIMANT_NAME, claim.getClaimData().getClaimant().getName());

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferMadeEvent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferMadeEvent.java
@@ -11,7 +11,7 @@ public class OfferMadeEvent {
 
     private final Claim claim;
 
-    public OfferMadeEvent(final Claim claim) {
+    public OfferMadeEvent(Claim claim) {
         this.claim = claim;
     }
 
@@ -20,7 +20,7 @@ public class OfferMadeEvent {
     }
 
     @Override
-    public boolean equals(final Object other) {
+    public boolean equals(Object other) {
         if (this == other) {
             return true;
         }
@@ -29,7 +29,7 @@ public class OfferMadeEvent {
             return false;
         }
 
-        final OfferMadeEvent that = (OfferMadeEvent) other;
+        OfferMadeEvent that = (OfferMadeEvent) other;
         return Objects.equals(claim, that.claim);
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferRejectedEvent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferRejectedEvent.java
@@ -5,7 +5,7 @@ import uk.gov.hmcts.cmc.domain.models.offers.MadeBy;
 
 public class OfferRejectedEvent extends OfferRespondedEvent {
 
-    public OfferRejectedEvent(final Claim claim, final MadeBy party) {
+    public OfferRejectedEvent(Claim claim, MadeBy party) {
         this.claim = claim;
         this.party = party;
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferRespondedCitizenActionsHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferRespondedCitizenActionsHandler.java
@@ -24,16 +24,16 @@ public class OfferRespondedCitizenActionsHandler {
 
     @Autowired
     public OfferRespondedCitizenActionsHandler(
-        final OfferMadeNotificationService offerMadeNotificationService,
-        final NotificationsProperties notificationsProperties
+        OfferMadeNotificationService offerMadeNotificationService,
+        NotificationsProperties notificationsProperties
     ) {
         this.offerMadeNotificationService = offerMadeNotificationService;
         this.notificationsProperties = notificationsProperties;
     }
 
     @EventListener
-    public void sendNotificationToClaimantOnOfferAcceptedByClaimant(final OfferAcceptedEvent event) {
-        final Claim claim = event.getClaim();
+    public void sendNotificationToClaimantOnOfferAcceptedByClaimant(OfferAcceptedEvent event) {
+        Claim claim = event.getClaim();
 
         offerMadeNotificationService.sendNotificationEmail(
             claim.getSubmitterEmail(),
@@ -44,8 +44,8 @@ public class OfferRespondedCitizenActionsHandler {
     }
 
     @EventListener
-    public void sendNotificationToDefendantOnOfferAcceptedByClaimant(final OfferAcceptedEvent event) {
-        final Claim claim = event.getClaim();
+    public void sendNotificationToDefendantOnOfferAcceptedByClaimant(OfferAcceptedEvent event) {
+        Claim claim = event.getClaim();
 
         offerMadeNotificationService.sendNotificationEmail(
             claim.getDefendantEmail(),
@@ -56,8 +56,8 @@ public class OfferRespondedCitizenActionsHandler {
     }
 
     @EventListener
-    public void sendNotificationToClaimantOnOfferRejectedByClaimant(final OfferRejectedEvent event) {
-        final Claim claim = event.getClaim();
+    public void sendNotificationToClaimantOnOfferRejectedByClaimant(OfferRejectedEvent event) {
+        Claim claim = event.getClaim();
 
         offerMadeNotificationService.sendNotificationEmail(
             claim.getSubmitterEmail(),
@@ -68,8 +68,8 @@ public class OfferRespondedCitizenActionsHandler {
     }
 
     @EventListener
-    public void sendNotificationToDefendantOnOfferRejectedByClaimant(final OfferRejectedEvent event) {
-        final Claim claim = event.getClaim();
+    public void sendNotificationToDefendantOnOfferRejectedByClaimant(OfferRejectedEvent event) {
+        Claim claim = event.getClaim();
 
         offerMadeNotificationService.sendNotificationEmail(
             claim.getDefendantEmail(),
@@ -79,7 +79,7 @@ public class OfferRespondedCitizenActionsHandler {
         );
     }
 
-    private Map<String, String> aggregateParams(final Claim claim) {
+    private Map<String, String> aggregateParams(Claim claim) {
 
         HashMap<String, String> parameters = new HashMap<>();
         parameters.put(CLAIMANT_NAME, claim.getClaimData().getClaimant().getName());

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferRespondedEvent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/offer/OfferRespondedEvent.java
@@ -26,7 +26,7 @@ public abstract class OfferRespondedEvent {
     }
 
     @Override
-    public boolean equals(final Object other) {
+    public boolean equals(Object other) {
         if (this == other) {
             return true;
         }
@@ -35,7 +35,7 @@ public abstract class OfferRespondedEvent {
             return false;
         }
 
-        final OfferRespondedEvent that = (OfferRespondedEvent) other;
+        OfferRespondedEvent that = (OfferRespondedEvent) other;
         return Objects.equals(claim, that.claim) && Objects.equals(party, that.party);
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/DefendantResponseCitizenNotificationsHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/DefendantResponseCitizenNotificationsHandler.java
@@ -15,12 +15,12 @@ public class DefendantResponseCitizenNotificationsHandler {
 
     @Autowired
     public DefendantResponseCitizenNotificationsHandler(
-        final DefendantResponseNotificationService defendantResponseNotificationService) {
+        DefendantResponseNotificationService defendantResponseNotificationService) {
         this.defendantResponseNotificationService = defendantResponseNotificationService;
     }
 
     @EventListener
-    public void notifyDefendantResponse(final DefendantResponseEvent event) {
+    public void notifyDefendantResponse(DefendantResponseEvent event) {
         defendantResponseNotificationService.notifyDefendant(
             event.getClaim(),
             event.getUserEmail(),
@@ -29,7 +29,7 @@ public class DefendantResponseCitizenNotificationsHandler {
     }
 
     @EventListener
-    public void notifyClaimantResponse(final DefendantResponseEvent event) {
+    public void notifyClaimantResponse(DefendantResponseEvent event) {
         Claim claim = event.getClaim();
 
         defendantResponseNotificationService.notifyClaimant(

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/DefendantResponseEvent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/DefendantResponseEvent.java
@@ -8,7 +8,7 @@ public class DefendantResponseEvent {
     private final String userEmail;
     private final Claim claim;
 
-    public DefendantResponseEvent(final Claim claim) {
+    public DefendantResponseEvent(Claim claim) {
         this.userEmail = claim.getDefendantEmail();
         this.claim = claim;
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/DefendantResponseStaffNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/DefendantResponseStaffNotificationHandler.java
@@ -17,7 +17,7 @@ public class DefendantResponseStaffNotificationHandler {
     }
 
     @EventListener
-    public void onDefendantResponseSubmitted(final DefendantResponseEvent event) {
+    public void onDefendantResponseSubmitted(DefendantResponseEvent event) {
         defendantResponseStaffNotificationService.notifyStaffDefenceSubmittedFor(
             event.getClaim(),
             event.getUserEmail()

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/MoreTimeRequestedCitizenNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/MoreTimeRequestedCitizenNotificationHandler.java
@@ -24,20 +24,20 @@ public class MoreTimeRequestedCitizenNotificationHandler {
 
     @Autowired
     public MoreTimeRequestedCitizenNotificationHandler(
-        final MoreTimeRequestedNotificationService notificationService,
-        final NotificationsProperties notificationsProperties
+        MoreTimeRequestedNotificationService notificationService,
+        NotificationsProperties notificationsProperties
     ) {
         this.notificationService = notificationService;
         this.notificationsProperties = notificationsProperties;
     }
 
     @EventListener
-    void sendNotifications(final MoreTimeRequestedEvent event) {
+    void sendNotifications(MoreTimeRequestedEvent event) {
         sendNotificationToClaimant(event);
         sendNotificationToDefendant(event);
     }
 
-    private void sendNotificationToDefendant(final MoreTimeRequestedEvent event) {
+    private void sendNotificationToDefendant(MoreTimeRequestedEvent event) {
         notificationService.sendMail(
             event.getDefendantEmail(),
             notificationsProperties.getTemplates().getEmail().getDefendantMoreTimeRequested(),
@@ -46,7 +46,7 @@ public class MoreTimeRequestedCitizenNotificationHandler {
         );
     }
 
-    private void sendNotificationToClaimant(final MoreTimeRequestedEvent event) {
+    private void sendNotificationToClaimant(MoreTimeRequestedEvent event) {
         notificationService.sendMail(
             event.getClaim().getSubmitterEmail(),
             notificationsProperties.getTemplates().getEmail().getClaimantMoreTimeRequested(),
@@ -55,7 +55,7 @@ public class MoreTimeRequestedCitizenNotificationHandler {
         );
     }
 
-    private Map<String, String> prepareNotificationParameters(final MoreTimeRequestedEvent event) {
+    private Map<String, String> prepareNotificationParameters(MoreTimeRequestedEvent event) {
 
         Claim claim = event.getClaim();
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/MoreTimeRequestedEvent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/MoreTimeRequestedEvent.java
@@ -10,7 +10,7 @@ public class MoreTimeRequestedEvent {
     private final LocalDate newResponseDeadline;
     private final String defendantEmail;
 
-    public MoreTimeRequestedEvent(final Claim claim, final LocalDate newResponseDeadline, final String defendantEmail) {
+    public MoreTimeRequestedEvent(Claim claim, LocalDate newResponseDeadline, String defendantEmail) {
         this.claim = claim;
         this.newResponseDeadline = newResponseDeadline;
         this.defendantEmail = defendantEmail;
@@ -29,7 +29,7 @@ public class MoreTimeRequestedEvent {
     }
 
     @Override
-    public boolean equals(final Object other) {
+    public boolean equals(Object other) {
         if (this == other) {
             return true;
         }
@@ -38,7 +38,7 @@ public class MoreTimeRequestedEvent {
             return false;
         }
 
-        final MoreTimeRequestedEvent that = (MoreTimeRequestedEvent) other;
+        MoreTimeRequestedEvent that = (MoreTimeRequestedEvent) other;
         return Objects.equals(claim, that.claim)
             && Objects.equals(newResponseDeadline, that.newResponseDeadline)
             && Objects.equals(defendantEmail, that.defendantEmail);

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/MoreTimeRequestedStaffNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/MoreTimeRequestedStaffNotificationHandler.java
@@ -25,9 +25,9 @@ public class MoreTimeRequestedStaffNotificationHandler {
 
     @Autowired
     public MoreTimeRequestedStaffNotificationHandler(
-        final MoreTimeRequestedNotificationService notificationService,
-        final NotificationsProperties notificationsProperties,
-        final StaffEmailProperties staffEmailProperties
+        MoreTimeRequestedNotificationService notificationService,
+        NotificationsProperties notificationsProperties,
+        StaffEmailProperties staffEmailProperties
     ) {
 
         this.notificationService = notificationService;
@@ -36,7 +36,7 @@ public class MoreTimeRequestedStaffNotificationHandler {
     }
 
     @EventListener
-    public void sendNotifications(final MoreTimeRequestedEvent event) {
+    public void sendNotifications(MoreTimeRequestedEvent event) {
         notificationService.sendMail(
             staffEmailProperties.getRecipient(),
             notificationsProperties.getTemplates().getEmail().getStaffMoreTimeRequested(),
@@ -45,7 +45,7 @@ public class MoreTimeRequestedStaffNotificationHandler {
         );
     }
 
-    private Map<String, String> prepareNotificationParameters(final MoreTimeRequestedEvent event) {
+    private Map<String, String> prepareNotificationParameters(MoreTimeRequestedEvent event) {
 
         Claim claim = event.getClaim();
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/solicitor/RepresentativeConfirmationHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/solicitor/RepresentativeConfirmationHandler.java
@@ -15,8 +15,8 @@ public class RepresentativeConfirmationHandler {
     private final NotificationsProperties notificationsProperties;
 
     public RepresentativeConfirmationHandler(
-        final ClaimIssuedNotificationService claimIssuedNotificationService,
-        final NotificationsProperties notificationsProperties
+        ClaimIssuedNotificationService claimIssuedNotificationService,
+        NotificationsProperties notificationsProperties
     ) {
         this.claimIssuedNotificationService = claimIssuedNotificationService;
         this.notificationsProperties = notificationsProperties;
@@ -24,7 +24,7 @@ public class RepresentativeConfirmationHandler {
 
     @EventListener
     public void sendConfirmation(RepresentedClaimIssuedEvent event) {
-        final Claim claim = event.getClaim();
+        Claim claim = event.getClaim();
 
         claimIssuedNotificationService.sendMail(
             claim,
@@ -36,7 +36,7 @@ public class RepresentativeConfirmationHandler {
     }
 
     private EmailTemplates getEmailTemplates() {
-        final NotificationTemplates templates = notificationsProperties.getTemplates();
+        NotificationTemplates templates = notificationsProperties.getTemplates();
         return templates.getEmail();
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/solicitor/RepresentedClaimIssuedEvent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/solicitor/RepresentedClaimIssuedEvent.java
@@ -15,7 +15,7 @@ public class RepresentedClaimIssuedEvent {
     private final String representativeEmail;
     private final String authorisation;
 
-    public RepresentedClaimIssuedEvent(Claim claim, final String submitterName, final String authorisation) {
+    public RepresentedClaimIssuedEvent(Claim claim, String submitterName, String authorisation) {
         this.claim = claim;
         this.representativeName = submitterName;
         this.representativeEmail = claim.getSubmitterEmail();
@@ -39,7 +39,7 @@ public class RepresentedClaimIssuedEvent {
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }
@@ -48,7 +48,7 @@ public class RepresentedClaimIssuedEvent {
             return false;
         }
 
-        final RepresentedClaimIssuedEvent that = (RepresentedClaimIssuedEvent) obj;
+        RepresentedClaimIssuedEvent that = (RepresentedClaimIssuedEvent) obj;
 
         return Objects.equals(claim, that.claim)
             && Objects.equals(representativeName, that.representativeName)

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/ConflictException.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/ConflictException.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.cmc.claimstore.exceptions;
 
 public class ConflictException extends RuntimeException {
-    public ConflictException(final String message) {
+    public ConflictException(String message) {
         super(message);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/CoreCaseDataStoreException.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/CoreCaseDataStoreException.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.cmc.claimstore.exceptions;
 
 public class CoreCaseDataStoreException extends RuntimeException {
 
-    public CoreCaseDataStoreException(final String message, final Throwable throwable) {
+    public CoreCaseDataStoreException(String message, Throwable throwable) {
         super(message, throwable);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/DocumentManagementException.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/DocumentManagementException.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.cmc.claimstore.exceptions;
 
 public class DocumentManagementException extends RuntimeException {
-    public DocumentManagementException(final String message) {
+    public DocumentManagementException(String message) {
         super(message);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/MoreTimeAlreadyRequestedException.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/MoreTimeAlreadyRequestedException.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.cmc.claimstore.exceptions;
 
 public class MoreTimeAlreadyRequestedException extends ConflictException {
-    public MoreTimeAlreadyRequestedException(final String message) {
+    public MoreTimeAlreadyRequestedException(String message) {
         super(message);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/MoreTimeRequestedAfterDeadlineException.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/exceptions/MoreTimeRequestedAfterDeadlineException.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.cmc.claimstore.exceptions;
 
 public class MoreTimeRequestedAfterDeadlineException extends ConflictException {
-    public MoreTimeRequestedAfterDeadlineException(final String message) {
+    public MoreTimeRequestedAfterDeadlineException(String message) {
         super(message);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/idam/models/GeneratePinResponse.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/idam/models/GeneratePinResponse.java
@@ -9,7 +9,7 @@ public class GeneratePinResponse {
     private final String pin;
     private final String userId;
 
-    public GeneratePinResponse(@JsonProperty("pin") final String pin, @JsonProperty("userId") final String userId) {
+    public GeneratePinResponse(@JsonProperty("pin") String pin, @JsonProperty("userId") String userId) {
         this.pin = pin;
         this.userId = userId;
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/idam/models/UserDetails.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/idam/models/UserDetails.java
@@ -15,10 +15,10 @@ public class UserDetails {
     private final String forename;
     private final String surname;
 
-    public UserDetails(@JsonProperty("id") final String id,
-                       @JsonProperty("email") final String email,
-                       @JsonProperty("forename") final String forename,
-                       @JsonProperty("surname") final String surname
+    public UserDetails(@JsonProperty("id") String id,
+                       @JsonProperty("email") String email,
+                       @JsonProperty("forename") String forename,
+                       @JsonProperty("surname") String surname
     ) {
         this.id = id;
         this.email = email;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/processors/JsonMapper.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/processors/JsonMapper.java
@@ -15,11 +15,11 @@ public class JsonMapper {
 
     private ObjectMapper objectMapper;
 
-    public JsonMapper(final ObjectMapper objectMapper) {
+    public JsonMapper(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public String toJson(final Object input) {
+    public String toJson(Object input) {
         try {
             return objectMapper.writeValueAsString(input);
         } catch (JsonProcessingException e) {
@@ -29,7 +29,7 @@ public class JsonMapper {
         }
     }
 
-    public <T> T fromJson(final String value, final Class<T> clazz) {
+    public <T> T fromJson(String value, Class<T> clazz) {
         try {
             return objectMapper.readValue(value, clazz);
         } catch (IOException e) {
@@ -39,7 +39,7 @@ public class JsonMapper {
         }
     }
 
-    public <T> T fromJson(final String value, final TypeReference<T> typeReference) {
+    public <T> T fromJson(String value, TypeReference<T> typeReference) {
         try {
             return objectMapper.readValue(value, typeReference);
         } catch (IOException e) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/processors/JsonMapper.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/processors/JsonMapper.java
@@ -13,7 +13,7 @@ public class JsonMapper {
     private static final String SERIALISATION_ERROR_MESSAGE = "Failed to serialize '%s' to JSON";
     private static final String DESERIALISATION_ERROR_MESSAGE = "Failed to deserialize '%s' from JSON";
 
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
     public JsonMapper(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
@@ -57,7 +57,7 @@ public interface ClaimRepository {
 
     @SingleValueResult
     @SqlQuery(SELECT_FROM_STATEMENT + " WHERE claim.id = :id")
-    Optional<Claim> getById(@Bind("id") final Long id);
+    Optional<Claim> getById(@Bind("id") Long id);
 
     @GetGeneratedKeys
     @SqlUpdate("INSERT INTO claim ( "
@@ -79,12 +79,12 @@ public interface ClaimRepository {
         + "next_legal_rep_reference_number()"
         + ")")
     Long saveRepresented(
-        @Bind("claim") final String claim,
-        @Bind("submitterId") final String submitterId,
-        @Bind("issuedOn") final LocalDate issuedOn,
-        @Bind("responseDeadline") final LocalDate responseDeadline,
-        @Bind("externalId") final String externalId,
-        @Bind("submitterEmail") final String submitterEmail
+        @Bind("claim") String claim,
+        @Bind("submitterId") String submitterId,
+        @Bind("issuedOn") LocalDate issuedOn,
+        @Bind("responseDeadline") LocalDate responseDeadline,
+        @Bind("externalId") String externalId,
+        @Bind("submitterEmail") String submitterEmail
     );
 
     @GetGeneratedKeys
@@ -109,21 +109,21 @@ public interface ClaimRepository {
         + "next_reference_number()"
         + ")")
     Long saveSubmittedByClaimant(
-        @Bind("claim") final String claim,
-        @Bind("submitterId") final String submitterId,
-        @Bind("letterHolderId") final String letterHolderId,
-        @Bind("issuedOn") final LocalDate issuedOn,
-        @Bind("responseDeadline") final LocalDate responseDeadline,
-        @Bind("externalId") final String externalId,
-        @Bind("submitterEmail") final String submitterEmail
+        @Bind("claim") String claim,
+        @Bind("submitterId") String submitterId,
+        @Bind("letterHolderId") String letterHolderId,
+        @Bind("issuedOn") LocalDate issuedOn,
+        @Bind("responseDeadline") LocalDate responseDeadline,
+        @Bind("externalId") String externalId,
+        @Bind("submitterEmail") String submitterEmail
     );
 
     @SqlUpdate(
         "UPDATE claim SET letter_holder_id = :letterHolderId WHERE id = :claimId"
     )
     Integer linkLetterHolder(
-        @Bind("claimId") final Long claimId,
-        @Bind("letterHolderId") final String letterHolderId
+        @Bind("claimId") Long claimId,
+        @Bind("letterHolderId") String letterHolderId
     );
 
     @SqlUpdate(
@@ -131,16 +131,16 @@ public interface ClaimRepository {
             + " WHERE id = :claimId"
     )
     Integer linkSealedClaimDocument(
-        @Bind("claimId") final Long claimId,
-        @Bind("documentSelfPath") final String documentSelfPath
+        @Bind("claimId") Long claimId,
+        @Bind("documentSelfPath") String documentSelfPath
     );
 
     @SqlUpdate(
         "UPDATE claim SET defendant_id = :defendantId WHERE id = :claimId"
     )
     Integer linkDefendant(
-        @Bind("claimId") final Long claimId,
-        @Bind("defendantId") final String defendantId
+        @Bind("claimId") Long claimId,
+        @Bind("defendantId") String defendantId
     );
 
     @SqlUpdate(
@@ -148,8 +148,8 @@ public interface ClaimRepository {
             + "WHERE id = :claimId AND more_time_requested = FALSE"
     )
     void requestMoreTime(
-        @Bind("claimId") final Long claimId,
-        @Bind("responseDeadline") final LocalDate responseDeadline
+        @Bind("claimId") Long claimId,
+        @Bind("responseDeadline") LocalDate responseDeadline
     );
 
     @SqlUpdate(
@@ -161,10 +161,10 @@ public interface ClaimRepository {
             + "WHERE id = :claimId"
     )
     void saveDefendantResponse(
-        @Bind("claimId") final Long claimId,
-        @Bind("defendantId") final String defendantId,
-        @Bind("defendantEmail") final String defendantEmail,
-        @Bind("response") final String response
+        @Bind("claimId") Long claimId,
+        @Bind("defendantId") String defendantId,
+        @Bind("defendantEmail") String defendantEmail,
+        @Bind("response") String response
     );
 
     @SqlUpdate("UPDATE claim SET "
@@ -173,7 +173,7 @@ public interface ClaimRepository {
         + "WHERE"
         + " id = :claimId")
     void saveCountyCourtJudgment(
-        @Bind("claimId") final long claimId,
-        @Bind("countyCourtJudgmentData") final String countyCourtJudgmentData
+        @Bind("claimId") long claimId,
+        @Bind("countyCourtJudgmentData") String countyCourtJudgmentData
     );
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/TestingSupportRepository.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/TestingSupportRepository.java
@@ -17,7 +17,7 @@ public interface TestingSupportRepository {
             + "WHERE id = :claimId"
     )
     void updateResponseDeadline(
-        @Bind("claimId") final Long claimId,
-        @Bind("responseDeadline") final LocalDate responseDeadline
+        @Bind("claimId") Long claimId,
+        @Bind("responseDeadline") LocalDate responseDeadline
     );
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/ClaimMapper.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/ClaimMapper.java
@@ -44,15 +44,15 @@ public class ClaimMapper implements ResultSetMapper<Claim> {
         );
     }
 
-    private ClaimData toClaimData(final String input) {
+    private ClaimData toClaimData(String input) {
         return jsonMapper.fromJson(input, ClaimData.class);
     }
 
-    private Response toNullableResponseData(final String input) {
+    private Response toNullableResponseData(String input) {
         return toNullableEntity(input, Response.class);
     }
 
-    private CountyCourtJudgment toNullableCountyCourtJudgment(final String input) {
+    private CountyCourtJudgment toNullableCountyCourtJudgment(String input) {
         return toNullableEntity(input, CountyCourtJudgment.class);
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/JsonMapperFactory.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/JsonMapperFactory.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.cmc.claimstore.repositories.mapping;
 import uk.gov.hmcts.cmc.claimstore.config.JacksonConfiguration;
 import uk.gov.hmcts.cmc.claimstore.processors.JsonMapper;
 
-public class JsonMapperFactory {
+public final class JsonMapperFactory {
 
     private JsonMapperFactory() {
         // Utility class

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/JsonMapperFactory.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/JsonMapperFactory.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.cmc.claimstore.repositories.mapping;
 import uk.gov.hmcts.cmc.claimstore.config.JacksonConfiguration;
 import uk.gov.hmcts.cmc.claimstore.processors.JsonMapper;
 
-public final class JsonMapperFactory {
+public class JsonMapperFactory {
 
     private JsonMapperFactory() {
         // Utility class

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/MappingUtils.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/mapping/MappingUtils.java
@@ -15,7 +15,7 @@ public class MappingUtils {
         return LocalDateTimeFactory.fromUTC(input.toLocalDateTime());
     }
 
-    public static Long toNullableLong(final Integer input) {
+    public static Long toNullableLong(Integer input) {
         return input != null ? input.longValue() : null;
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentService.java
@@ -19,9 +19,9 @@ public class CountyCourtJudgmentService {
 
     @Autowired
     public CountyCourtJudgmentService(
-        final ClaimService claimService,
-        final AuthorisationService authorisationService,
-        final EventProducer eventProducer
+        ClaimService claimService,
+        AuthorisationService authorisationService,
+        EventProducer eventProducer
     ) {
         this.claimService = claimService;
         this.authorisationService = authorisationService;
@@ -29,7 +29,7 @@ public class CountyCourtJudgmentService {
     }
 
     @Transactional
-    public Claim save(final String submitterId, final CountyCourtJudgment countyCourtJudgment, final long claimId) {
+    public Claim save(String submitterId, CountyCourtJudgment countyCourtJudgment, long claimId) {
 
         Claim claim = claimService.getClaimById(claimId);
 
@@ -58,15 +58,15 @@ public class CountyCourtJudgmentService {
         return claimWithCCJ;
     }
 
-    private boolean canCountyCourtJudgmentBeRequestedYet(final Claim claim) {
+    private boolean canCountyCourtJudgmentBeRequestedYet(Claim claim) {
         return LocalDate.now().isAfter(claim.getResponseDeadline());
     }
 
-    private boolean isResponseAlreadySubmitted(final Claim claim) {
+    private boolean isResponseAlreadySubmitted(Claim claim) {
         return null != claim.getRespondedAt();
     }
 
-    private boolean isCountyCourtJudgmentAlreadySubmitted(final Claim claim) {
+    private boolean isCountyCourtJudgmentAlreadySubmitted(Claim claim) {
         return claim.getCountyCourtJudgment() != null;
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/DefendantResponseService.java
@@ -17,10 +17,10 @@ public class DefendantResponseService {
     private final AuthorisationService authorisationService;
 
     public DefendantResponseService(
-        final EventProducer eventProducer,
-        final ClaimService claimService,
-        final UserService userService,
-        final AuthorisationService authorisationService) {
+        EventProducer eventProducer,
+        ClaimService claimService,
+        UserService userService,
+        AuthorisationService authorisationService) {
         this.eventProducer = eventProducer;
         this.claimService = claimService;
         this.userService = userService;
@@ -29,12 +29,12 @@ public class DefendantResponseService {
 
     @Transactional
     public Claim save(
-        final long claimId,
-        final String defendantId,
-        final Response response,
-        final String authorization
+        long claimId,
+        String defendantId,
+        Response response,
+        String authorization
     ) {
-        final Claim claim = claimService.getClaimById(claimId);
+        Claim claim = claimService.getClaimById(claimId);
 
         authorisationService.assertIsDefendantOnClaim(claim, defendantId);
 
@@ -46,21 +46,21 @@ public class DefendantResponseService {
             throw new CountyCourtJudgmentAlreadyRequestedException(claimId);
         }
 
-        final String defendantEmail = userService.getUserDetails(authorization).getEmail();
+        String defendantEmail = userService.getUserDetails(authorization).getEmail();
         claimService.saveDefendantResponse(claimId, defendantId, defendantEmail, response);
 
-        final Claim claimAfterSavingResponse = claimService.getClaimById(claimId);
+        Claim claimAfterSavingResponse = claimService.getClaimById(claimId);
 
         eventProducer.createDefendantResponseEvent(claimAfterSavingResponse);
 
         return claimAfterSavingResponse;
     }
 
-    private boolean isResponseAlreadySubmitted(final Claim claim) {
+    private boolean isResponseAlreadySubmitted(Claim claim) {
         return null != claim.getRespondedAt();
     }
 
-    private boolean isCCJAlreadyRequested(final Claim claim) {
+    private boolean isCCJAlreadyRequested(Claim claim) {
         return claim.getCountyCourtJudgmentRequestedAt() != null;
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/FreeMediationDecisionDateCalculator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/FreeMediationDecisionDateCalculator.java
@@ -11,12 +11,12 @@ public class FreeMediationDecisionDateCalculator {
     private int freeMediationTimeForDecisionInDays;
 
     public FreeMediationDecisionDateCalculator(
-        @Value("${dateCalculations.freeMediationTimeForDecisionInDays}") final int freeMediationTimeForDecisionInDays) {
+        @Value("${dateCalculations.freeMediationTimeForDecisionInDays}") int freeMediationTimeForDecisionInDays) {
 
         this.freeMediationTimeForDecisionInDays = freeMediationTimeForDecisionInDays;
     }
 
-    public LocalDate calculateDecisionDate(final LocalDate responseSubmissionDate) {
+    public LocalDate calculateDecisionDate(LocalDate responseSubmissionDate) {
         return responseSubmissionDate.plusDays(freeMediationTimeForDecisionInDays);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/IssueDateCalculator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/IssueDateCalculator.java
@@ -17,7 +17,7 @@ public class IssueDateCalculator {
      */
     private final int endOfBusinessDayHour;
 
-    private WorkingDayIndicator workingDayIndicator;
+    private final WorkingDayIndicator workingDayIndicator;
 
     public IssueDateCalculator(WorkingDayIndicator workingDayIndicator,
                                @Value("${dateCalculations.endOfBusinessDayHour}") int endOfBusinessDayHour) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/IssueDateCalculator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/IssueDateCalculator.java
@@ -20,7 +20,7 @@ public class IssueDateCalculator {
     private WorkingDayIndicator workingDayIndicator;
 
     public IssueDateCalculator(WorkingDayIndicator workingDayIndicator,
-                               @Value("${dateCalculations.endOfBusinessDayHour}") final int endOfBusinessDayHour) {
+                               @Value("${dateCalculations.endOfBusinessDayHour}") int endOfBusinessDayHour) {
         this.workingDayIndicator = workingDayIndicator;
         this.endOfBusinessDayHour = endOfBusinessDayHour;
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/OfferResponseDeadlineCalculator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/OfferResponseDeadlineCalculator.java
@@ -14,16 +14,16 @@ public class OfferResponseDeadlineCalculator {
     private final int endOfBusinessDayHour;
 
     public OfferResponseDeadlineCalculator(
-        final WorkingDayIndicator workingDayIndicator,
-        @Value("${dateCalculations.offerMadeTimeForResponseInDays}") final int offerMadeTimeForResponseInDays,
-        @Value("${dateCalculations.endOfBusinessDayHour}") final int endOfBusinessDayHour) {
+        WorkingDayIndicator workingDayIndicator,
+        @Value("${dateCalculations.offerMadeTimeForResponseInDays}") int offerMadeTimeForResponseInDays,
+        @Value("${dateCalculations.endOfBusinessDayHour}") int endOfBusinessDayHour) {
 
         this.workingDayIndicator = workingDayIndicator;
         this.offerMadeTimeForResponseInDays = offerMadeTimeForResponseInDays;
         this.endOfBusinessDayHour = endOfBusinessDayHour;
     }
 
-    public LocalDate calculateOfferResponseDeadline(final LocalDateTime offerSentAt) {
+    public LocalDate calculateOfferResponseDeadline(LocalDateTime offerSentAt) {
 
         LocalDate offerMadeOn = offerSentAt.toLocalDate();
 
@@ -34,7 +34,7 @@ public class OfferResponseDeadlineCalculator {
         return calculateFirstWorkingDayAfterOffset(offerMadeOn, offerMadeTimeForResponseInDays);
     }
 
-    private LocalDate calculateFirstWorkingDayAfterOffset(final LocalDate date, final int offset) {
+    private LocalDate calculateFirstWorkingDayAfterOffset(LocalDate date, int offset) {
         LocalDate result = date.plusDays(offset);
 
         while (!workingDayIndicator.isWorkingDay(result)) {
@@ -44,7 +44,7 @@ public class OfferResponseDeadlineCalculator {
         return result;
     }
 
-    private boolean isTooLateForToday(final LocalDateTime dateTime) {
+    private boolean isTooLateForToday(LocalDateTime dateTime) {
         return dateTime.getHour() >= endOfBusinessDayHour;
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/OffersService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/OffersService.java
@@ -69,7 +69,7 @@ public class OffersService {
         eventProducer.createOfferRejectedEvent(claim, party);
     }
 
-    private void assertSettlementIsNotReached(final Claim claim) {
+    private void assertSettlementIsNotReached(Claim claim) {
         if (claim.getSettlementReachedAt() != null) {
             throw new ConflictException(format("Settlement for claim %d has been already reached", claim.getId()));
         }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ResponseDeadlineCalculator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ResponseDeadlineCalculator.java
@@ -18,9 +18,9 @@ public class ResponseDeadlineCalculator {
 
     public ResponseDeadlineCalculator(
         WorkingDayIndicator workingDayIndicator,
-        @Value("${dateCalculations.serviceDays}") final int serviceDays,
-        @Value("${dateCalculations.responseDays}") final int timeForResponseInDays,
-        @Value("${dateCalculations.requestedAdditionalTimeInDays}") final int requestedAdditionalTimeInDays) {
+        @Value("${dateCalculations.serviceDays}") int serviceDays,
+        @Value("${dateCalculations.responseDays}") int timeForResponseInDays,
+        @Value("${dateCalculations.requestedAdditionalTimeInDays}") int requestedAdditionalTimeInDays) {
 
         this.workingDayIndicator = workingDayIndicator;
         this.serviceDays = serviceDays;
@@ -45,7 +45,7 @@ public class ResponseDeadlineCalculator {
         );
     }
 
-    private LocalDate calculateFirstWorkingDayAfterOffset(final LocalDate date, final int offset) {
+    private LocalDate calculateFirstWorkingDayAfterOffset(LocalDate date, int offset) {
         LocalDate result = date.plusDays(offset);
 
         while (!workingDayIndicator.isWorkingDay(result)) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/TemplateService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/TemplateService.java
@@ -20,11 +20,11 @@ public class TemplateService {
     private final PebbleEngine pebbleEngine;
 
     @Autowired
-    public TemplateService(final PebbleEngine pebbleEngine) {
+    public TemplateService(PebbleEngine pebbleEngine) {
         this.pebbleEngine = pebbleEngine;
     }
 
-    public String evaluate(final String template, final Map<String, Object> values) {
+    public String evaluate(String template, Map<String, Object> values) {
         notNull(template);
         notNull(values);
         try (Writer writer = new StringWriter()) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/UserService.java
@@ -11,15 +11,15 @@ public class UserService {
 
     private IdamApi idamApi;
 
-    public UserService(final IdamApi idamApi) {
+    public UserService(IdamApi idamApi) {
         this.idamApi = idamApi;
     }
 
-    public UserDetails getUserDetails(final String authorisation) {
+    public UserDetails getUserDetails(String authorisation) {
         return idamApi.retrieveUserDetails(authorisation);
     }
 
-    public GeneratePinResponse generatePin(final String name, final String authorisation) {
+    public GeneratePinResponse generatePin(String name, String authorisation) {
         return idamApi.generatePin(
             new GeneratePinRequest(name),
             authorisation.replace("Bearer: ", "")

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/bankholidays/PublicHolidaysCollection.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/bankholidays/PublicHolidaysCollection.java
@@ -24,7 +24,7 @@ public class PublicHolidaysCollection {
     private Set<LocalDate> retrieveAllPublicHolidays() {
         BankHolidays value = bankHolidaysApi.retrieveAll();
 
-        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(BankHolidays.Division.EventDate.FORMAT);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(BankHolidays.Division.EventDate.FORMAT);
 
         return value.englandAndWales.events.stream()
             .map(item -> LocalDate.parse(item.date, formatter))

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/CoreCaseDataService.java
@@ -23,8 +23,8 @@ public class CoreCaseDataService {
 
     @Autowired
     public CoreCaseDataService(
-        final SaveCoreCaseDataService saveCoreCaseDataService,
-        final CaseMapper caseMapper
+        SaveCoreCaseDataService saveCoreCaseDataService,
+        CaseMapper caseMapper
     ) {
         this.saveCoreCaseDataService = saveCoreCaseDataService;
         this.caseMapper = caseMapper;
@@ -32,8 +32,8 @@ public class CoreCaseDataService {
 
     public CaseDetails save(String authorisation, Claim claim) {
         try {
-            final CCDCase ccdCase = caseMapper.to(claim);
-            final EventRequestData eventRequestData = EventRequestData.builder()
+            CCDCase ccdCase = caseMapper.to(claim);
+            EventRequestData eventRequestData = EventRequestData.builder()
                 .userId(claim.getSubmitterId())
                 .jurisdictionId(JURISDICTION_ID)
                 .caseTypeId(CASE_TYPE_ID)

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/CoreCaseDataService.java
@@ -30,7 +30,7 @@ public class CoreCaseDataService {
         this.caseMapper = caseMapper;
     }
 
-    public CaseDetails save(final String authorisation, final Claim claim) {
+    public CaseDetails save(String authorisation, Claim claim) {
         try {
             final CCDCase ccdCase = caseMapper.to(claim);
             final EventRequestData eventRequestData = EventRequestData.builder()

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/SaveCoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/SaveCoreCaseDataService.java
@@ -27,9 +27,9 @@ public class SaveCoreCaseDataService {
 
     @Autowired
     public SaveCoreCaseDataService(
-        final CoreCaseDataApi coreCaseDataApi,
-        final ObjectMapper objectMapper,
-        final AuthTokenGenerator authTokenGenerator
+        CoreCaseDataApi coreCaseDataApi,
+        ObjectMapper objectMapper,
+        AuthTokenGenerator authTokenGenerator
     ) {
         this.coreCaseDataApi = coreCaseDataApi;
         this.objectMapper = objectMapper;
@@ -37,9 +37,9 @@ public class SaveCoreCaseDataService {
     }
 
     public CaseDetails save(
-        final String authorisation,
-        final EventRequestData eventRequestData,
-        final CCDCase ccdCase
+        String authorisation,
+        EventRequestData eventRequestData,
+        CCDCase ccdCase
     ) {
         StartEventResponse startEventResponse = this.coreCaseDataApi.start(
             authorisation,

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/document/AlwaysGenerateDocumentsService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/document/AlwaysGenerateDocumentsService.java
@@ -26,13 +26,13 @@ public class AlwaysGenerateDocumentsService implements DocumentsService {
 
     @Autowired
     public AlwaysGenerateDocumentsService(
-        final ClaimService claimService,
-        final ClaimIssueReceiptService claimIssueReceiptService,
-        final LegalSealedClaimPdfService legalSealedClaimPdfService,
-        final DefendantResponseCopyService defendantResponseCopyService,
-        final DefendantResponseReceiptService defendantResponseReceiptService,
-        final CountyCourtJudgmentPdfService countyCourtJudgmentPdfService,
-        final SettlementAgreementCopyService settlementAgreementCopyService) {
+        ClaimService claimService,
+        ClaimIssueReceiptService claimIssueReceiptService,
+        LegalSealedClaimPdfService legalSealedClaimPdfService,
+        DefendantResponseCopyService defendantResponseCopyService,
+        DefendantResponseReceiptService defendantResponseReceiptService,
+        CountyCourtJudgmentPdfService countyCourtJudgmentPdfService,
+        SettlementAgreementCopyService settlementAgreementCopyService) {
         this.claimService = claimService;
         this.claimIssueReceiptService = claimIssueReceiptService;
         this.legalSealedClaimPdfService = legalSealedClaimPdfService;
@@ -48,12 +48,12 @@ public class AlwaysGenerateDocumentsService implements DocumentsService {
     }
 
     @Override
-    public byte[] getLegalSealedClaim(final String externalId, final String authorisation) {
+    public byte[] getLegalSealedClaim(String externalId, String authorisation) {
         return legalSealedClaimPdfService.createPdf(getClaimByExternalId(externalId));
     }
 
     @Override
-    public byte[] generateDefendantResponseCopy(final String externalId) {
+    public byte[] generateDefendantResponseCopy(String externalId) {
         return defendantResponseCopyService.createPdf(getClaimByExternalId(externalId));
     }
 
@@ -63,16 +63,16 @@ public class AlwaysGenerateDocumentsService implements DocumentsService {
     }
 
     @Override
-    public byte[] generateCountyCourtJudgement(final String externalId) {
+    public byte[] generateCountyCourtJudgement(String externalId) {
         return countyCourtJudgmentPdfService.createPdf(getClaimByExternalId(externalId));
     }
 
     @Override
-    public byte[] generateSettlementAgreement(final String externalId) {
+    public byte[] generateSettlementAgreement(String externalId) {
         return settlementAgreementCopyService.createPdf(getClaimByExternalId(externalId));
     }
 
-    private Claim getClaimByExternalId(final String externalId) {
+    private Claim getClaimByExternalId(String externalId) {
         return claimService.getClaimByExternalId(externalId);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/document/DocumentManagementBackedDocumentsService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/document/DocumentManagementBackedDocumentsService.java
@@ -34,14 +34,14 @@ public class DocumentManagementBackedDocumentsService implements DocumentsServic
     @SuppressWarnings("squid:S00107")
     // Content providers are formatted values and aren't worth splitting into multiple models.
     public DocumentManagementBackedDocumentsService(
-        final ClaimService claimService,
-        final DocumentManagementService documentManagementService,
-        final ClaimIssueReceiptService claimIssueReceiptService,
-        final LegalSealedClaimPdfService legalSealedClaimPdfService,
-        final DefendantResponseCopyService defendantResponseCopyService,
-        final DefendantResponseReceiptService defendantResponseReceiptService,
-        final CountyCourtJudgmentPdfService countyCourtJudgmentPdfService,
-        final SettlementAgreementCopyService settlementAgreementCopyService) {
+        ClaimService claimService,
+        DocumentManagementService documentManagementService,
+        ClaimIssueReceiptService claimIssueReceiptService,
+        LegalSealedClaimPdfService legalSealedClaimPdfService,
+        DefendantResponseCopyService defendantResponseCopyService,
+        DefendantResponseReceiptService defendantResponseReceiptService,
+        CountyCourtJudgmentPdfService countyCourtJudgmentPdfService,
+        SettlementAgreementCopyService settlementAgreementCopyService) {
         this.claimService = claimService;
         this.documentManagementService = documentManagementService;
         this.claimIssueReceiptService = claimIssueReceiptService;
@@ -58,13 +58,13 @@ public class DocumentManagementBackedDocumentsService implements DocumentsServic
     }
 
     @Override
-    public byte[] getLegalSealedClaim(final String externalId, final String authorisation) {
+    public byte[] getLegalSealedClaim(String externalId, String authorisation) {
         Claim claim = getClaimByExternalId(externalId);
         return downloadOrGenerateAndUpload(claim, () -> legalSealedClaimPdfService.createPdf(claim), authorisation);
     }
 
     @Override
-    public byte[] generateDefendantResponseCopy(final String externalId) {
+    public byte[] generateDefendantResponseCopy(String externalId) {
         return defendantResponseCopyService.createPdf(getClaimByExternalId(externalId));
     }
 
@@ -74,16 +74,16 @@ public class DocumentManagementBackedDocumentsService implements DocumentsServic
     }
 
     @Override
-    public byte[] generateCountyCourtJudgement(final String externalId) {
+    public byte[] generateCountyCourtJudgement(String externalId) {
         return countyCourtJudgmentPdfService.createPdf(getClaimByExternalId(externalId));
     }
 
     @Override
-    public byte[] generateSettlementAgreement(final String externalId) {
+    public byte[] generateSettlementAgreement(String externalId) {
         return settlementAgreementCopyService.createPdf(getClaimByExternalId(externalId));
     }
 
-    private Claim getClaimByExternalId(final String externalId) {
+    private Claim getClaimByExternalId(String externalId) {
         return claimService.getClaimByExternalId(externalId);
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/document/DocumentManagementService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/document/DocumentManagementService.java
@@ -32,29 +32,29 @@ public class DocumentManagementService {
 
     @Autowired
     public DocumentManagementService(
-        final DocumentMetadataDownloadClientApi documentMetadataDownloadApi,
-        final DocumentDownloadClientApi documentDownloadClientApi,
-        final DocumentUploadClientApi documentUploadClientApi
+        DocumentMetadataDownloadClientApi documentMetadataDownloadApi,
+        DocumentDownloadClientApi documentDownloadClientApi,
+        DocumentUploadClientApi documentUploadClientApi
     ) {
         this.documentMetadataDownloadClient = documentMetadataDownloadApi;
         this.documentDownloadClient = documentDownloadClientApi;
         this.documentUploadClient = documentUploadClientApi;
     }
 
-    public String uploadDocument(final String authorisation, final PDF document) {
+    public String uploadDocument(String authorisation, PDF document) {
         return uploadDocument(authorisation, document.getFilename(), document.getBytes(), PDF.CONTENT_TYPE);
     }
 
     public String uploadDocument(
-        final String authorisation,
-        final String originalFileName,
-        final byte[] documentBytes,
-        final String contentType
+        String authorisation,
+        String originalFileName,
+        byte[] documentBytes,
+        String contentType
     ) {
-        final MultipartFile file = new InMemoryMultipartFile(FILES_NAME, originalFileName, contentType, documentBytes);
-        final UploadResponse response = documentUploadClient.upload(authorisation, singletonList(file));
+        MultipartFile file = new InMemoryMultipartFile(FILES_NAME, originalFileName, contentType, documentBytes);
+        UploadResponse response = documentUploadClient.upload(authorisation, singletonList(file));
 
-        final Document document = response.getEmbedded().getDocuments().stream()
+        Document document = response.getEmbedded().getDocuments().stream()
             .findFirst()
             .orElseThrow(() ->
                 new DocumentManagementException("Document management failed uploading file" + originalFileName));
@@ -62,14 +62,14 @@ public class DocumentManagementService {
         return URI.create(document.links.self.href).getPath();
     }
 
-    public byte[] downloadDocument(final String authorisation, final String documentSelfPath) {
-        final Document documentMetadata = documentMetadataDownloadClient.getDocumentMetadata(authorisation,
+    public byte[] downloadDocument(String authorisation, String documentSelfPath) {
+        Document documentMetadata = documentMetadataDownloadClient.getDocumentMetadata(authorisation,
             documentSelfPath);
 
-        final ResponseEntity<Resource> responseEntity = documentDownloadClient.downloadBinary(authorisation,
+        ResponseEntity<Resource> responseEntity = documentDownloadClient.downloadBinary(authorisation,
             URI.create(documentMetadata.links.binary.href).getPath());
 
-        final ByteArrayResource resource = (ByteArrayResource) responseEntity.getBody();
+        ByteArrayResource resource = (ByteArrayResource) responseEntity.getBody();
         return resource.getByteArray();
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/CCJRequestedNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/CCJRequestedNotificationService.java
@@ -31,15 +31,15 @@ public class CCJRequestedNotificationService {
 
     @Autowired
     public CCJRequestedNotificationService(
-        final NotificationClient notificationClient,
-        final NotificationsProperties notificationsProperties
+        NotificationClient notificationClient,
+        NotificationsProperties notificationsProperties
     ) {
         this.notificationClient = notificationClient;
         this.notificationsProperties = notificationsProperties;
     }
 
-    public void notifyClaimant(final Claim claim) {
-        final Map<String, String> parameters = aggregateParams(claim);
+    public void notifyClaimant(Claim claim) {
+        Map<String, String> parameters = aggregateParams(claim);
         sendNotificationEmail(
             claim.getSubmitterEmail(),
             notificationsProperties.getTemplates().getEmail().getClaimantCCJRequested(),
@@ -50,10 +50,10 @@ public class CCJRequestedNotificationService {
 
     @Retryable(value = NotificationException.class, backoff = @Backoff(delay = 200))
     public void sendNotificationEmail(
-        final String targetEmail,
-        final String emailTemplate,
-        final Map<String, String> parameters,
-        final String reference
+        String targetEmail,
+        String emailTemplate,
+        Map<String, String> parameters,
+        String reference
     ) {
         try {
             notificationClient.sendEmail(emailTemplate, targetEmail, parameters, reference);
@@ -64,13 +64,13 @@ public class CCJRequestedNotificationService {
 
     @Recover
     public void logNotificationFailure(
-        final NotificationException exception,
-        final Claim claim,
-        final String targetEmail,
-        final String emailTemplate,
-        final String reference
+        NotificationException exception,
+        Claim claim,
+        String targetEmail,
+        String emailTemplate,
+        String reference
     ) {
-        final String errorMessage = String.format(
+        String errorMessage = String.format(
             "Failure: failed to send notification ( %s to %s ) due to %s",
             reference, targetEmail, exception.getMessage()
         );
@@ -78,7 +78,7 @@ public class CCJRequestedNotificationService {
         logger.info(errorMessage, exception);
     }
 
-    private Map<String, String> aggregateParams(final Claim claim) {
+    private Map<String, String> aggregateParams(Claim claim) {
 
         HashMap<String, String> parameters = new HashMap<>();
         parameters.put(CLAIMANT_NAME, claim.getClaimData().getClaimant().getName());

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/ClaimIssuedNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/ClaimIssuedNotificationService.java
@@ -41,8 +41,8 @@ public class ClaimIssuedNotificationService {
 
     @Autowired
     public ClaimIssuedNotificationService(
-        final NotificationClient notificationClient,
-        final NotificationsProperties notificationsProperties
+        NotificationClient notificationClient,
+        NotificationsProperties notificationsProperties
     ) {
         this.notificationClient = notificationClient;
         this.notificationsProperties = notificationsProperties;
@@ -50,14 +50,14 @@ public class ClaimIssuedNotificationService {
 
     @Retryable(value = NotificationException.class, backoff = @Backoff(delay = 200))
     public void sendMail(
-        final Claim claim,
-        final String targetEmail,
-        final String pin,
-        final String emailTemplateId,
-        final String reference,
-        final String submitterName
+        Claim claim,
+        String targetEmail,
+        String pin,
+        String emailTemplateId,
+        String reference,
+        String submitterName
     ) {
-        final Map<String, String> parameters = aggregateParams(claim, pin, submitterName);
+        Map<String, String> parameters = aggregateParams(claim, pin, submitterName);
         try {
             notificationClient.sendEmail(emailTemplateId, targetEmail, parameters, reference);
         } catch (NotificationClientException e) {
@@ -67,15 +67,15 @@ public class ClaimIssuedNotificationService {
 
     @Recover
     public void logNotificationFailure(
-        final NotificationException exception,
-        final Claim claim,
-        final String targetEmail,
-        final String pin,
-        final String emailTemplateId,
-        final String reference,
-        final String submitterName
+        NotificationException exception,
+        Claim claim,
+        String targetEmail,
+        String pin,
+        String emailTemplateId,
+        String reference,
+        String submitterName
     ) {
-        final String errorMessage = "Failure: "
+        String errorMessage = "Failure: "
             + " failed to send notification (" + reference
             + " to " + targetEmail + ") "
             + " due to " + exception.getMessage();
@@ -83,8 +83,8 @@ public class ClaimIssuedNotificationService {
         logger.info(errorMessage, exception);
     }
 
-    private Map<String, String> aggregateParams(final Claim claim, final String pin,
-                                                final String submitterName) {
+    private Map<String, String> aggregateParams(Claim claim, String pin,
+                                                String submitterName) {
         ImmutableMap.Builder<String, String> parameters = new ImmutableMap.Builder<>();
         parameters.put(CLAIM_REFERENCE_NUMBER, claim.getReferenceNumber());
 
@@ -105,8 +105,8 @@ public class ClaimIssuedNotificationService {
         return parameters.build();
     }
 
-    private String getNameWithTitle(final NamedParty party) {
-        final StringBuilder title = new StringBuilder();
+    private String getNameWithTitle(NamedParty party) {
+        StringBuilder title = new StringBuilder();
         if (party instanceof TitledParty) {
             ((TitledParty) party).getTitle().ifPresent(t -> title.append(t).append(" "));
         }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/DefendantResponseNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/DefendantResponseNotificationService.java
@@ -51,23 +51,23 @@ public class DefendantResponseNotificationService {
 
     @Autowired
     public DefendantResponseNotificationService(
-        final NotificationClient notificationClient,
-        final FreeMediationDecisionDateCalculator freeMediationDecisionDateCalculator,
-        final NotificationsProperties notificationsProperties
+        NotificationClient notificationClient,
+        FreeMediationDecisionDateCalculator freeMediationDecisionDateCalculator,
+        NotificationsProperties notificationsProperties
     ) {
         this.notificationClient = notificationClient;
         this.freeMediationDecisionDateCalculator = freeMediationDecisionDateCalculator;
         this.notificationsProperties = notificationsProperties;
     }
 
-    public void notifyDefendant(final Claim claim, final String defendantEmail, final String reference) {
-        final Map<String, String> parameters = aggregateParams(claim);
+    public void notifyDefendant(Claim claim, String defendantEmail, String reference) {
+        Map<String, String> parameters = aggregateParams(claim);
 
         String template = getDefendantResponseIssuedEmailTemplate(claim.getClaimData().getClaimant());
         notify(defendantEmail, template, parameters, reference);
     }
 
-    private String getDefendantResponseIssuedEmailTemplate(final Party party) {
+    private String getDefendantResponseIssuedEmailTemplate(Party party) {
         if (party instanceof Individual || party instanceof SoleTrader) {
             return getEmailTemplates().getDefendantResponseIssuedToIndividual();
         } else if (party instanceof Company || party instanceof Organisation) {
@@ -78,20 +78,20 @@ public class DefendantResponseNotificationService {
     }
 
     public void notifyClaimant(
-        final Claim claim,
-        final String reference
+        Claim claim,
+        String reference
     ) {
-        final Map<String, String> parameters = aggregateParams(claim, claim.getResponse()
+        Map<String, String> parameters = aggregateParams(claim, claim.getResponse()
             .orElseThrow(IllegalStateException::new));
         notify(claim.getSubmitterEmail(), getEmailTemplates().getClaimantResponseIssued(), parameters, reference);
     }
 
     @Retryable(value = NotificationException.class, backoff = @Backoff(delay = 200))
     public void notify(
-        final String targetEmail,
-        final String emailTemplate,
-        final Map<String, String> parameters,
-        final String reference
+        String targetEmail,
+        String emailTemplate,
+        Map<String, String> parameters,
+        String reference
     ) {
 
         try {
@@ -103,13 +103,13 @@ public class DefendantResponseNotificationService {
 
     @Recover
     public void logNotificationFailure(
-        final NotificationException exception,
-        final Claim claim,
-        final String targetEmail,
-        final String emailTemplate,
-        final String reference
+        NotificationException exception,
+        Claim claim,
+        String targetEmail,
+        String emailTemplate,
+        String reference
     ) {
-        final String errorMessage = String.format(
+        String errorMessage = String.format(
             "Failure: failed to send notification ( %s to %s ) due to %s",
             reference, targetEmail, exception.getMessage()
         );
@@ -117,7 +117,7 @@ public class DefendantResponseNotificationService {
         logger.info(errorMessage, exception);
     }
 
-    private Map<String, String> aggregateParams(final Claim claim) {
+    private Map<String, String> aggregateParams(Claim claim) {
 
         ImmutableMap.Builder<String, String> parameters = new ImmutableMap.Builder<>();
         parameters.put(CLAIMANT_NAME, claim.getClaimData().getClaimant().getName());
@@ -129,7 +129,7 @@ public class DefendantResponseNotificationService {
         return parameters.build();
     }
 
-    private Map<String, String> aggregateParams(final Claim claim, final Response response) {
+    private Map<String, String> aggregateParams(Claim claim, Response response) {
         boolean isFreeMediationApplicable = response.getFreeMediation().isPresent();
         boolean isFreeMediationRequested = response.getFreeMediation()
             .orElse(Response.FreeMediationOption.NO).equals(Response.FreeMediationOption.YES);
@@ -154,7 +154,7 @@ public class DefendantResponseNotificationService {
     }
 
     private EmailTemplates getEmailTemplates() {
-        final NotificationTemplates templates = notificationsProperties.getTemplates();
+        NotificationTemplates templates = notificationsProperties.getTemplates();
         return templates.getEmail();
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/MoreTimeRequestedNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/MoreTimeRequestedNotificationService.java
@@ -19,16 +19,16 @@ public class MoreTimeRequestedNotificationService {
     private final NotificationClient notificationClient;
 
     @Autowired
-    public MoreTimeRequestedNotificationService(final NotificationClient notificationClient) {
+    public MoreTimeRequestedNotificationService(NotificationClient notificationClient) {
         this.notificationClient = notificationClient;
     }
 
     @Retryable(value = NotificationException.class, backoff = @Backoff(delay = 200))
     public void sendMail(
-        final String targetEmail,
-        final String emailTemplateId,
-        final Map<String, String> parameters,
-        final String reference
+        String targetEmail,
+        String emailTemplateId,
+        Map<String, String> parameters,
+        String reference
     ) {
         try {
             notificationClient.sendEmail(emailTemplateId, targetEmail, parameters, reference);
@@ -39,13 +39,13 @@ public class MoreTimeRequestedNotificationService {
 
     @Recover
     public void logNotificationFailure(
-        final NotificationException exception,
-        final String targetEmail,
-        final String emailTemplateId,
-        final Map<String, String> parameters,
-        final String reference
+        NotificationException exception,
+        String targetEmail,
+        String emailTemplateId,
+        Map<String, String> parameters,
+        String reference
     ) {
-        final String errorMessage = String.format(
+        String errorMessage = String.format(
             "Failure: failed to send notification (%s to %s) due to %s",
             reference,
             targetEmail,

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/NotificationReferenceBuilder.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/NotificationReferenceBuilder.java
@@ -22,7 +22,7 @@ public class NotificationReferenceBuilder {
 
     public static class MoreTimeRequested {
 
-        public static String TEMPLATE = "more-time-requested-notification-to-%s-%s";
+        public static final String TEMPLATE = "more-time-requested-notification-to-%s-%s";
 
         private MoreTimeRequested() {
             // do not instantiate
@@ -35,7 +35,7 @@ public class NotificationReferenceBuilder {
 
     public static class ResponseSubmitted {
 
-        public static String TEMPLATE = "%s-response-notification-%s";
+        public static final String TEMPLATE = "%s-response-notification-%s";
 
         private ResponseSubmitted() {
             // do not instantiate
@@ -52,7 +52,7 @@ public class NotificationReferenceBuilder {
 
     public static class CCJRequested {
 
-        public static String TEMPLATE = "%s-ccj-requested-notification-%s";
+        public static final String TEMPLATE = "%s-ccj-requested-notification-%s";
 
         private CCJRequested() {
             // do not instantiate
@@ -65,7 +65,7 @@ public class NotificationReferenceBuilder {
 
     public static class OfferMade {
 
-        public static String TEMPLATE = "%s-offer-made-notification-%s";
+        public static final String TEMPLATE = "%s-offer-made-notification-%s";
 
         private OfferMade() {
             // do not instantiate
@@ -82,7 +82,7 @@ public class NotificationReferenceBuilder {
 
     public static class OfferAccepted {
 
-        public static String TEMPLATE = "to-%s-offer-accepted-by-claimant-notification-%s";
+        public static final String TEMPLATE = "to-%s-offer-accepted-by-claimant-notification-%s";
 
         private OfferAccepted() {
             // do not instantiate
@@ -99,7 +99,7 @@ public class NotificationReferenceBuilder {
 
     public static class OfferRejected {
 
-        public static String TEMPLATE = "to-%s-offer-rejected-by-claimant-notification-%s";
+        public static final String TEMPLATE = "to-%s-offer-rejected-by-claimant-notification-%s";
 
         private OfferRejected() {
             // do not instantiate

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/NotificationReferenceBuilder.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/NotificationReferenceBuilder.java
@@ -13,103 +13,103 @@ public class NotificationReferenceBuilder {
     }
 
     private static String reference(
-        final String template,
-        final String toWhom,
-        final String claimReferenceNumber
+        String template,
+        String toWhom,
+        String claimReferenceNumber
     ) {
         return String.format(template, toWhom, claimReferenceNumber);
     }
 
     public static class MoreTimeRequested {
 
-        public static final String TEMPLATE = "more-time-requested-notification-to-%s-%s";
+        public static String TEMPLATE = "more-time-requested-notification-to-%s-%s";
 
         private MoreTimeRequested() {
             // do not instantiate
         }
 
-        public static String referenceForDefendant(final String claimReferenceNumber) {
+        public static String referenceForDefendant(String claimReferenceNumber) {
             return reference(TEMPLATE, DEFENDANT, claimReferenceNumber);
         }
     }
 
     public static class ResponseSubmitted {
 
-        public static final String TEMPLATE = "%s-response-notification-%s";
+        public static String TEMPLATE = "%s-response-notification-%s";
 
         private ResponseSubmitted() {
             // do not instantiate
         }
 
-        public static String referenceForClaimant(final String claimReferenceNumber) {
+        public static String referenceForClaimant(String claimReferenceNumber) {
             return reference(TEMPLATE, CLAIMANT, claimReferenceNumber);
         }
 
-        public static String referenceForDefendant(final String claimReferenceNumber) {
+        public static String referenceForDefendant(String claimReferenceNumber) {
             return reference(TEMPLATE, DEFENDANT, claimReferenceNumber);
         }
     }
 
     public static class CCJRequested {
 
-        public static final String TEMPLATE = "%s-ccj-requested-notification-%s";
+        public static String TEMPLATE = "%s-ccj-requested-notification-%s";
 
         private CCJRequested() {
             // do not instantiate
         }
 
-        public static String referenceForClaimant(final String claimReferenceNumber) {
+        public static String referenceForClaimant(String claimReferenceNumber) {
             return reference(TEMPLATE, CLAIMANT, claimReferenceNumber);
         }
     }
 
     public static class OfferMade {
 
-        public static final String TEMPLATE = "%s-offer-made-notification-%s";
+        public static String TEMPLATE = "%s-offer-made-notification-%s";
 
         private OfferMade() {
             // do not instantiate
         }
 
-        public static String referenceForClaimant(final String claimReferenceNumber) {
+        public static String referenceForClaimant(String claimReferenceNumber) {
             return reference(TEMPLATE, CLAIMANT, claimReferenceNumber);
         }
 
-        public static String referenceForDefendant(final String claimReferenceNumber) {
+        public static String referenceForDefendant(String claimReferenceNumber) {
             return reference(TEMPLATE, DEFENDANT, claimReferenceNumber);
         }
     }
 
     public static class OfferAccepted {
 
-        public static final String TEMPLATE = "to-%s-offer-accepted-by-claimant-notification-%s";
+        public static String TEMPLATE = "to-%s-offer-accepted-by-claimant-notification-%s";
 
         private OfferAccepted() {
             // do not instantiate
         }
 
-        public static String referenceForClaimant(final String claimReferenceNumber) {
+        public static String referenceForClaimant(String claimReferenceNumber) {
             return reference(TEMPLATE, CLAIMANT, claimReferenceNumber);
         }
 
-        public static String referenceForDefendant(final String claimReferenceNumber) {
+        public static String referenceForDefendant(String claimReferenceNumber) {
             return reference(TEMPLATE, DEFENDANT, claimReferenceNumber);
         }
     }
 
     public static class OfferRejected {
 
-        public static final String TEMPLATE = "to-%s-offer-rejected-by-claimant-notification-%s";
+        public static String TEMPLATE = "to-%s-offer-rejected-by-claimant-notification-%s";
 
         private OfferRejected() {
             // do not instantiate
         }
 
-        public static String referenceForClaimant(final String claimReferenceNumber) {
+        public static String referenceForClaimant(String claimReferenceNumber) {
             return reference(TEMPLATE, CLAIMANT, claimReferenceNumber);
         }
 
-        public static String referenceForDefendant(final String claimReferenceNumber) {
+        public static String referenceForDefendant(String claimReferenceNumber) {
             return reference(TEMPLATE, DEFENDANT, claimReferenceNumber);
         }
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/OfferMadeNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/notifications/OfferMadeNotificationService.java
@@ -21,17 +21,17 @@ public class OfferMadeNotificationService {
 
     @Autowired
     public OfferMadeNotificationService(
-        final NotificationClient notificationClient
+        NotificationClient notificationClient
     ) {
         this.notificationClient = notificationClient;
     }
 
     @Retryable(value = NotificationException.class, backoff = @Backoff(delay = 200))
     public void sendNotificationEmail(
-        final String targetEmail,
-        final String emailTemplate,
-        final Map<String, String> parameters,
-        final String reference
+        String targetEmail,
+        String emailTemplate,
+        Map<String, String> parameters,
+        String reference
     ) {
         try {
             notificationClient.sendEmail(emailTemplate, targetEmail, parameters, reference);
@@ -42,13 +42,13 @@ public class OfferMadeNotificationService {
 
     @Recover
     public void logNotificationFailure(
-        final NotificationException exception,
-        final String targetEmail,
-        final String emailTemplate,
-        final Map<String, String> parameters,
-        final String reference
+        NotificationException exception,
+        String targetEmail,
+        String emailTemplate,
+        Map<String, String> parameters,
+        String reference
     ) {
-        final String errorMessage = String.format(
+        String errorMessage = String.format(
             "Failure: failed to send notification ( %s to %s ) due to %s",
             reference, targetEmail, exception.getMessage()
         );

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/CCJStaffNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/CCJStaffNotificationService.java
@@ -32,10 +32,10 @@ public class CCJStaffNotificationService {
 
     @Autowired
     public CCJStaffNotificationService(
-        final EmailService emailService,
-        final StaffEmailProperties staffEmailProperties,
-        final RequestSubmittedNotificationEmailContentProvider ccjRequestSubmittedEmailContentProvider,
-        final CountyCourtJudgmentPdfService countyCourtJudgmentPdfService
+        EmailService emailService,
+        StaffEmailProperties staffEmailProperties,
+        RequestSubmittedNotificationEmailContentProvider ccjRequestSubmittedEmailContentProvider,
+        CountyCourtJudgmentPdfService countyCourtJudgmentPdfService
     ) {
         this.emailService = emailService;
         this.staffEmailProperties = staffEmailProperties;
@@ -43,12 +43,12 @@ public class CCJStaffNotificationService {
         this.countyCourtJudgmentPdfService = countyCourtJudgmentPdfService;
     }
 
-    public void notifyStaffCCJRequestSubmitted(final Claim claim) {
+    public void notifyStaffCCJRequestSubmitted(Claim claim) {
         requireNonNull(claim);
         emailService.sendEmail(staffEmailProperties.getSender(), prepareEmailData(claim));
     }
 
-    private EmailData prepareEmailData(final Claim claim) {
+    private EmailData prepareEmailData(Claim claim) {
         Map<String, Object> map = createParameterMap(claim);
 
         EmailContent emailContent = ccjRequestSubmittedEmailContentProvider.createContent(map);
@@ -60,7 +60,7 @@ public class CCJStaffNotificationService {
         );
     }
 
-    private Map<String, Object> createParameterMap(final Claim claim) {
+    private Map<String, Object> createParameterMap(Claim claim) {
         Map<String, Object> map = new HashMap<>();
         map.put("claimReferenceNumber", claim.getReferenceNumber());
         map.put("claimantName", claim.getClaimData().getClaimant().getName());
@@ -70,7 +70,7 @@ public class CCJStaffNotificationService {
         return map;
     }
 
-    private EmailAttachment generateCountyCourtJudgmentPdf(final Claim claim) {
+    private EmailAttachment generateCountyCourtJudgmentPdf(Claim claim) {
         byte[] generatedPdf = countyCourtJudgmentPdfService.createPdf(claim);
 
         return pdf(

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/ClaimIssuedStaffNotificationEmailContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/ClaimIssuedStaffNotificationEmailContentProvider.java
@@ -15,15 +15,15 @@ public class ClaimIssuedStaffNotificationEmailContentProvider implements EmailCo
     private final TemplateService templateService;
 
     public ClaimIssuedStaffNotificationEmailContentProvider(
-        final StaffEmailTemplates staffEmailTemplates,
-        final TemplateService templateService
+        StaffEmailTemplates staffEmailTemplates,
+        TemplateService templateService
     ) {
         this.staffEmailTemplates = staffEmailTemplates;
         this.templateService = templateService;
     }
 
     @Override
-    public EmailContent createContent(final Map<String, Object> claim) {
+    public EmailContent createContent(Map<String, Object> claim) {
         return new EmailContent(
             evaluateTemplate(staffEmailTemplates.getClaimIssuedEmailSubject(), claim),
             staffEmailTemplates.getClaimIssuedEmailBody().trim()

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/ClaimIssuedStaffNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/ClaimIssuedStaffNotificationService.java
@@ -29,9 +29,9 @@ public class ClaimIssuedStaffNotificationService {
 
     @Autowired
     public ClaimIssuedStaffNotificationService(
-        final EmailService emailService,
-        final StaffEmailProperties staffEmailProperties,
-        final ClaimIssuedStaffNotificationEmailContentProvider provider
+        EmailService emailService,
+        StaffEmailProperties staffEmailProperties,
+        ClaimIssuedStaffNotificationEmailContentProvider provider
     ) {
         this.emailService = emailService;
         this.staffEmailProperties = staffEmailProperties;
@@ -39,16 +39,16 @@ public class ClaimIssuedStaffNotificationService {
     }
 
     @EventListener
-    public void notifyStaffOfClaimIssue(final DocumentGeneratedEvent event) {
+    public void notifyStaffOfClaimIssue(DocumentGeneratedEvent event) {
         requireNonNull(event);
 
-        final EmailData emailData = prepareEmailData(event.getClaim(), event.getDocuments());
+        EmailData emailData = prepareEmailData(event.getClaim(), event.getDocuments());
         emailService.sendEmail(staffEmailProperties.getSender(), emailData);
     }
 
     private EmailData prepareEmailData(
-        final Claim claim,
-        final List<PDF> documents) {
+        Claim claim,
+        List<PDF> documents) {
         EmailContent content = provider.createContent(wrapInMap(claim));
         List<EmailAttachment> attachments = documents.stream()
             .map(document -> pdf(document.getBytes(), document.getFilename()))

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/DefendantResponseStaffNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/DefendantResponseStaffNotificationService.java
@@ -29,10 +29,10 @@ public class DefendantResponseStaffNotificationService {
 
     @Autowired
     public DefendantResponseStaffNotificationService(
-        final EmailService emailService,
-        final StaffEmailProperties emailProperties,
-        final DefendantResponseStaffNotificationEmailContentProvider emailContentProvider,
-        final DefendantResponseCopyService defendantResponseCopyService) {
+        EmailService emailService,
+        StaffEmailProperties emailProperties,
+        DefendantResponseStaffNotificationEmailContentProvider emailContentProvider,
+        DefendantResponseCopyService defendantResponseCopyService) {
         this.emailService = emailService;
         this.emailProperties = emailProperties;
         this.emailContentProvider = emailContentProvider;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/OfferAcceptedStaffNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/OfferAcceptedStaffNotificationService.java
@@ -29,10 +29,10 @@ public class OfferAcceptedStaffNotificationService {
 
     @Autowired
     public OfferAcceptedStaffNotificationService(
-        final EmailService emailService,
-        final StaffEmailProperties emailProperties,
-        final SettlementAgreementEmailContentProvider emailContentProvider,
-        final SettlementAgreementCopyService copyService
+        EmailService emailService,
+        StaffEmailProperties emailProperties,
+        SettlementAgreementEmailContentProvider emailContentProvider,
+        SettlementAgreementCopyService copyService
     ) {
         this.emailService = emailService;
         this.emailProperties = emailProperties;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/ClaimantContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/ClaimantContentProvider.java
@@ -16,11 +16,11 @@ public class ClaimantContentProvider {
     private final PersonContentProvider personContentProvider;
 
     @Autowired
-    public ClaimantContentProvider(final PersonContentProvider personContentProvider) {
+    public ClaimantContentProvider(PersonContentProvider personContentProvider) {
         this.personContentProvider = personContentProvider;
     }
 
-    public ClaimantContent createContent(final Party claimant, final String submitterEmail) {
+    public ClaimantContent createContent(Party claimant, String submitterEmail) {
         requireNonNull(claimant);
         requireNonBlank(submitterEmail);
         PersonContent personContent = personContentProvider.createContent(

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/DefendantResponseStaffNotificationEmailContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/DefendantResponseStaffNotificationEmailContentProvider.java
@@ -17,14 +17,14 @@ public class DefendantResponseStaffNotificationEmailContentProvider
     private final StaffEmailTemplates emailTemplates;
 
     @Autowired
-    public DefendantResponseStaffNotificationEmailContentProvider(final TemplateService templateService,
-                                                                  final StaffEmailTemplates emailTemplates) {
+    public DefendantResponseStaffNotificationEmailContentProvider(TemplateService templateService,
+                                                                  StaffEmailTemplates emailTemplates) {
         this.templateService = templateService;
         this.emailTemplates = emailTemplates;
     }
 
     @Override
-    public EmailContent createContent(final Map<String, Object> input) {
+    public EmailContent createContent(Map<String, Object> input) {
         return new EmailContent(
             evaluateTemplate(emailTemplates.getDefendantResponseEmailSubject(), input),
             evaluateTemplate(emailTemplates.getDefendantResponseEmailBody(), input)

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/PersonContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/PersonContentProvider.java
@@ -10,13 +10,13 @@ import static java.util.Objects.requireNonNull;
 public class PersonContentProvider {
 
     public PersonContent createContent(
-        final String partyType,
-        final String name,
-        final Address address,
-        final Address correspondenceAddress,
-        final String email,
-        final String contactPerson,
-        final String businessName
+        String partyType,
+        String name,
+        Address address,
+        Address correspondenceAddress,
+        String email,
+        String contactPerson,
+        String businessName
     ) {
         requireNonNull(name);
         requireNonNull(address);

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/AmountContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/AmountContentProvider.java
@@ -18,7 +18,7 @@ import static uk.gov.hmcts.cmc.claimstore.utils.Formatting.formatPercent;
 
 public class AmountContentProvider {
 
-    private InterestCalculationService interestCalculationService;
+    private final InterestCalculationService interestCalculationService;
 
     public AmountContentProvider(InterestCalculationService interestCalculationService) {
         this.interestCalculationService = interestCalculationService;
@@ -74,10 +74,10 @@ public class AmountContentProvider {
     }
 
     private static BigDecimal getInterestAmount(
-        final InterestCalculationService interestCalculationService,
-        final Claim claim,
-        final LocalDate toDate,
-        final BigDecimal claimAmount
+        InterestCalculationService interestCalculationService,
+        Claim claim,
+        LocalDate toDate,
+        BigDecimal claimAmount
     ) {
         if (!claim.getClaimData().getInterest().getType()
             .equals(InterestType.NO_INTEREST)) {
@@ -91,7 +91,7 @@ public class AmountContentProvider {
         return BigDecimal.ZERO;
     }
 
-    private static LocalDate getInterestFromDate(final Claim claim) {
+    private static LocalDate getInterestFromDate(Claim claim) {
         if (claim.getClaimData().getInterestDate().getType().equals(InterestDate.InterestDateType.CUSTOM)) {
             InterestDate interestDate = claim.getClaimData().getInterestDate();
             return interestDate.getDate();

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/ContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/ContentProvider.java
@@ -14,7 +14,7 @@ import static java.util.Objects.requireNonNull;
 @Component
 public class ContentProvider {
 
-    private InterestCalculationService interestCalculationService;
+    private final InterestCalculationService interestCalculationService;
 
     @Autowired
     public ContentProvider(InterestCalculationService interestCalculationService) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/ContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/ContentProvider.java
@@ -14,10 +14,10 @@ import static java.util.Objects.requireNonNull;
 @Component
 public class ContentProvider {
 
-    private final InterestCalculationService interestCalculationService;
+    private InterestCalculationService interestCalculationService;
 
     @Autowired
-    public ContentProvider(final InterestCalculationService interestCalculationService) {
+    public ContentProvider(InterestCalculationService interestCalculationService) {
         this.interestCalculationService = interestCalculationService;
     }
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/RepaymentPlanContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/RepaymentPlanContentProvider.java
@@ -7,7 +7,7 @@ import uk.gov.hmcts.cmc.domain.models.ccj.RepaymentPlan;
 import static uk.gov.hmcts.cmc.claimstore.utils.Formatting.formatDate;
 import static uk.gov.hmcts.cmc.claimstore.utils.Formatting.formatMoney;
 
-public final class RepaymentPlanContentProvider {
+public class RepaymentPlanContentProvider {
 
     private RepaymentPlanContentProvider() {
         // Utils class no constructing

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/RepaymentPlanContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/RepaymentPlanContentProvider.java
@@ -7,7 +7,7 @@ import uk.gov.hmcts.cmc.domain.models.ccj.RepaymentPlan;
 import static uk.gov.hmcts.cmc.claimstore.utils.Formatting.formatDate;
 import static uk.gov.hmcts.cmc.claimstore.utils.Formatting.formatMoney;
 
-public class RepaymentPlanContentProvider {
+public final class RepaymentPlanContentProvider {
 
     private RepaymentPlanContentProvider() {
         // Utils class no constructing

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/RequestSubmittedNotificationEmailContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/RequestSubmittedNotificationEmailContentProvider.java
@@ -17,15 +17,15 @@ public class RequestSubmittedNotificationEmailContentProvider implements EmailCo
     private final StaffEmailTemplates emailTemplates;
 
     public RequestSubmittedNotificationEmailContentProvider(
-        final TemplateService templateService,
-        final StaffEmailTemplates emailTemplates
+        TemplateService templateService,
+        StaffEmailTemplates emailTemplates
     ) {
         this.templateService = templateService;
         this.emailTemplates = emailTemplates;
     }
 
     @Override
-    public EmailContent createContent(final Map<String, Object> input) {
+    public EmailContent createContent(Map<String, Object> input) {
         notEmpty(input);
 
         return new EmailContent(

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/models/ClaimantContent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/models/ClaimantContent.java
@@ -5,13 +5,13 @@ import uk.gov.hmcts.cmc.domain.models.Address;
 public class ClaimantContent extends PersonContent {
 
     public ClaimantContent(
-        final String cliamantType,
-        final String fullName,
-        final Address address,
-        final Address correspondenceAddress,
-        final String email,
-        final String contactPerson,
-        final String businessName
+        String cliamantType,
+        String fullName,
+        Address address,
+        Address correspondenceAddress,
+        String email,
+        String contactPerson,
+        String businessName
     ) {
         super(cliamantType, fullName, address, correspondenceAddress, email, contactPerson, businessName);
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/models/PersonContent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/models/PersonContent.java
@@ -13,13 +13,13 @@ public class PersonContent {
     private final String businessName;
 
     public PersonContent(
-        final String partyType,
-        final String fullName,
-        final Address address,
-        final Address correspondenceAddress,
-        final String email,
-        final String contactPerson,
-        final String businessName
+        String partyType,
+        String fullName,
+        Address address,
+        Address correspondenceAddress,
+        String email,
+        String contactPerson,
+        String businessName
     ) {
         this.partyType = partyType;
         this.fullName = fullName;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/stereotypes/EmailContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/stereotypes/EmailContentProvider.java
@@ -17,7 +17,7 @@ public interface EmailContentProvider<T> {
 
     EmailContent createContent(T input);
 
-    default String evaluateTemplate(final String template, final Map<String, Object> input) {
+    default String evaluateTemplate(String template, Map<String, Object> input) {
         return getTemplateService().evaluate(template, input).trim();
     }
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimControllerTest.java
@@ -39,7 +39,7 @@ public class ClaimControllerTest {
     @Test
     public void shouldSaveClaimInRepository() throws JsonProcessingException {
         //given
-        final ClaimData input = SampleClaimData.validDefaults();
+        ClaimData input = SampleClaimData.validDefaults();
         when(claimService.saveClaim(eq(USER_ID), eq(input), eq(AUTHORISATION))).thenReturn(CLAIM);
 
         //when
@@ -55,7 +55,7 @@ public class ClaimControllerTest {
         when(claimService.getClaimBySubmitterId(eq(USER_ID))).thenReturn(Collections.singletonList(CLAIM));
 
         //when
-        final List<Claim> output = claimController.getBySubmitterId(USER_ID);
+        List<Claim> output = claimController.getBySubmitterId(USER_ID);
 
         //then
         assertThat(output.get(0)).isEqualTo(CLAIM);

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/DefendantResponseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/DefendantResponseControllerTest.java
@@ -35,7 +35,7 @@ public class DefendantResponseControllerTest {
     @Test
     public void shouldSaveResponseInRepository() throws JsonProcessingException {
         //given
-        final Response input = SampleResponse.FullDefence.builder()
+        Response input = SampleResponse.FullDefence.builder()
             .build();
 
         Claim sampleClaim = SampleClaim.getWithDefaultResponse();

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/LegalSealedClaimDataContentProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/LegalSealedClaimDataContentProviderTest.java
@@ -21,15 +21,15 @@ public class LegalSealedClaimDataContentProviderTest {
     @Test
     public void shouldCreateContent() throws Exception {
         //given
-        final Claim claim = SampleClaim.builder().withClaimData(
+        Claim claim = SampleClaim.builder().withClaimData(
             SampleClaimData.builder().withFeeAmount(BigInteger.valueOf(50001)).build()
         ).build();
 
-        final LegalSealedClaimContentProvider legalSealedClaimContentProvider
+        LegalSealedClaimContentProvider legalSealedClaimContentProvider
             = new LegalSealedClaimContentProvider(statementOfValueProvider, false);
 
         //when
-        final Map<String, Object> contents = legalSealedClaimContentProvider.createContent(claim);
+        Map<String, Object> contents = legalSealedClaimContentProvider.createContent(claim);
 
         //then
         assertThat(contents).isNotEmpty().containsKey("feePaid").containsValue("£500.01");
@@ -38,13 +38,13 @@ public class LegalSealedClaimDataContentProviderTest {
     @Test
     public void contentShouldIncludeWaterMarkFlag() throws Exception {
         //given
-        final Claim claim = SampleClaim.getDefaultForLegal();
+        Claim claim = SampleClaim.getDefaultForLegal();
 
-        final LegalSealedClaimContentProvider legalSealedClaimContentProvider
+        LegalSealedClaimContentProvider legalSealedClaimContentProvider
             = new LegalSealedClaimContentProvider(statementOfValueProvider, true);
 
         //when
-        final Map<String, Object> contents = legalSealedClaimContentProvider.createContent(claim);
+        Map<String, Object> contents = legalSealedClaimContentProvider.createContent(claim);
 
         //then
         assertThat(contents).isNotEmpty().containsKey("watermarkPdf");

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/PartyDetailsContentProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/PartyDetailsContentProviderTest.java
@@ -19,12 +19,12 @@ public class PartyDetailsContentProviderTest {
 
     private static final LocalDate DATE_OF_BIRTH = LocalDate.of(2017, 7, 19);
 
-    private PartyDetailsContentProvider provider = new PartyDetailsContentProvider();
+    private final PartyDetailsContentProvider provider = new PartyDetailsContentProvider();
 
-    private TheirDetails defendant = SampleTheirDetails.builder()
+    private final TheirDetails defendant = SampleTheirDetails.builder()
         .individualDetails();
 
-    private Address correspondenceAddress = SampleAddress.builder()
+    private final Address correspondenceAddress = SampleAddress.builder()
         .withLine1("Correspondence Road 1")
         .withPostcode("BB 127NQ")
         .build();

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/StatementOfValueProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/StatementOfValueProviderTest.java
@@ -31,7 +31,7 @@ public class StatementOfValueProviderTest {
     @Test
     public void shouldCreateContentWithAmountRange() throws Exception {
         //given
-        final Claim claim = buildClaimModel(
+        Claim claim = buildClaimModel(
             SampleClaimData.builder()
                 .withAmount(
                     SampleAmountRange.builder()
@@ -40,7 +40,7 @@ public class StatementOfValueProviderTest {
                 ).build());
 
         //when
-        final StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
+        StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
 
         //then
         assertThat(statementOfValueContent.getClaimValue()).contains("100.50");
@@ -50,7 +50,7 @@ public class StatementOfValueProviderTest {
     @Test
     public void shouldCreateContentWithAmountRangeWithoutLowerValue() throws Exception {
         //given
-        final Claim claim = buildClaimModel(
+        Claim claim = buildClaimModel(
             SampleClaimData.builder()
                 .withAmount(
                     SampleAmountRange.builder()
@@ -60,7 +60,7 @@ public class StatementOfValueProviderTest {
                 ).build());
 
         //when
-        final StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
+        StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
 
         //then
         assertThat(statementOfValueContent.getClaimValue()).contains(String.format(RECOVER_UP_TO, "£100.50"));
@@ -71,10 +71,10 @@ public class StatementOfValueProviderTest {
     @Test
     public void shouldCreateContentWithAmountNotKnown() throws Exception {
         //given
-        final Claim claim = buildClaimModel(SampleClaimData.builder().withAmount(new NotKnown()).build());
+        Claim claim = buildClaimModel(SampleClaimData.builder().withAmount(new NotKnown()).build());
 
         //when
-        final StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
+        StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
 
         //then
         assertThat(statementOfValueContent.getClaimValue()).contains(CAN_NOT_STATE);
@@ -83,7 +83,7 @@ public class StatementOfValueProviderTest {
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowErrorForInvalidAmountType() throws Exception {
         //given
-        final Claim claim = SampleClaim.builder().build();
+        Claim claim = SampleClaim.builder().build();
 
         //when
         statementOfValueProvider.create(claim);
@@ -93,7 +93,7 @@ public class StatementOfValueProviderTest {
     @Test
     public void shouldCreateContentWithPersonalInjury() throws Exception {
         //given
-        final Claim claim = buildClaimModel(
+        Claim claim = buildClaimModel(
             SampleClaimData.builder()
                 .withAmount(
                     SampleAmountRange.builder()
@@ -104,10 +104,10 @@ public class StatementOfValueProviderTest {
                 .withHousingDisrepair(null)
                 .build());
 
-        final String expected = String.format(PERSONAL_INJURY_DAMAGES, MORE_THAN_THOUSAND_POUNDS.getDisplayValue());
+        String expected = String.format(PERSONAL_INJURY_DAMAGES, MORE_THAN_THOUSAND_POUNDS.getDisplayValue());
 
         //when
-        final StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
+        StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
 
         //then
         assertThat(statementOfValueContent.getPersonalInjury()).contains(PERSONAL_INJURY);
@@ -117,7 +117,7 @@ public class StatementOfValueProviderTest {
     @Test
     public void shouldCreateContentWithHousingDisrepair() throws Exception {
         //given
-        final Claim claim = buildClaimModel(
+        Claim claim = buildClaimModel(
             SampleClaimData.builder()
                 .withPersonalInjury(null)
                 .withAmount(SampleAmountRange.builder()
@@ -127,7 +127,7 @@ public class StatementOfValueProviderTest {
                 ).build());
 
         //when
-        final StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
+        StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
 
         //then
         assertThat(statementOfValueContent.getHousingDisrepair()).contains(HOUSING_DISREPAIR);
@@ -136,7 +136,7 @@ public class StatementOfValueProviderTest {
     @Test
     public void shouldCreateContentWithHousingDisrepairAndPersonalInjury() throws Exception {
         //given
-        final Claim claim = buildClaimModel(
+        Claim claim = buildClaimModel(
             SampleClaimData.builder()
                 .withAmount(
                     SampleAmountRange.builder()
@@ -146,7 +146,7 @@ public class StatementOfValueProviderTest {
                 ).build());
 
         //when
-        final StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
+        StatementOfValueContent statementOfValueContent = statementOfValueProvider.create(claim);
 
         //then
         assertThat(statementOfValueContent.getHousingDisrepair()).contains(ALSO_HOUSING_DISREPAIR);

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/events/EventProducerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/events/EventProducerTest.java
@@ -81,7 +81,7 @@ public class EventProducerTest {
     @Test
     public void shouldCreateDefendantResponseEvent() throws Exception {
         //given
-        final DefendantResponseEvent expectedEvent
+        DefendantResponseEvent expectedEvent
             = new DefendantResponseEvent(CLAIM);
 
         //when
@@ -95,7 +95,7 @@ public class EventProducerTest {
     public void shouldCreateMoreTimeForResponseRequestEvent() throws Exception {
 
         //given
-        final MoreTimeRequestedEvent expectedEvent
+        MoreTimeRequestedEvent expectedEvent
             = new MoreTimeRequestedEvent(CLAIM, NEW_RESPONSE_DEADLINE, DEFENDANT_EMAIL);
 
         //when

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/events/RepresentedClaimIssuedEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/events/RepresentedClaimIssuedEventHandlerTest.java
@@ -50,7 +50,7 @@ public class RepresentedClaimIssuedEventHandlerTest {
     @Test
     public void sendNotificationsSendsNotificationsToRepresentative() throws NotificationClientException {
 
-        final RepresentedClaimIssuedEvent representedClaimIssuedEvent
+        RepresentedClaimIssuedEvent representedClaimIssuedEvent
             = new RepresentedClaimIssuedEvent(CLAIM, SUBMITTER_NAME, AUTHORISATION);
 
         representativeConfirmationHandler.sendConfirmation(representedClaimIssuedEvent);

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/events/claim/ClaimIssuedCitizenActionsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/events/claim/ClaimIssuedCitizenActionsHandlerTest.java
@@ -55,7 +55,7 @@ public class ClaimIssuedCitizenActionsHandlerTest {
     @Test
     public void sendNotificationsSendsNotificationsToClaimantAndDefendant() throws NotificationClientException {
 
-        final ClaimIssuedEvent claimIssuedEvent
+        ClaimIssuedEvent claimIssuedEvent
             = new ClaimIssuedEvent(CLAIM, PIN, SUBMITTER_NAME, AUTHORISATION);
 
         claimIssuedCitizenActionsHandler.sendClaimantNotification(claimIssuedEvent);
@@ -82,7 +82,7 @@ public class ClaimIssuedCitizenActionsHandlerTest {
     @Test(expected = IllegalArgumentException.class)
     public void sendFailSendingNotificationToDefendantWhenPinIsMissing() throws NotificationClientException {
 
-        final ClaimIssuedEvent claimIssuedEvent
+        ClaimIssuedEvent claimIssuedEvent
             = new ClaimIssuedEvent(CLAIM, null, SUBMITTER_NAME, AUTHORISATION);
 
         claimIssuedCitizenActionsHandler.sendDefendantNotification(claimIssuedEvent);

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/events/response/DefendantResponseCitizenNotificationsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/events/response/DefendantResponseCitizenNotificationsHandlerTest.java
@@ -15,10 +15,11 @@ import static uk.gov.hmcts.cmc.claimstore.utils.VerificationModeUtils.once;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefendantResponseCitizenNotificationsHandlerTest {
-    private DefendantResponseCitizenNotificationsHandler defendantResponseCitizenNotificationsHandler;
     private static final DefendantResponseEvent RESPONSE_EVENT = new DefendantResponseEvent(
         SampleClaimIssuedEvent.CLAIM_WITH_RESPONSE
     );
+
+    private DefendantResponseCitizenNotificationsHandler defendantResponseCitizenNotificationsHandler;
 
     @Mock
     private DefendantResponseNotificationService defendantResponseNotificationService;

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/events/response/MoreTimeRequestedCitizenNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/events/response/MoreTimeRequestedCitizenNotificationHandlerTest.java
@@ -54,7 +54,7 @@ public class MoreTimeRequestedCitizenNotificationHandlerTest {
     @Test
     public void sendNotificationsSendsNotificationsToDefendant() throws NotificationClientException {
 
-        final MoreTimeRequestedEvent event = SampleMoreTimeRequestedEvent.getDefault();
+        MoreTimeRequestedEvent event = SampleMoreTimeRequestedEvent.getDefault();
 
         handler.sendNotifications(event);
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/events/response/MoreTimeRequestedStaffNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/events/response/MoreTimeRequestedStaffNotificationHandlerTest.java
@@ -57,7 +57,7 @@ public class MoreTimeRequestedStaffNotificationHandlerTest {
     @Test
     public void sendNotificationsSendsNotificationsToStaff() throws NotificationClientException {
 
-        final MoreTimeRequestedEvent event = SampleMoreTimeRequestedEvent.getDefault();
+        MoreTimeRequestedEvent event = SampleMoreTimeRequestedEvent.getDefault();
 
         handler.sendNotifications(event);
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/events/utils/sampledata/SampleMoreTimeRequestedEvent.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/events/utils/sampledata/SampleMoreTimeRequestedEvent.java
@@ -20,7 +20,7 @@ public class SampleMoreTimeRequestedEvent {
         return new MoreTimeRequestedEvent(CLAIM, NEW_RESPONSE_DEADLINE, DEFENDANT_EMAIL);
     }
 
-    public static String getReference(final String toWhom, final String claimReferenceNumber) {
+    public static String getReference(String toWhom, String claimReferenceNumber) {
         return String.format("more-time-requested-notification-to-%s-%s", toWhom, claimReferenceNumber);
     }
 }

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/idam/models/UserDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/idam/models/UserDetailsTest.java
@@ -11,10 +11,10 @@ public class UserDetailsTest {
     @Test
     public void shouldReturnFullNameWhenBothArePresent() throws Exception {
         //given
-        final UserDetails userDetails = SampleUserDetails.builder().build();
+        UserDetails userDetails = SampleUserDetails.builder().build();
 
         //when
-        final String fullName = userDetails.getFullName();
+        String fullName = userDetails.getFullName();
 
         //then
         assertThat(fullName).isEqualTo(SUBMITTER_FORENAME + " " + SUBMITTER_SURNAME);
@@ -23,10 +23,10 @@ public class UserDetailsTest {
     @Test
     public void shouldReturnForNameWhenSurnameIsMissing() throws Exception {
         //given
-        final UserDetails userDetails = SampleUserDetails.builder().withSurname(null).build();
+        UserDetails userDetails = SampleUserDetails.builder().withSurname(null).build();
 
         //when
-        final String fullName = userDetails.getFullName();
+        String fullName = userDetails.getFullName();
 
         //then
         assertThat(fullName).isEqualTo(SUBMITTER_FORENAME);

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/processors/JsonMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/processors/JsonMapperTest.java
@@ -32,7 +32,7 @@ public class JsonMapperTest {
     @Test
     public void shouldProcessClaimDataToJson() throws Exception {
         //given
-        final ClaimData input = SampleClaimData.builder()
+        ClaimData input = SampleClaimData.builder()
             .withExternalId(UUID.fromString("9f49d8df-b734-4e86-aeb6-e22f0c2ca78d"))
             .withInterestDate(SampleInterestDate.builder()
                 .withDate(LocalDate.of(2015, 2, 2))
@@ -53,23 +53,23 @@ public class JsonMapperTest {
             .build();
 
         //when
-        final String output = processor.toJson(input);
+        String output = processor.toJson(input);
 
         //then
-        final String expected = new ResourceReader().read("/claim-application.json");
+        String expected = new ResourceReader().read("/claim-application.json");
         JSONAssert.assertEquals(expected, output, STRICT);
     }
 
     @Test
     public void shouldProcessFromJson() throws Exception {
         //given
-        final String input = new ResourceReader().read("/claim-application.json");
+        String input = new ResourceReader().read("/claim-application.json");
 
         //when
-        final ClaimData output = processor.fromJson(input, ClaimData.class);
+        ClaimData output = processor.fromJson(input, ClaimData.class);
 
         //then
-        final ClaimData expected = SampleClaimData.builder()
+        ClaimData expected = SampleClaimData.builder()
             .withExternalId(UUID.fromString("9f49d8df-b734-4e86-aeb6-e22f0c2ca78d"))
             .withInterestDate(SampleInterestDate.builder()
                 .withDate(LocalDate.of(2015, 2, 2))
@@ -94,13 +94,13 @@ public class JsonMapperTest {
     @Test
     public void shouldProcessLegalClaimFromJson() throws Exception {
         //given
-        final String input = new ResourceReader().read("/legal-claim-application.json");
+        String input = new ResourceReader().read("/legal-claim-application.json");
 
         //when
-        final ClaimData output = processor.fromJson(input, ClaimData.class);
+        ClaimData output = processor.fromJson(input, ClaimData.class);
 
         //then
-        final ClaimData expected = SampleClaimData.builder()
+        ClaimData expected = SampleClaimData.builder()
             .withExternalId(UUID.fromString("9f49d8df-b734-4e86-aeb6-e22f0c2ca78d"))
             .withInterestDate(
                 SampleInterestDate.builder()
@@ -123,13 +123,13 @@ public class JsonMapperTest {
     @Test
     public void shouldProcessDependantResponseFromJson() throws Exception {
         //given
-        final String input = new ResourceReader().read("/defendant-response.json");
+        String input = new ResourceReader().read("/defendant-response.json");
 
         //when
-        final Response output = processor.fromJson(input, Response.class);
+        Response output = processor.fromJson(input, Response.class);
 
         //then
-        final Response expected = SampleResponse.validDefaults();
+        Response expected = SampleResponse.validDefaults();
         assertThat(output).isEqualTo(expected);
     }
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/AuthorisationServiceIsDefendantOnClaimTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/AuthorisationServiceIsDefendantOnClaimTest.java
@@ -11,7 +11,7 @@ public class AuthorisationServiceIsDefendantOnClaimTest {
 
     private static final String USER_ID = "123456789";
 
-    private AuthorisationService authorisationService = new AuthorisationService();
+    private final AuthorisationService authorisationService = new AuthorisationService();
 
     @Test
     public void shouldReturnTrueIfUserIsDefendantOnClaim() {

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/AuthorisationServiceIsSubmitterOnClaimTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/AuthorisationServiceIsSubmitterOnClaimTest.java
@@ -11,7 +11,7 @@ public class AuthorisationServiceIsSubmitterOnClaimTest {
 
     private static final String USER_ID = "123456789";
 
-    private AuthorisationService authorisationService = new AuthorisationService();
+    private final AuthorisationService authorisationService = new AuthorisationService();
 
     @Test
     public void shouldReturnTrueIfUserIsSubmitterOnTheClaim() {

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
@@ -149,7 +149,7 @@ public class ClaimServiceTest {
 
         ClaimData app = SampleClaimData.validDefaults();
         String jsonApp = new ResourceReader().read("/claim-application.json");
-        final String authorisationToken = "Open sesame!";
+        String authorisationToken = "Open sesame!";
 
         when(userService.getUserDetails(eq(authorisationToken))).thenReturn(claimantDetails);
         when(mapper.toJson(eq(app))).thenReturn(jsonApp);
@@ -177,8 +177,8 @@ public class ClaimServiceTest {
 
     @Test(expected = ConflictException.class)
     public void saveClaimShouldThrowConflictExceptionForDuplicateClaim() {
-        final ClaimData app = SampleClaimData.validDefaults();
-        final String authorisationToken = "Open same!";
+        ClaimData app = SampleClaimData.validDefaults();
+        String authorisationToken = "Open same!";
         when(claimRepository.getClaimByExternalId(any())).thenReturn(Optional.of(claim));
 
         claimService.saveClaim(USER_ID, app, authorisationToken);

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentServiceTest.java
@@ -75,7 +75,7 @@ public class CountyCourtJudgmentServiceTest {
     @Test(expected = ForbiddenActionException.class)
     public void saveThrowsForbiddenActionExceptionWhenClaimWasSubmittedBySomeoneElse() {
 
-        final String differentUser = "34234234";
+        String differentUser = "34234234";
 
         Claim claim = SampleClaim.getDefault();
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/OfferResponseDeadlineCalculatorTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/OfferResponseDeadlineCalculatorTest.java
@@ -34,7 +34,7 @@ public class OfferResponseDeadlineCalculatorTest {
 
         when(publicHolidaysCollection.getPublicHolidays()).thenReturn(new TreeSet<>());
 
-        final WorkingDayIndicator workingDayIndicator = new WorkingDayIndicator(publicHolidaysCollection);
+        WorkingDayIndicator workingDayIndicator = new WorkingDayIndicator(publicHolidaysCollection);
 
         calculator = new OfferResponseDeadlineCalculator(
             workingDayIndicator, DAYS_FOR_RESPONSE, END_OF_BUSINESS_DAY

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/UserServiceTest.java
@@ -29,8 +29,8 @@ public class UserServiceTest {
     @Test
     public void shouldGetUserDetails() {
         //given
-        final String authorisationToken = "Open sesame!";
-        final UserDetails userDetails = SampleUserDetails.getDefault();
+        String authorisationToken = "Open sesame!";
+        UserDetails userDetails = SampleUserDetails.getDefault();
         when(idamApi.retrieveUserDetails(authorisationToken)).thenReturn(userDetails);
 
         //when

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/bankholidays/PublicHolidaysCollectionTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/bankholidays/PublicHolidaysCollectionTest.java
@@ -66,7 +66,7 @@ public class PublicHolidaysCollectionTest {
         return expResponse;
     }
 
-    private static BankHolidays.Division.EventDate createItem(final String date) {
+    private static BankHolidays.Division.EventDate createItem(String date) {
         BankHolidays.Division.EventDate item = new BankHolidays.Division.EventDate();
         item.date = date;
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/ClaimIssuedNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/ClaimIssuedNotificationServiceTest.java
@@ -83,7 +83,7 @@ public class ClaimIssuedNotificationServiceTest extends BaseNotificationServiceT
         verify(notificationClient).sendEmail(
             eq(CLAIMANT_CLAIM_ISSUED_TEMPLATE), anyString(), templateParameters.capture(), anyString());
 
-        final String name = ((TitledParty) claim.getClaimData().getClaimant()).getTitle()
+        String name = ((TitledParty) claim.getClaimData().getClaimant()).getTitle()
             .orElseThrow(IllegalArgumentException::new)
             + " "
             + claim.getClaimData().getClaimant().getName();

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/MoreTimeRequestedNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/MoreTimeRequestedNotificationServiceTest.java
@@ -20,10 +20,11 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class MoreTimeRequestedNotificationServiceTest extends BaseNotificationServiceTest {
 
-    private MoreTimeRequestedNotificationService service;
     private static final String REFERENCE = "reference";
     private static final String TEMPLATE_ID = "templateId";
     private static final Map<String, String> PARAMETERS = new HashMap<>();
+
+    private MoreTimeRequestedNotificationService service;
 
     @Before
     public void beforeEachTest() {

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/OfferMadeNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/OfferMadeNotificationServiceTest.java
@@ -20,10 +20,11 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class OfferMadeNotificationServiceTest extends BaseNotificationServiceTest {
 
-    private OfferMadeNotificationService service;
     private static final String REFERENCE = "reference";
     private static final String TEMPLATE_ID = "templateId";
     private static final Map<String, String> PARAMETERS = new HashMap<>();
+
+    private OfferMadeNotificationService service;
 
     @Before
     public void beforeEachTest() {

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/fixtures/SampleUserDetails.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/fixtures/SampleUserDetails.java
@@ -17,22 +17,22 @@ public final class SampleUserDetails {
         return new SampleUserDetails();
     }
 
-    public SampleUserDetails withMail(final String userEmail) {
+    public SampleUserDetails withMail(String userEmail) {
         this.userEmail = userEmail;
         return this;
     }
 
-    public SampleUserDetails withUserId(final String userId) {
+    public SampleUserDetails withUserId(String userId) {
         this.userId = userId;
         return this;
     }
 
-    public SampleUserDetails withForename(final String forename) {
+    public SampleUserDetails withForename(String forename) {
         this.forename = forename;
         return this;
     }
 
-    public SampleUserDetails withSurname(final String surname) {
+    public SampleUserDetails withSurname(String surname) {
         this.surname = surname;
         return this;
     }

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/CCJStaffNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/CCJStaffNotificationServiceTest.java
@@ -25,10 +25,10 @@ import static org.mockito.Mockito.when;
 
 public class CCJStaffNotificationServiceTest extends MockSpringTest {
 
+    private static final byte[] PDF_CONTENT = {1, 2, 3, 4};
+
     @Autowired
     private CCJStaffNotificationService service;
-
-    private static final byte[] PDF_CONTENT = {1, 2, 3, 4};
 
     @Captor
     private ArgumentCaptor<String> senderArgument;

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/OfferAcceptedStaffNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/OfferAcceptedStaffNotificationServiceTest.java
@@ -27,10 +27,10 @@ import static org.mockito.Mockito.when;
 
 public class OfferAcceptedStaffNotificationServiceTest extends MockSpringTest {
 
+    private static final byte[] PDF_CONTENT = {1, 2, 3, 4};
+
     @Autowired
     private OfferAcceptedStaffNotificationService service;
-
-    private static final byte[] PDF_CONTENT = {1, 2, 3, 4};
 
     @Captor
     private ArgumentCaptor<String> senderArgument;

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/ClaimantContentProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/ClaimantContentProviderTest.java
@@ -11,7 +11,7 @@ public class ClaimantContentProviderTest {
 
     private static final String EMAIL = "claimant@domain.com";
 
-    private Individual claimant = SampleParty.builder().individual();
+    private final Individual claimant = SampleParty.builder().individual();
 
     private ClaimantContentProvider provider = new ClaimantContentProvider(
         new PersonContentProvider()

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/DefendantPinLetterContentProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/DefendantPinLetterContentProviderTest.java
@@ -24,10 +24,10 @@ public class DefendantPinLetterContentProviderTest {
     private static final String DEFENDANT_PIN = "dsf4dd2";
     private static final String FRONTEND_BASE_URL = "https://moneyclaim.hmcts.net";
 
+    private final Claim claim = SampleClaim.getDefault();
+
     @Mock
     private NotificationsProperties notificationsProperties;
-
-    private Claim claim = SampleClaim.getDefault();
 
     private DefendantPinLetterContentProvider provider;
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/utils/ResourceLoader.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/utils/ResourceLoader.java
@@ -24,12 +24,12 @@ public class ResourceLoader {
     }
 
     public static StartEventResponse successfulCoreCaseDataStoreStartResponse() {
-        final String response = new ResourceReader().read("/core-case-data/start-response.success.json");
+        String response = new ResourceReader().read("/core-case-data/start-response.success.json");
         return jsonMapper.fromJson(response, StartEventResponse.class);
     }
 
     public static CaseDetails successfulCoreCaseDataStoreSubmitResponse() {
-        final String response = new ResourceReader().read("/core-case-data/submit-response.success.json");
+        String response = new ResourceReader().read("/core-case-data/submit-response.success.json");
         return jsonMapper.fromJson(response, CaseDetails.class);
     }
 }

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/utils/ResourceLoader.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/utils/ResourceLoader.java
@@ -12,12 +12,12 @@ public class ResourceLoader {
     }
 
     public static UploadResponse successfulDocumentManagementUploadResponse() {
-        final String response = new ResourceReader().read("/document-management/response.success.json");
+        String response = new ResourceReader().read("/document-management/response.success.json");
         return jsonMapper.fromJson(response, UploadResponse.class);
     }
 
     public static UploadResponse unsuccessfulDocumentManagementUploadResponse() {
-        final String response = new ResourceReader().read("/document-management/response.failure.json");
+        String response = new ResourceReader().read("/document-management/response.failure.json");
         return jsonMapper.fromJson(response, UploadResponse.class);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

PR removes final modifier from local variables, constructor arguments and method arguments. Argument assignment will be controlled by static analysis tools (Checkstyle)

> Rationale: Parameter assignment is often considered poor programming practice. Forcing developers to declare parameters as final is often onerous. Having a check ensure that parameters are never assigned would give the best of both worlds.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```