### PR TITLE
Align AAT environment variable names

### DIFF
--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/AATConfiguration.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/AATConfiguration.java
@@ -13,7 +13,11 @@ public class AATConfiguration {
 
     @Valid
     @NotNull
-    private TestUser testUser;
+    private TestUser testCitizenUser;
+
+    @Valid
+    @NotNull
+    private TestUser testSolicitorUser;
 
     @NotBlank
     private String testInstanceUri;
@@ -21,12 +25,20 @@ public class AATConfiguration {
     @NotBlank
     private String testUserEmailPattern;
 
-    public TestUser getTestUser() {
-        return testUser;
+    public TestUser getTestCitizenUser() {
+        return testCitizenUser;
     }
 
-    public void setTestUser(TestUser testUser) {
-        this.testUser = testUser;
+    public void setTestCitizenUser(TestUser testCitizenUser) {
+        this.testCitizenUser = testCitizenUser;
+    }
+
+    public TestUser getTestSolicitorUser() {
+        return testSolicitorUser;
+    }
+
+    public void setTestSolicitorUser(TestUser testSolicitorUser) {
+        this.testSolicitorUser = testSolicitorUser;
     }
 
     public String getTestInstanceUri() {

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/Bootstrap.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/Bootstrap.java
@@ -5,6 +5,7 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.cmc.claimstore.idam.models.User;
 import uk.gov.hmcts.cmc.claimstore.services.UserService;
 
 import javax.annotation.PostConstruct;
@@ -16,8 +17,7 @@ public class Bootstrap {
     private final UserService userService;
     private final AATConfiguration aatConfiguration;
 
-    private String authenticationToken;
-    private String userId;
+    private User citizenUser;
 
     @Autowired
     public Bootstrap(
@@ -37,19 +37,14 @@ public class Bootstrap {
             .objectMapperConfig(
                 ObjectMapperConfig.objectMapperConfig().jackson2ObjectMapperFactory((cls, charset) -> objectMapper)
             );
-        authenticationToken = userService.authenticateUser(
+        citizenUser = userService.authenticateUser(
             aatConfiguration.getTestCitizenUser().getUsername(),
             aatConfiguration.getTestCitizenUser().getPassword()
-        ).getAuthorisation();
-        userId = userService.getUserDetails(authenticationToken).getId();
+        );
     }
 
-    public String getUserAuthenticationToken() {
-        return authenticationToken;
-    }
-
-    public String getUserId() {
-        return userId;
+    public User getCitizenUser() {
+        return citizenUser;
     }
 
 }

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/Bootstrap.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/Bootstrap.java
@@ -38,8 +38,8 @@ public class Bootstrap {
                 ObjectMapperConfig.objectMapperConfig().jackson2ObjectMapperFactory((cls, charset) -> objectMapper)
             );
         authenticationToken = userService.authenticateUser(
-            aatConfiguration.getTestUser().getUsername(),
-            aatConfiguration.getTestUser().getPassword()
+            aatConfiguration.getTestCitizenUser().getUsername(),
+            aatConfiguration.getTestCitizenUser().getPassword()
         ).getAuthorisation();
         userId = userService.getUserDetails(authenticationToken).getId();
     }

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
@@ -17,7 +17,10 @@ public class LinkDefendantTest extends BaseTest {
 
     @Test
     public void shouldBeAbleToSuccessfullyLinkDefendant() {
-        Claim createdCase = commonOperations.submitClaim(bootstrap.getUserAuthenticationToken(), bootstrap.getUserId());
+        Claim createdCase = commonOperations.submitClaim(
+            bootstrap.getCitizenUser().getAuthorisation(),
+            bootstrap.getCitizenUser().getUserDetails().getId()
+        );
 
         User defendant = idamTestService.createDefendant();
 

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RequestCountyCourtJudgementTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RequestCountyCourtJudgementTest.java
@@ -22,7 +22,10 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
 
     @Test
     public void shouldBeAbleToSuccessfullyRequestCCJ() {
-        Claim createdCase = commonOperations.submitClaim(bootstrap.getUserAuthenticationToken(), bootstrap.getUserId());
+        Claim createdCase = commonOperations.submitClaim(
+            bootstrap.getCitizenUser().getAuthorisation(),
+            bootstrap.getCitizenUser().getUserDetails().getId()
+        );
 
         updateResponseDeadlineToEnableCCJ(createdCase.getReferenceNumber());
 
@@ -43,7 +46,10 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
 
     @Test
     public void shouldReturnUnprocessableEntityWhenInvalidJudgementIsSubmitted() {
-        Claim createdCase = commonOperations.submitClaim(bootstrap.getUserAuthenticationToken(), bootstrap.getUserId());
+        Claim createdCase = commonOperations.submitClaim(
+            bootstrap.getCitizenUser().getAuthorisation(),
+            bootstrap.getCitizenUser().getUserDetails().getId()
+        );
 
         updateResponseDeadlineToEnableCCJ(createdCase.getReferenceNumber());
 
@@ -58,7 +64,10 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
 
     @Test
     public void shouldNotBeAllowedToRequestCCJWhenResponseDeadlineHasNotPassed() {
-        Claim createdCase = commonOperations.submitClaim(bootstrap.getUserAuthenticationToken(), bootstrap.getUserId());
+        Claim createdCase = commonOperations.submitClaim(
+            bootstrap.getCitizenUser().getAuthorisation(),
+            bootstrap.getCitizenUser().getUserDetails().getId()
+        );
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
             .withPaymentOptionImmediately()
@@ -73,7 +82,7 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
         return RestAssured
             .given()
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header(HttpHeaders.AUTHORIZATION, bootstrap.getUserAuthenticationToken())
+            .header(HttpHeaders.AUTHORIZATION, bootstrap.getCitizenUser().getAuthorisation())
             .body(jsonMapper.toJson(ccj))
             .when()
             .post("/claims/" + externalId + "/county-court-judgment");

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
@@ -38,7 +38,10 @@ public class RespondToClaimTest extends BaseTest {
     }
 
     private void shouldBeAbleToSuccessfullySubmit(Response response) {
-        Claim createdCase = commonOperations.submitClaim(bootstrap.getUserAuthenticationToken(), bootstrap.getUserId());
+        Claim createdCase = commonOperations.submitClaim(
+            bootstrap.getCitizenUser().getAuthorisation(),
+            bootstrap.getCitizenUser().getUserDetails().getId()
+        );
 
         User defendant = idamTestService.createDefendant();
 
@@ -61,7 +64,10 @@ public class RespondToClaimTest extends BaseTest {
 
     @Test
     public void shouldReturnUnprocessableEntityWhenInvalidResponseIsSubmitted() {
-        Claim createdCase = commonOperations.submitClaim(bootstrap.getUserAuthenticationToken(), bootstrap.getUserId());
+        Claim createdCase = commonOperations.submitClaim(
+            bootstrap.getCitizenUser().getAuthorisation(),
+            bootstrap.getCitizenUser().getUserDetails().getId()
+        );
 
         User defendant = idamTestService.createDefendant();
 

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
@@ -63,10 +63,10 @@ public class SubmitClaimTest extends BaseTest {
         return RestAssured
             .given()
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header(HttpHeaders.AUTHORIZATION, bootstrap.getUserAuthenticationToken())
+            .header(HttpHeaders.AUTHORIZATION, bootstrap.getCitizenUser().getAuthorisation())
             .body(jsonMapper.toJson(claimData))
             .when()
-            .post("/claims/" + bootstrap.getUserId());
+            .post("/claims/" + bootstrap.getCitizenUser().getUserDetails().getId());
     }
 
 }

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
@@ -30,8 +30,8 @@ public class IdamTestService {
 
     public User createDefendant() {
         String email = testData.nextUserEmail();
-        idamTestApi.createUser(createDefendantRequest(email, aatConfiguration.getTestUser().getPassword()));
-        return userService.authenticateUser(email, aatConfiguration.getTestUser().getPassword());
+        idamTestApi.createUser(createDefendantRequest(email, aatConfiguration.getTestCitizenUser().getPassword()));
+        return userService.authenticateUser(email, aatConfiguration.getTestCitizenUser().getPassword());
     }
 
     private CreateUserRequest createDefendantRequest(String username, String password) {

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/smoke/RetrieveCaseTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/smoke/RetrieveCaseTest.java
@@ -16,18 +16,18 @@ public class RetrieveCaseTest extends BaseTest {
 
     @Test
     public void shouldBeAbleToRetrieveCasesBySubmitterId() {
-        testCasesRetrievalFor("/claims/claimant/" + bootstrap.getUserId());
+        testCasesRetrievalFor("/claims/claimant/" + bootstrap.getCitizenUser().getUserDetails().getId());
     }
 
     @Test
     public void shouldBeAbleToRetrieveCasesByDefendantId() {
-        testCasesRetrievalFor("/claims/defendant/" + bootstrap.getUserId());
+        testCasesRetrievalFor("/claims/defendant/" + bootstrap.getCitizenUser().getUserDetails().getId());
     }
 
     private void testCasesRetrievalFor(String uriPath) {
         String response = RestAssured
             .given()
-            .header(HttpHeaders.AUTHORIZATION, bootstrap.getUserAuthenticationToken())
+            .header(HttpHeaders.AUTHORIZATION, bootstrap.getCitizenUser().getAuthorisation())
             .when()
             .get(uriPath)
             .then()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,3 +103,7 @@ spring:
 
 aat:
   test-instance-uri: "${TEST_URL:}"
+  test-citizen-user:
+    password: "${AAT_TEST_USER_PASSWORD:}"
+  test-solicitor-user:
+    password: "${AAT_TEST_USER_PASSWORD:}"


### PR DESCRIPTION
### Change description ###

Aligns environment variable names used for AAT smoke and functional testing:

- `AAT_TEST_CITIZEN_USER_USERNAME`
- `AAT_TEST_SOLICITOR_USER_USERNAME`
- `AAT_TEST_USER_PASSWORD` (both above users will re-use the same password until a need arises to do otherwise)

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
