### PR TITLE
ROC-3003: Call CCD save only if the transaction is committed

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/ccd/CoreCaseDataUploader.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/ccd/CoreCaseDataUploader.java
@@ -4,8 +4,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
 import uk.gov.hmcts.cmc.claimstore.events.solicitor.RepresentedClaimIssuedEvent;
 import uk.gov.hmcts.cmc.claimstore.exceptions.CoreCaseDataStoreException;
 import uk.gov.hmcts.cmc.claimstore.services.ccd.CoreCaseDataService;
@@ -21,7 +21,7 @@ public class CoreCaseDataUploader {
         this.coreCaseDataService = coreCaseDataService;
     }
 
-    @EventListener
+    @TransactionalEventListener
     public void saveClaim(RepresentedClaimIssuedEvent event) {
         try {
             coreCaseDataService.save(event.getAuthorisation(), event.getClaim());


### PR DESCRIPTION

### JIRA link (if applicable) ###
[ROC-3003](https://tools.hmcts.net/jira/browse/ROC-3003)


### Change description ###
This PR fixes the scenario where save claim transaction rolls back but the CCD uploader event listener does not rolls back. The fix will invoke CCD uploader after commit of the transaction.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
