### PR TITLE
ROC-2844: Fix displaying interest on the claim issue receipt and defendant response receipt

### DIFF
--- a/src/main/resources/citizen/templates/document/claimIssueReceipt.html
+++ b/src/main/resources/citizen/templates/document/claimIssueReceipt.html
@@ -252,20 +252,20 @@
       <tr>
         <td>Accrued interest:</td>
         <td>
-          Interest will accrue at the daily rate of {{ claim.interest.accruedInterest }} up to the date of judgment
+          Interest will accrue at the daily rate of {{ claim.interest.dailyAmount }} up to the date of judgment
         </td>
       </tr>
       <tr>
         <td>Date interest is claimed from:</td>
         <td>
-          {{ claim.interest.dateClaimedFrom }}
+          {{ claim.interest.fromDate }}
         </td>
       </tr>
-      {% if claim.interest.claimedAtDateOfSubmission is defined %}
+      {% if claim.interest.customFromDate %}
       <tr>
         <td>Total interest claimed to the date of submission:</td>
         <td>
-          {{ claim.interest.claimedAtDateOfSubmission }}
+          {{ claim.interest.amount }}
         </td>
       </tr>
       {% endif %}

--- a/src/main/resources/citizen/templates/document/defendantResponseReceipt.html
+++ b/src/main/resources/citizen/templates/document/defendantResponseReceipt.html
@@ -285,7 +285,7 @@
       <tr>
         <td>Interest rate:</td>
         <td>
-          {{ claim.interest.rate }}% a year
+          {{ claim.interest.rate }} a year
         </td>
       </tr>
       <tr>
@@ -297,19 +297,17 @@
       <tr>
         <td>Date interest is claimed from:</td>
         <td>
-          {{ claim.interest.dateClaimedFrom }}
+          {{ claim.interest.fromDate }}
         </td>
       </tr>
-      {% if claim.interest.claimedAtDateOfSubmission is defined %}
+      {% if claim.interest.customFromDate %}
       <tr>
         <td>Total interest claimed to the date of submission:</td>
         <td>
-          {{ claim.interest.claimedAtDateOfSubmission }}
+          {{ claim.interest.amount }}
         </td>
       </tr>
       {% endif %}
-      {% endif %}
-      {% if claim.interest is defined %}
       <tr>
         <td>Accrued interest:</td>
         <td>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-2844

### Change description ###

This PR fixes binding between interest content and templates so that data can be properly displayed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```