### PR TITLE
Fix an incorrect logging message

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/healthcheck/GovNotifyHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/healthcheck/GovNotifyHealthIndicator.java
@@ -26,7 +26,7 @@ public class GovNotifyHealthIndicator implements HealthIndicator {
             client.getNotifications(null, null, "fake_ref", null);
             return Health.up().build();
         } catch (Exception exc) {
-            LOGGER.error("Error on pdf service healthcheck", exc);
+            LOGGER.error("Error on GOV Notify service healthcheck", exc);
             return Health.down(exc).build();
         }
     }


### PR DESCRIPTION
### Change description ###

GOV Notify healthcheck was logging as a PDF service one.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
