### PR TITLE
Remove classification from case data content

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/SaveCoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/SaveCoreCaseDataService.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.exception.InvalidCaseDataException;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.ccd.client.model.Classification;
 import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.EventRequestData;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
@@ -53,7 +52,6 @@ public class SaveCoreCaseDataService {
 
         CaseDataContent caseDataContent = CaseDataContent.builder()
             .eventToken(startEventResponse.getToken())
-            .securityClassification(Classification.RESTRICTED)
             .event(Event.builder()
                 .id(startEventResponse.getEventId())
                 .summary("CMC case submission event")


### PR DESCRIPTION
### Change description ###
This PR removes the classification from `CaseDataContent` which was added by mistake.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
