### PR TITLE
ROC-3027: Use external id as identifier rather than database id

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/ClaimStore.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/ClaimStore.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.cmc.claimstore.processors.JsonMapper;
 import uk.gov.hmcts.cmc.claimstore.repositories.ClaimRepository;
+import uk.gov.hmcts.cmc.claimstore.repositories.ClaimSearchRepository;
 import uk.gov.hmcts.cmc.claimstore.repositories.OffersRepository;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.ClaimData;
@@ -27,6 +28,9 @@ public class ClaimStore {
     private ClaimRepository claimRepository;
 
     @Autowired
+    private ClaimSearchRepository claimSearchRepository;
+
+    @Autowired
     private OffersRepository offersRepository;
 
     @Autowired
@@ -34,6 +38,10 @@ public class ClaimStore {
 
     public Claim getClaim(long claimId) {
         return claimRepository.getById(claimId).orElseThrow(RuntimeException::new);
+    }
+
+    public Claim getClaimByExternalId(String externalId) {
+        return claimSearchRepository.getClaimByExternalId(externalId).orElseThrow(RuntimeException::new);
     }
 
     public Claim saveClaim(ClaimData claimData) {
@@ -79,17 +87,17 @@ public class ClaimStore {
         return getClaim(claimId);
     }
 
-    public Claim saveCountyCourtJudgement(long claimId, CountyCourtJudgment ccj) {
-        logger.info(String.format("Saving county court judgement with claim : %d", claimId));
+    public Claim saveCountyCourtJudgement(String externalId, CountyCourtJudgment ccj) {
+        logger.info(String.format("Saving county court judgement with claim : %s", externalId));
 
         this.claimRepository.saveCountyCourtJudgment(
-            claimId,
+            externalId,
             jsonMapper.toJson(ccj)
         );
 
         logger.info("Saved county court judgement");
 
-        return getClaim(claimId);
+        return getClaimByExternalId(externalId);
     }
 
     public Claim makeOffer(long claimId, Settlement settlement) {

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateCountyCourtJudgementCopyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateCountyCourtJudgementCopyTest.java
@@ -24,7 +24,7 @@ public class GenerateCountyCourtJudgementCopyTest extends BaseGetTest {
     @Test
     public void shouldReturnPdfDocumentIfEverythingIsFine() throws Exception {
         Claim claim = claimStore.saveClaim(SampleClaimData.builder().build());
-        claimStore.saveCountyCourtJudgement(claim.getId(), SampleCountyCourtJudgment.builder().build());
+        claimStore.saveCountyCourtJudgement(claim.getExternalId(), SampleCountyCourtJudgment.builder().build());
 
         given(pdfServiceClient.generateFromHtml(any(), any()))
             .willReturn(PDF_BYTES);
@@ -46,7 +46,7 @@ public class GenerateCountyCourtJudgementCopyTest extends BaseGetTest {
     @Test
     public void shouldReturnServerErrorWhenPdfGenerationFails() throws Exception {
         Claim claim = claimStore.saveClaim(SampleClaimData.builder().build());
-        claimStore.saveCountyCourtJudgement(claim.getId(), SampleCountyCourtJudgment.builder().build());
+        claimStore.saveCountyCourtJudgement(claim.getExternalId(), SampleCountyCourtJudgment.builder().build());
 
         given(pdfServiceClient.generateFromHtml(any(), any()))
             .willThrow(new PDFServiceClientException(new RuntimeException("Something bad happened!")));

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
@@ -23,17 +23,15 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import static uk.gov.hmcts.cmc.claimstore.controllers.PathPatterns.CLAIM_REFERENCE_PATTERN;
+import static uk.gov.hmcts.cmc.claimstore.controllers.PathPatterns.UUID_PATTERN;
+
 @Api
 @RestController
 @RequestMapping(
     path = "/claims",
     produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 public class ClaimController {
-
-    public static final String UUID_PATTERN = "\\p{XDigit}{8}-\\p{XDigit}"
-        + "{4}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{12}";
-
-    public static final String CLAIM_REFERENCE_PATTERN = "^\\d{3}(?:LR|MC)\\d{3}$";
 
     private final ClaimService claimService;
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CountyCourtJudgmentController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CountyCourtJudgmentController.java
@@ -19,7 +19,7 @@ import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-import static uk.gov.hmcts.cmc.claimstore.controllers.ClaimController.UUID_PATTERN;
+import static uk.gov.hmcts.cmc.claimstore.controllers.PathPatterns.UUID_PATTERN;
 
 @Api
 @RestController

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CountyCourtJudgmentController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CountyCourtJudgmentController.java
@@ -19,6 +19,8 @@ import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import static uk.gov.hmcts.cmc.claimstore.controllers.ClaimController.UUID_PATTERN;
+
 @Api
 @RestController
 @RequestMapping(
@@ -36,14 +38,14 @@ public class CountyCourtJudgmentController {
         this.userService = userService;
     }
 
-    @PostMapping("/{claimId:\\d+}/county-court-judgment")
+    @PostMapping("/{externalId:" + UUID_PATTERN + "}/county-court-judgment")
     @ApiOperation("Save County Court Judgment")
     public Claim save(
-        @PathVariable("claimId") Long claimId,
+        @PathVariable("externalId") String externalId,
         @NotNull @RequestBody @Valid CountyCourtJudgment countyCourtJudgment,
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation
     ) {
         String submitterId = userService.getUserDetails(authorisation).getId();
-        return countyCourtJudgmentService.save(submitterId, countyCourtJudgment, claimId);
+        return countyCourtJudgmentService.save(submitterId, countyCourtJudgment, externalId, authorisation);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/PathPatterns.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/PathPatterns.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.cmc.claimstore.controllers;
+
+public class PathPatterns {
+
+    public static final String UUID_PATTERN = "\\p{XDigit}{8}-\\p{XDigit}"
+        + "{4}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{12}";
+
+    public static final String CLAIM_REFERENCE_PATTERN = "^\\d{3}(?:LR|MC)\\d{3}$";
+
+    private PathPatterns() {
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
@@ -18,10 +18,10 @@ import java.util.Optional;
 public interface ClaimRepository {
 
     @SuppressWarnings("squid:S1214") // Pointless to create class for this
-        String SELECT_FROM_STATEMENT = "SELECT * FROM claim";
+    String SELECT_FROM_STATEMENT = "SELECT * FROM claim";
 
     @SuppressWarnings("squid:S1214") // Pointless to create class for this
-        String ORDER_BY_ID_DESCENDING = " ORDER BY claim.id DESC";
+    String ORDER_BY_ID_DESCENDING = " ORDER BY claim.id DESC";
 
     @SqlQuery(SELECT_FROM_STATEMENT + ORDER_BY_ID_DESCENDING)
     List<Claim> findAll();

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/ClaimRepository.java
@@ -18,10 +18,10 @@ import java.util.Optional;
 public interface ClaimRepository {
 
     @SuppressWarnings("squid:S1214") // Pointless to create class for this
-    String SELECT_FROM_STATEMENT = "SELECT * FROM claim";
+        String SELECT_FROM_STATEMENT = "SELECT * FROM claim";
 
     @SuppressWarnings("squid:S1214") // Pointless to create class for this
-    String ORDER_BY_ID_DESCENDING = " ORDER BY claim.id DESC";
+        String ORDER_BY_ID_DESCENDING = " ORDER BY claim.id DESC";
 
     @SqlQuery(SELECT_FROM_STATEMENT + ORDER_BY_ID_DESCENDING)
     List<Claim> findAll();
@@ -157,10 +157,9 @@ public interface ClaimRepository {
     @SqlUpdate("UPDATE claim SET "
         + " county_court_judgment = :countyCourtJudgmentData::JSONB,"
         + " county_court_judgment_requested_at = now() at time zone 'utc'"
-        + "WHERE"
-        + " id = :claimId")
+        + " WHERE external_id = :externalId")
     void saveCountyCourtJudgment(
-        @Bind("claimId") long claimId,
+        @Bind("externalId") String externalId,
         @Bind("countyCourtJudgmentData") String countyCourtJudgmentData
     );
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRule.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRule.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Service
 public class CountyCourtJudgmentRule {
 
-    public void assertCanIssueCountyCourtJudgment(final Claim claim) {
+    public void assertCountyCourtJudgementCanBeRequested(Claim claim) {
 
         if (isResponseAlreadySubmitted(claim)) {
             throw new ForbiddenActionException("Response for the claim " + claim.getExternalId() + " was submitted");
@@ -27,15 +27,15 @@ public class CountyCourtJudgmentRule {
         }
     }
 
-    private boolean canCountyCourtJudgmentBeRequestedYet(final Claim claim) {
+    private boolean canCountyCourtJudgmentBeRequestedYet(Claim claim) {
         return LocalDate.now().isAfter(claim.getResponseDeadline());
     }
 
-    private boolean isResponseAlreadySubmitted(final Claim claim) {
+    private boolean isResponseAlreadySubmitted(Claim claim) {
         return null != claim.getRespondedAt();
     }
 
-    private boolean isCountyCourtJudgmentAlreadySubmitted(final Claim claim) {
+    private boolean isCountyCourtJudgmentAlreadySubmitted(Claim claim) {
         return claim.getCountyCourtJudgment() != null;
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRule.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRule.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.cmc.claimstore.rules;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.cmc.claimstore.exceptions.ForbiddenActionException;
+import uk.gov.hmcts.cmc.domain.models.Claim;
+
+import java.time.LocalDate;
+
+@Service
+public class CountyCourtJudgmentRule {
+
+    public void assertCanIssueCountyCourtJudgment(final Claim claim) {
+
+        if (isResponseAlreadySubmitted(claim)) {
+            throw new ForbiddenActionException("Response for the claim " + claim.getExternalId() + " was submitted");
+        }
+
+        if (isCountyCourtJudgmentAlreadySubmitted(claim)) {
+            throw new ForbiddenActionException("County Court Judgment for the claim "
+                + claim.getExternalId() + " was submitted");
+        }
+
+        if (!canCountyCourtJudgmentBeRequestedYet(claim)) {
+            throw new ForbiddenActionException(
+                "County Court Judgment for claim " + claim.getExternalId() + " cannot be requested yet"
+            );
+        }
+    }
+
+    private boolean canCountyCourtJudgmentBeRequestedYet(final Claim claim) {
+        return LocalDate.now().isAfter(claim.getResponseDeadline());
+    }
+
+    private boolean isResponseAlreadySubmitted(final Claim claim) {
+        return null != claim.getRespondedAt();
+    }
+
+    private boolean isCountyCourtJudgmentAlreadySubmitted(final Claim claim) {
+        return claim.getCountyCourtJudgment() != null;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRule.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRule.java
@@ -5,12 +5,14 @@ import uk.gov.hmcts.cmc.claimstore.exceptions.ForbiddenActionException;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 
 import java.time.LocalDate;
+import java.util.Objects;
+import javax.validation.constraints.NotNull;
 
 @Service
 public class CountyCourtJudgmentRule {
 
-    public void assertCountyCourtJudgementCanBeRequested(Claim claim) {
-
+    public void assertCountyCourtJudgementCanBeRequested(@NotNull Claim claim) {
+        Objects.requireNonNull(claim, "claim object can not be null");
         if (isResponseAlreadySubmitted(claim)) {
             throw new ForbiddenActionException("Response for the claim " + claim.getExternalId() + " was submitted");
         }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
@@ -182,8 +182,8 @@ public class ClaimService {
         claimRepository.linkSealedClaimDocument(claimId, documentSelfPath);
     }
 
-    public void saveCountyCourtJudgment(long claimId, CountyCourtJudgment countyCourtJudgment) {
-        claimRepository.saveCountyCourtJudgment(claimId, jsonMapper.toJson(countyCourtJudgment));
+    public void saveCountyCourtJudgment(String externalId, CountyCourtJudgment countyCourtJudgment) {
+        claimRepository.saveCountyCourtJudgment(externalId, jsonMapper.toJson(countyCourtJudgment));
     }
 
     public void saveDefendantResponse(long claimId, String defendantId, String defendantEmail, Response response) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentService.java
@@ -41,7 +41,7 @@ public class CountyCourtJudgmentService {
 
         authorisationService.assertIsSubmitterOnClaim(claim, submitterId);
 
-        countyCourtJudgmentRule.assertCanIssueCountyCourtJudgment(claim);
+        countyCourtJudgmentRule.assertCountyCourtJudgementCanBeRequested(claim);
 
         claimService.saveCountyCourtJudgment(externalId, countyCourtJudgment);
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CountyCourtJudgmentService.java
@@ -4,11 +4,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.cmc.claimstore.events.EventProducer;
-import uk.gov.hmcts.cmc.claimstore.exceptions.ForbiddenActionException;
+import uk.gov.hmcts.cmc.claimstore.rules.CountyCourtJudgmentRule;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
-
-import java.time.LocalDate;
 
 @Component
 public class CountyCourtJudgmentService {
@@ -16,57 +14,42 @@ public class CountyCourtJudgmentService {
     private final ClaimService claimService;
     private final AuthorisationService authorisationService;
     private final EventProducer eventProducer;
+    private final CountyCourtJudgmentRule countyCourtJudgmentRule;
 
     @Autowired
     public CountyCourtJudgmentService(
         ClaimService claimService,
         AuthorisationService authorisationService,
-        EventProducer eventProducer
+        EventProducer eventProducer,
+        CountyCourtJudgmentRule countyCourtJudgmentRule
     ) {
         this.claimService = claimService;
         this.authorisationService = authorisationService;
         this.eventProducer = eventProducer;
+        this.countyCourtJudgmentRule = countyCourtJudgmentRule;
     }
 
     @Transactional
-    public Claim save(String submitterId, CountyCourtJudgment countyCourtJudgment, long claimId) {
+    public Claim save(
+        String submitterId,
+        CountyCourtJudgment countyCourtJudgment,
+        String externalId,
+        String authorisation
+    ) {
 
-        Claim claim = claimService.getClaimById(claimId);
+        Claim claim = claimService.getClaimByExternalId(externalId, authorisation);
 
         authorisationService.assertIsSubmitterOnClaim(claim, submitterId);
 
-        if (isResponseAlreadySubmitted(claim)) {
-            throw new ForbiddenActionException("Response for the claim " + claimId + " was submitted");
-        }
+        countyCourtJudgmentRule.assertCanIssueCountyCourtJudgment(claim);
 
-        if (isCountyCourtJudgmentAlreadySubmitted(claim)) {
-            throw new ForbiddenActionException("County Court Judgment for the claim " + claimId + " was submitted");
-        }
+        claimService.saveCountyCourtJudgment(externalId, countyCourtJudgment);
 
-        if (!canCountyCourtJudgmentBeRequestedYet(claim)) {
-            throw new ForbiddenActionException(
-                "County Court Judgment for claim " + claimId + " cannot be requested yet"
-            );
-        }
-
-        claimService.saveCountyCourtJudgment(claimId, countyCourtJudgment);
-
-        Claim claimWithCCJ = claimService.getClaimById(claimId);
+        Claim claimWithCCJ = claimService.getClaimByExternalId(externalId, authorisation);
 
         eventProducer.createCountyCourtJudgmentRequestedEvent(claimWithCCJ);
 
         return claimWithCCJ;
     }
 
-    private boolean canCountyCourtJudgmentBeRequestedYet(Claim claim) {
-        return LocalDate.now().isAfter(claim.getResponseDeadline());
-    }
-
-    private boolean isResponseAlreadySubmitted(Claim claim) {
-        return null != claim.getRespondedAt();
-    }
-
-    private boolean isCountyCourtJudgmentAlreadySubmitted(Claim claim) {
-        return claim.getCountyCourtJudgment() != null;
-    }
 }

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRuleTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRuleTest.java
@@ -4,35 +4,43 @@ import org.junit.Test;
 import uk.gov.hmcts.cmc.claimstore.exceptions.ForbiddenActionException;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
+import uk.gov.hmcts.cmc.domain.models.sampledata.SampleCountyCourtJudgment;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+
+import static java.time.LocalDateTime.now;
 
 public class CountyCourtJudgmentRuleTest {
 
     private final CountyCourtJudgmentRule countyCourtJudgmentRule = new CountyCourtJudgmentRule();
 
     @Test
-    public void saveShouldFinishSuccessfullyForHappyPath() {
+    public void shouldNotThrowExceptionWhenCCJCanBeRequested() {
         Claim claim = SampleClaim.builder().withResponseDeadline(LocalDate.now().minusMonths(2)).build();
-        countyCourtJudgmentRule.assertCanIssueCountyCourtJudgment(claim);
+        countyCourtJudgmentRule.assertCountyCourtJudgementCanBeRequested(claim);
     }
 
     @Test(expected = ForbiddenActionException.class)
-    public void shouldThrowsForbiddenActionExceptionWhenClaimWasResponded() {
-        Claim respondedClaim = SampleClaim.builder().withRespondedAt(LocalDateTime.now().minusDays(2)).build();
-        countyCourtJudgmentRule.assertCanIssueCountyCourtJudgment(respondedClaim);
+    public void shouldThrowExceptionWhenClaimWasResponded() {
+        Claim respondedClaim = SampleClaim.builder().withRespondedAt(now().minusDays(2)).build();
+        countyCourtJudgmentRule.assertCountyCourtJudgementCanBeRequested(respondedClaim);
     }
 
     @Test(expected = ForbiddenActionException.class)
-    public void shouldThrowsForbiddenActionExceptionWhenUserCannotRequestCountyCourtJudgmentYet() {
+    public void shouldThrowExceptionWhenUserCannotRequestCountyCourtJudgmentYet() {
         Claim claim = SampleClaim.getWithResponseDeadline(LocalDate.now().plusDays(12));
-        countyCourtJudgmentRule.assertCanIssueCountyCourtJudgment(claim);
+        countyCourtJudgmentRule.assertCountyCourtJudgementCanBeRequested(claim);
     }
 
     @Test(expected = ForbiddenActionException.class)
-    public void shouldThrowsForbiddenActionExceptionWhenCountyCourtJudgmentWasAlreadySubmitted() {
-        Claim claim = SampleClaim.getDefault();
-        countyCourtJudgmentRule.assertCanIssueCountyCourtJudgment(claim);
+    public void shouldThrowExceptionWhenCountyCourtJudgmentWasAlreadySubmitted() {
+        Claim claim = SampleClaim.builder()
+            .withCountyCourtJudgmentRequestedAt(now())
+            .withCountyCourtJudgment(
+                SampleCountyCourtJudgment.builder()
+                    .withPaymentOptionImmediately()
+                    .build()
+            ).build();
+        countyCourtJudgmentRule.assertCountyCourtJudgementCanBeRequested(claim);
     }
 }

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRuleTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRuleTest.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.cmc.claimstore.rules;
+
+import org.junit.Test;
+import uk.gov.hmcts.cmc.claimstore.exceptions.ForbiddenActionException;
+import uk.gov.hmcts.cmc.domain.models.Claim;
+import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class CountyCourtJudgmentRuleTest {
+
+    private final CountyCourtJudgmentRule countyCourtJudgmentRule = new CountyCourtJudgmentRule();
+
+    @Test
+    public void saveShouldFinishSuccessfullyForHappyPath() {
+        Claim claim = SampleClaim.builder().withResponseDeadline(LocalDate.now().minusMonths(2)).build();
+        countyCourtJudgmentRule.assertCanIssueCountyCourtJudgment(claim);
+    }
+
+    @Test(expected = ForbiddenActionException.class)
+    public void shouldThrowsForbiddenActionExceptionWhenClaimWasResponded() {
+        Claim respondedClaim = SampleClaim.builder().withRespondedAt(LocalDateTime.now().minusDays(2)).build();
+        countyCourtJudgmentRule.assertCanIssueCountyCourtJudgment(respondedClaim);
+    }
+
+    @Test(expected = ForbiddenActionException.class)
+    public void shouldThrowsForbiddenActionExceptionWhenUserCannotRequestCountyCourtJudgmentYet() {
+        Claim claim = SampleClaim.getWithResponseDeadline(LocalDate.now().plusDays(12));
+        countyCourtJudgmentRule.assertCanIssueCountyCourtJudgment(claim);
+    }
+
+    @Test(expected = ForbiddenActionException.class)
+    public void shouldThrowsForbiddenActionExceptionWhenCountyCourtJudgmentWasAlreadySubmitted() {
+        Claim claim = SampleClaim.getDefault();
+        countyCourtJudgmentRule.assertCanIssueCountyCourtJudgment(claim);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[ROC-3027](https://tools.hmcts.net/jira/browse/ROC-3027)
### Change description ###
This PR refactors code for CCJ to use external id as identifier rather than database id. The frontend PR to accommodate the change is required.

Relevant pull request at `cmc-citizen-frontend` repo is: https://github.com/hmcts/cmc-citizen-frontend/pull/336

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

