### PR TITLE
Bump java-logging version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,8 +108,8 @@ dependencies {
 
   compile group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.4.0-RELEASE'
 
-  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '1.4.0'
-  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '1.4.0'
+  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '1.4.2'
+  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '1.4.2'
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
 
   compile group: 'uk.gov.hmcts.reform', name: 'pdf-service-client', version: '5.0.0'


### PR DESCRIPTION
This restores stacktraces, they are slightly more verbose than before,
but all the information is there again