### PR TITLE
ROC-1105: Configure new pdf service client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '1.4.0'
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
 
-  compile group: 'uk.gov.hmcts.reform', name: 'pdf-service-client', version: '4.0.0'
+  compile group: 'uk.gov.hmcts.reform', name: 'pdf-service-client', version: '4.1.0'
 
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
 
@@ -124,7 +124,7 @@ dependencies {
 
   compile group: 'io.github.openfeign', name: 'feign-httpclient', version: '9.5.0'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '1.0.3'
-  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.1.0'
+  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.3.0'
   compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '1.0.9'
 
   testCompile project(':domain-sample-data')

--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '1.4.0'
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
 
-  compile group: 'uk.gov.hmcts.reform', name: 'pdf-service-client', version: '4.1.0'
+  compile group: 'uk.gov.hmcts.reform', name: 'pdf-service-client', version: '5.0.0'
 
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ dependencies {
 
   compile group: 'io.github.openfeign', name: 'feign-httpclient', version: '9.5.0'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '1.0.3'
-  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.3.0'
+  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.4.0'
   compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '1.0.9'
 
   testCompile project(':domain-sample-data')

--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '1.4.0'
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
 
-  compile group: 'uk.gov.hmcts.reform.cmc', name: 'pdf-service-client', version: '1.2.2'
+  compile group: 'uk.gov.hmcts.reform', name: 'pdf-service-client', version: '4.0.0'
 
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
 
@@ -124,7 +124,7 @@ dependencies {
 
   compile group: 'io.github.openfeign', name: 'feign-httpclient', version: '9.5.0'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '1.0.3'
-  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.0.8'
+  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.1.0'
   compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '1.0.9'
 
   testCompile project(':domain-sample-data')

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/DownloadRepresentedClaimCopyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/DownloadRepresentedClaimCopyTest.java
@@ -5,7 +5,7 @@ import org.springframework.test.context.TestPropertySource;
 import uk.gov.hmcts.cmc.claimstore.controllers.base.BaseDownloadDocumentTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.exception.PDFServiceClientException;
+import uk.gov.hmcts.reform.pdf.service.client.exception.PDFServiceClientException;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateClaimIssueReceiptTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateClaimIssueReceiptTest.java
@@ -6,7 +6,7 @@ import uk.gov.hmcts.cmc.claimstore.BaseIntegrationTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.exception.PDFServiceClientException;
+import uk.gov.hmcts.reform.pdf.service.client.exception.PDFServiceClientException;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateCountyCourtJudgementCopyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateCountyCourtJudgementCopyTest.java
@@ -6,7 +6,7 @@ import uk.gov.hmcts.cmc.claimstore.BaseIntegrationTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleCountyCourtJudgment;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.exception.PDFServiceClientException;
+import uk.gov.hmcts.reform.pdf.service.client.exception.PDFServiceClientException;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateDefendantResponseCopyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateDefendantResponseCopyTest.java
@@ -6,7 +6,7 @@ import uk.gov.hmcts.cmc.claimstore.BaseIntegrationTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.exception.PDFServiceClientException;
+import uk.gov.hmcts.reform.pdf.service.client.exception.PDFServiceClientException;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateDefendantResponseReceiptTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateDefendantResponseReceiptTest.java
@@ -6,7 +6,7 @@ import uk.gov.hmcts.cmc.claimstore.BaseIntegrationTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.exception.PDFServiceClientException;
+import uk.gov.hmcts.reform.pdf.service.client.exception.PDFServiceClientException;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateSettlementAgreementCopyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateSettlementAgreementCopyTest.java
@@ -10,7 +10,7 @@ import uk.gov.hmcts.cmc.domain.models.offers.Settlement;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
 import uk.gov.hmcts.cmc.domain.models.sampledata.offers.SampleOffer;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.exception.PDFServiceClientException;
+import uk.gov.hmcts.reform.pdf.service.client.exception.PDFServiceClientException;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimWithCoreCaseDataStoreTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimWithCoreCaseDataStoreTest.java
@@ -57,7 +57,7 @@ public class SaveClaimWithCoreCaseDataStoreTest extends BaseSaveTest {
             )
         ).willReturn(successfulCoreCaseDataStoreSubmitResponse());
 
-        given(serviceAuthorisationApi.serviceToken(anyString(), anyString())).willReturn(SERVICE_TOKEN);
+        given(authTokenGenerator.generate()).willReturn(SERVICE_TOKEN);
 
         MvcResult result = makeRequest(claimData)
             .andExpect(status().isOk())
@@ -102,7 +102,7 @@ public class SaveClaimWithCoreCaseDataStoreTest extends BaseSaveTest {
             )
         ).willThrow(FeignException.class);
 
-        given(serviceAuthorisationApi.serviceToken(anyString(), anyString())).willReturn(SERVICE_TOKEN);
+        given(authTokenGenerator.generate()).willReturn(SERVICE_TOKEN);
 
         MvcResult result = makeRequest(claimData)
             .andExpect(status().isOk())
@@ -137,7 +137,7 @@ public class SaveClaimWithCoreCaseDataStoreTest extends BaseSaveTest {
             )
         ).willThrow(FeignException.class);
 
-        given(serviceAuthorisationApi.serviceToken(anyString(), anyString())).willReturn(SERVICE_TOKEN);
+        given(authTokenGenerator.generate()).willReturn(SERVICE_TOKEN);
 
         MvcResult result = makeRequest(claimData)
             .andExpect(status().isOk())

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/JacksonConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/JacksonConfiguration.java
@@ -8,11 +8,13 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 @Configuration
 public class JacksonConfiguration {
 
     @Bean
+    @Primary
     public ObjectMapper objectMapper() {
         return new ObjectMapper()
             .registerModule(new Jdk8Module())
@@ -20,4 +22,5 @@ public class JacksonConfiguration {
             .registerModule(new JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/PDFServiceConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/PDFServiceConfiguration.java
@@ -2,15 +2,21 @@ package uk.gov.hmcts.cmc.claimstore.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.PDFServiceProperties;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 @Configuration
 public class PDFServiceConfiguration {
 
     @Bean
-    public PDFServiceClient pdfServiceClient(PDFServiceProperties properties) {
-        return new PDFServiceClient(properties.getUrl(), "v1");
+    public PDFServiceClient pdfServiceClient(
+        RestTemplate restTemplate,
+        AuthTokenGenerator authTokenGenerator,
+        PDFServiceProperties properties
+    ) {
+        return new PDFServiceClient(restTemplate, authTokenGenerator::generate, properties.getUrl());
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/PDFServiceConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/PDFServiceConfiguration.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cmc.claimstore.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -13,10 +14,14 @@ public class PDFServiceConfiguration {
     @Bean
     public PDFServiceClient pdfServiceClient(
         RestTemplate restTemplate,
+        ObjectMapper objectMapper,
         AuthTokenGenerator authTokenGenerator,
         PDFServiceProperties properties
     ) {
-        return new PDFServiceClient(restTemplate, authTokenGenerator::generate, properties.getUrl());
+        return PDFServiceClient.builder()
+            .restOperations(restTemplate)
+            .objectMapper(objectMapper)
+            .build(authTokenGenerator::generate, properties.getUrl());
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/ServiceTokenGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/ServiceTokenGeneratorConfiguration.java
@@ -6,9 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
-import uk.gov.hmcts.reform.authorisation.generators.AutorefreshingJwtAuthTokenGenerator;
-import uk.gov.hmcts.reform.authorisation.generators.BearerTokenGenerator;
-import uk.gov.hmcts.reform.authorisation.generators.ServiceAuthTokenGenerator;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
 
 @Configuration
 @Lazy
@@ -18,14 +16,9 @@ public class ServiceTokenGeneratorConfiguration {
     public AuthTokenGenerator authTokenGenerator(
         @Value("${idam.s2s-auth.totp_secret}") String secret,
         @Value("${idam.s2s-auth.microservice}") String microService,
-        ServiceAuthorisationApi serviceAuthorisationApi) {
-
-        AuthTokenGenerator serviceAuthTokenGenerator
-            = new ServiceAuthTokenGenerator(secret, microService, serviceAuthorisationApi);
-
-        return new BearerTokenGenerator(
-            new AutorefreshingJwtAuthTokenGenerator(serviceAuthTokenGenerator)
-        );
+        ServiceAuthorisationApi serviceAuthorisationApi
+    ) {
+        return AuthTokenGeneratorFactory.createDefaultGenerator(secret, microService, serviceAuthorisationApi);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/ServiceTokenGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/ServiceTokenGeneratorConfiguration.java
@@ -6,7 +6,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
-import uk.gov.hmcts.reform.authorisation.generators.CachedServiceAuthTokenGenerator;
+import uk.gov.hmcts.reform.authorisation.generators.AutorefreshingJwtAuthTokenGenerator;
+import uk.gov.hmcts.reform.authorisation.generators.BearerTokenGenerator;
 import uk.gov.hmcts.reform.authorisation.generators.ServiceAuthTokenGenerator;
 
 @Configuration
@@ -17,12 +18,14 @@ public class ServiceTokenGeneratorConfiguration {
     public AuthTokenGenerator authTokenGenerator(
         @Value("${idam.s2s-auth.totp_secret}") String secret,
         @Value("${idam.s2s-auth.microservice}") String microService,
-        @Value("${idam.s2s-auth.tokenTimeToLiveInSeconds:14400}") int ttl,
         ServiceAuthorisationApi serviceAuthorisationApi) {
 
         AuthTokenGenerator serviceAuthTokenGenerator
             = new ServiceAuthTokenGenerator(secret, microService, serviceAuthorisationApi);
 
-        return new CachedServiceAuthTokenGenerator(serviceAuthTokenGenerator, ttl);
+        return new BearerTokenGenerator(
+            new AutorefreshingJwtAuthTokenGenerator(serviceAuthTokenGenerator)
+        );
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/CitizenSealedClaimPdfService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/CitizenSealedClaimPdfService.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimIssueReceiptService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimIssueReceiptService.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/CountyCourtJudgmentPdfService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/CountyCourtJudgmentPdfService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.claimstore.services.staff.content.countycourtjudgment.ContentProvider;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantPinLetterPdfService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantPinLetterPdfService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.claimstore.services.staff.content.DefendantPinLetterContentProvider;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantResponseCopyService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantResponseCopyService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.claimstore.documents.content.DefendantResponseContentProvider;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantResponseReceiptService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantResponseReceiptService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.claimstore.documents.content.DefendantResponseContentProvider;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/LegalSealedClaimPdfService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/LegalSealedClaimPdfService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.claimstore.documents.content.LegalSealedClaimContentProvider;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/SettlementAgreementCopyService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/SettlementAgreementCopyService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.claimstore.documents.content.settlementagreement.SettlementAgreementPDFContentProvider;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/healthcheck/PDFServiceHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/healthcheck/PDFServiceHealthIndicator.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 @Component
 public class PDFServiceHealthIndicator implements HealthIndicator {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,6 @@ idam:
     url: "http://localhost:4552"
     totp_secret: "AAAAAAAAAAAAAAAA"
     microservice: "cmc_claim_store"
-    tokenTimeToLiveInSeconds: 14400
 
 bankHolidays:
   api:

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/MockSpringTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/MockSpringTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.cmc.claimstore.services.UserService;
 import uk.gov.hmcts.cmc.claimstore.services.bankholidays.PublicHolidaysCollection;
 import uk.gov.hmcts.cmc.email.EmailService;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.document.DocumentDownloadClientApi;
 import uk.gov.hmcts.reform.document.DocumentMetadataDownloadClientApi;
@@ -59,6 +60,9 @@ public abstract class MockSpringTest {
 
     @MockBean
     protected PDFServiceClient pdfServiceClient;
+
+    @MockBean
+    protected AuthTokenGenerator authTokenGenerator;
 
     @MockBean
     protected DocumentMetadataDownloadClientApi documentMetadataDownloadClient;

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/MockSpringTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/MockSpringTest.java
@@ -24,10 +24,10 @@ import uk.gov.hmcts.cmc.claimstore.services.bankholidays.PublicHolidaysCollectio
 import uk.gov.hmcts.cmc.email.EmailService;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
 import uk.gov.hmcts.reform.document.DocumentDownloadClientApi;
 import uk.gov.hmcts.reform.document.DocumentMetadataDownloadClientApi;
 import uk.gov.hmcts.reform.document.DocumentUploadClientApi;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 import uk.gov.service.notify.NotificationClient;
 
 import javax.sql.DataSource;

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/CitizenSealedClaimPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/CitizenSealedClaimPdfServiceTest.java
@@ -7,7 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantResponseCopyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/DefendantResponseCopyServiceTest.java
@@ -8,7 +8,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.claimstore.documents.content.DefendantResponseContentProvider;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/LegalSealedClaimPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/LegalSealedClaimPdfServiceTest.java
@@ -8,7 +8,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.claimstore.documents.content.LegalSealedClaimContentProvider;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.reform.cmc.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 import static org.mockito.Mockito.verify;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-1105

### Change description ###

This change configures PDF Service client to use a HTTP client which has proper request tracing headers passing configured.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
