### PR TITLE
Rename env variables to be more intuitive

### DIFF
--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/AATConfiguration.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/AATConfiguration.java
@@ -8,37 +8,37 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 @Component
-@ConfigurationProperties(prefix = "aat")
+@ConfigurationProperties
 public class AATConfiguration {
 
     @Valid
     @NotNull
-    private TestUser testCitizenUser;
+    private TestUser smokeTestCitizen;
 
     @Valid
     @NotNull
-    private TestUser testSolicitorUser;
+    private TestUser smokeTestSolicitor;
 
     @NotBlank
     private String testInstanceUri;
 
     @NotBlank
-    private String testUserEmailPattern;
+    private String generatedUserEmailPattern;
 
-    public TestUser getTestCitizenUser() {
-        return testCitizenUser;
+    public TestUser getSmokeTestCitizen() {
+        return smokeTestCitizen;
     }
 
-    public void setTestCitizenUser(TestUser testCitizenUser) {
-        this.testCitizenUser = testCitizenUser;
+    public void setSmokeTestCitizen(TestUser smokeTestCitizen) {
+        this.smokeTestCitizen = smokeTestCitizen;
     }
 
-    public TestUser getTestSolicitorUser() {
-        return testSolicitorUser;
+    public TestUser getSmokeTestSolicitor() {
+        return smokeTestSolicitor;
     }
 
-    public void setTestSolicitorUser(TestUser testSolicitorUser) {
-        this.testSolicitorUser = testSolicitorUser;
+    public void setSmokeTestSolicitor(TestUser smokeTestSolicitor) {
+        this.smokeTestSolicitor = smokeTestSolicitor;
     }
 
     public String getTestInstanceUri() {
@@ -49,12 +49,12 @@ public class AATConfiguration {
         this.testInstanceUri = testInstanceUri;
     }
 
-    public String getTestUserEmailPattern() {
-        return testUserEmailPattern;
+    public String getGeneratedUserEmailPattern() {
+        return generatedUserEmailPattern;
     }
 
-    public void setTestUserEmailPattern(String testUserEmailPattern) {
-        this.testUserEmailPattern = testUserEmailPattern;
+    public void setGeneratedUserEmailPattern(String generatedUserEmailPattern) {
+        this.generatedUserEmailPattern = generatedUserEmailPattern;
     }
 
 }

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/Bootstrap.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/Bootstrap.java
@@ -17,7 +17,7 @@ public class Bootstrap {
     private final UserService userService;
     private final AATConfiguration aatConfiguration;
 
-    private User citizenUser;
+    private User smokeTestCitizen;
 
     @Autowired
     public Bootstrap(
@@ -37,14 +37,14 @@ public class Bootstrap {
             .objectMapperConfig(
                 ObjectMapperConfig.objectMapperConfig().jackson2ObjectMapperFactory((cls, charset) -> objectMapper)
             );
-        citizenUser = userService.authenticateUser(
+        smokeTestCitizen = userService.authenticateUser(
             aatConfiguration.getSmokeTestCitizen().getUsername(),
             aatConfiguration.getSmokeTestCitizen().getPassword()
         );
     }
 
-    public User getCitizenUser() {
-        return citizenUser;
+    public User getSmokeTestCitizen() {
+        return smokeTestCitizen;
     }
 
 }

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/Bootstrap.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/Bootstrap.java
@@ -38,8 +38,8 @@ public class Bootstrap {
                 ObjectMapperConfig.objectMapperConfig().jackson2ObjectMapperFactory((cls, charset) -> objectMapper)
             );
         citizenUser = userService.authenticateUser(
-            aatConfiguration.getTestCitizenUser().getUsername(),
-            aatConfiguration.getTestCitizenUser().getPassword()
+            aatConfiguration.getSmokeTestCitizen().getUsername(),
+            aatConfiguration.getSmokeTestCitizen().getPassword()
         );
     }
 

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/FunctionalTestsUsers.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/FunctionalTestsUsers.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.cmc.claimstore.tests.functional;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.cmc.claimstore.idam.models.User;
+import uk.gov.hmcts.cmc.claimstore.tests.idam.IdamTestService;
+
+import javax.annotation.PostConstruct;
+
+@Lazy
+@Component
+public class FunctionalTestsUsers {
+
+    private final IdamTestService idamTestService;
+
+    private User claimant;
+
+    public FunctionalTestsUsers(IdamTestService idamTestService) {
+        this.idamTestService = idamTestService;
+    }
+
+    @PostConstruct
+    public void initialize() {
+        claimant = idamTestService.createCitizen();
+    }
+
+    public User getClaimant() {
+        return claimant;
+    }
+
+}

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
@@ -18,8 +18,8 @@ public class LinkDefendantTest extends BaseTest {
     @Test
     public void shouldBeAbleToSuccessfullyLinkDefendant() {
         Claim createdCase = commonOperations.submitClaim(
-            bootstrap.getCitizenUser().getAuthorisation(),
-            bootstrap.getCitizenUser().getUserDetails().getId()
+            bootstrap.getSmokeTestCitizen().getAuthorisation(),
+            bootstrap.getSmokeTestCitizen().getUserDetails().getId()
         );
 
         User defendant = idamTestService.createCitizen();

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
@@ -22,7 +22,7 @@ public class LinkDefendantTest extends BaseTest {
             bootstrap.getCitizenUser().getUserDetails().getId()
         );
 
-        User defendant = idamTestService.createDefendant();
+        User defendant = idamTestService.createCitizen();
 
         Claim claim = linkDefendant(defendant, createdCase.getExternalId())
             .then()
@@ -35,7 +35,7 @@ public class LinkDefendantTest extends BaseTest {
 
     @Test
     public void shouldReturnNotFoundResponseWhenGivenInvalidClaimExternalReference() {
-        User defendant = idamTestService.createDefendant();
+        User defendant = idamTestService.createCitizen();
 
         String invalidCaseReference = UUID.randomUUID().toString();
 

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.cmc.claimstore.tests.functional;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -15,11 +17,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LinkDefendantTest extends BaseTest {
 
+    private User claimant;
+
+    @Before
+    public void beforeEachTest() {
+        claimant = idamTestService.createCitizen();
+    }
+
     @Test
     public void shouldBeAbleToSuccessfullyLinkDefendant() {
         Claim createdCase = commonOperations.submitClaim(
-            bootstrap.getSmokeTestCitizen().getAuthorisation(),
-            bootstrap.getSmokeTestCitizen().getUserDetails().getId()
+            claimant.getAuthorisation(),
+            claimant.getUserDetails().getId()
         );
 
         User defendant = idamTestService.createCitizen();

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
@@ -2,9 +2,8 @@ package uk.gov.hmcts.cmc.claimstore.tests.functional;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.cmc.claimstore.idam.models.User;
@@ -17,18 +16,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LinkDefendantTest extends BaseTest {
 
-    private User claimant;
-
-    @Before
-    public void beforeEachTest() {
-        claimant = idamTestService.createCitizen();
-    }
+    @Autowired
+    private FunctionalTestsUsers functionalTestsUsers;
 
     @Test
     public void shouldBeAbleToSuccessfullyLinkDefendant() {
         Claim createdCase = commonOperations.submitClaim(
-            claimant.getAuthorisation(),
-            claimant.getUserDetails().getId()
+            functionalTestsUsers.getClaimant().getAuthorisation(),
+            functionalTestsUsers.getClaimant().getUserDetails().getId()
         );
 
         User defendant = idamTestService.createCitizen();

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RequestCountyCourtJudgementTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RequestCountyCourtJudgementTest.java
@@ -2,12 +2,11 @@ package uk.gov.hmcts.cmc.claimstore.tests.functional;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
-import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import uk.gov.hmcts.cmc.claimstore.idam.models.User;
 import uk.gov.hmcts.cmc.claimstore.tests.BaseTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
@@ -22,18 +21,14 @@ import static org.assertj.core.api.Assertions.within;
 
 public class RequestCountyCourtJudgementTest extends BaseTest {
 
-    private User claimant;
-
-    @Before
-    public void beforeEachTest() {
-        claimant = idamTestService.createCitizen();
-    }
+    @Autowired
+    private FunctionalTestsUsers functionalTestsUsers;
 
     @Test
     public void shouldBeAbleToSuccessfullyRequestCCJ() {
         Claim createdCase = commonOperations.submitClaim(
-            claimant.getAuthorisation(),
-            claimant.getUserDetails().getId()
+            functionalTestsUsers.getClaimant().getAuthorisation(),
+            functionalTestsUsers.getClaimant().getUserDetails().getId()
         );
 
         updateResponseDeadlineToEnableCCJ(createdCase.getReferenceNumber());
@@ -56,8 +51,8 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
     @Test
     public void shouldReturnUnprocessableEntityWhenInvalidJudgementIsSubmitted() {
         Claim createdCase = commonOperations.submitClaim(
-            claimant.getAuthorisation(),
-            claimant.getUserDetails().getId()
+            functionalTestsUsers.getClaimant().getAuthorisation(),
+            functionalTestsUsers.getClaimant().getUserDetails().getId()
         );
 
         updateResponseDeadlineToEnableCCJ(createdCase.getReferenceNumber());
@@ -74,8 +69,8 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
     @Test
     public void shouldNotBeAllowedToRequestCCJWhenResponseDeadlineHasNotPassed() {
         Claim createdCase = commonOperations.submitClaim(
-            claimant.getAuthorisation(),
-            claimant.getUserDetails().getId()
+            functionalTestsUsers.getClaimant().getAuthorisation(),
+            functionalTestsUsers.getClaimant().getUserDetails().getId()
         );
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
@@ -91,7 +86,7 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
         return RestAssured
             .given()
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header(HttpHeaders.AUTHORIZATION, claimant.getAuthorisation())
+            .header(HttpHeaders.AUTHORIZATION, functionalTestsUsers.getClaimant().getAuthorisation())
             .body(jsonMapper.toJson(ccj))
             .when()
             .post("/claims/" + externalId + "/county-court-judgment");

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RequestCountyCourtJudgementTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RequestCountyCourtJudgementTest.java
@@ -23,8 +23,8 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
     @Test
     public void shouldBeAbleToSuccessfullyRequestCCJ() {
         Claim createdCase = commonOperations.submitClaim(
-            bootstrap.getCitizenUser().getAuthorisation(),
-            bootstrap.getCitizenUser().getUserDetails().getId()
+            bootstrap.getSmokeTestCitizen().getAuthorisation(),
+            bootstrap.getSmokeTestCitizen().getUserDetails().getId()
         );
 
         updateResponseDeadlineToEnableCCJ(createdCase.getReferenceNumber());
@@ -47,8 +47,8 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
     @Test
     public void shouldReturnUnprocessableEntityWhenInvalidJudgementIsSubmitted() {
         Claim createdCase = commonOperations.submitClaim(
-            bootstrap.getCitizenUser().getAuthorisation(),
-            bootstrap.getCitizenUser().getUserDetails().getId()
+            bootstrap.getSmokeTestCitizen().getAuthorisation(),
+            bootstrap.getSmokeTestCitizen().getUserDetails().getId()
         );
 
         updateResponseDeadlineToEnableCCJ(createdCase.getReferenceNumber());
@@ -65,8 +65,8 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
     @Test
     public void shouldNotBeAllowedToRequestCCJWhenResponseDeadlineHasNotPassed() {
         Claim createdCase = commonOperations.submitClaim(
-            bootstrap.getCitizenUser().getAuthorisation(),
-            bootstrap.getCitizenUser().getUserDetails().getId()
+            bootstrap.getSmokeTestCitizen().getAuthorisation(),
+            bootstrap.getSmokeTestCitizen().getUserDetails().getId()
         );
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
@@ -82,7 +82,7 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
         return RestAssured
             .given()
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header(HttpHeaders.AUTHORIZATION, bootstrap.getCitizenUser().getAuthorisation())
+            .header(HttpHeaders.AUTHORIZATION, bootstrap.getSmokeTestCitizen().getAuthorisation())
             .body(jsonMapper.toJson(ccj))
             .when()
             .post("/claims/" + externalId + "/county-court-judgment");

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
@@ -39,8 +39,8 @@ public class RespondToClaimTest extends BaseTest {
 
     private void shouldBeAbleToSuccessfullySubmit(Response response) {
         Claim createdCase = commonOperations.submitClaim(
-            bootstrap.getCitizenUser().getAuthorisation(),
-            bootstrap.getCitizenUser().getUserDetails().getId()
+            bootstrap.getSmokeTestCitizen().getAuthorisation(),
+            bootstrap.getSmokeTestCitizen().getUserDetails().getId()
         );
 
         User defendant = idamTestService.createCitizen();
@@ -65,8 +65,8 @@ public class RespondToClaimTest extends BaseTest {
     @Test
     public void shouldReturnUnprocessableEntityWhenInvalidResponseIsSubmitted() {
         Claim createdCase = commonOperations.submitClaim(
-            bootstrap.getCitizenUser().getAuthorisation(),
-            bootstrap.getCitizenUser().getUserDetails().getId()
+            bootstrap.getSmokeTestCitizen().getAuthorisation(),
+            bootstrap.getSmokeTestCitizen().getUserDetails().getId()
         );
 
         User defendant = idamTestService.createCitizen();

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.cmc.claimstore.tests.functional;
 
 import io.restassured.RestAssured;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
 public class RespondToClaimTest extends BaseTest {
+
+    private User claimant;
+
+    @Before
+    public void beforeEachTest() {
+        claimant = idamTestService.createCitizen();
+    }
 
     @Test
     public void shouldBeAbleToSuccessfullySubmitDisputeDefence() {
@@ -39,8 +47,8 @@ public class RespondToClaimTest extends BaseTest {
 
     private void shouldBeAbleToSuccessfullySubmit(Response response) {
         Claim createdCase = commonOperations.submitClaim(
-            bootstrap.getSmokeTestCitizen().getAuthorisation(),
-            bootstrap.getSmokeTestCitizen().getUserDetails().getId()
+            claimant.getAuthorisation(),
+            claimant.getUserDetails().getId()
         );
 
         User defendant = idamTestService.createCitizen();
@@ -65,8 +73,8 @@ public class RespondToClaimTest extends BaseTest {
     @Test
     public void shouldReturnUnprocessableEntityWhenInvalidResponseIsSubmitted() {
         Claim createdCase = commonOperations.submitClaim(
-            bootstrap.getSmokeTestCitizen().getAuthorisation(),
-            bootstrap.getSmokeTestCitizen().getUserDetails().getId()
+            claimant.getAuthorisation(),
+            claimant.getUserDetails().getId()
         );
 
         User defendant = idamTestService.createCitizen();

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.cmc.claimstore.tests.functional;
 
 import io.restassured.RestAssured;
-import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -21,12 +21,8 @@ import static org.assertj.core.api.Assertions.within;
 
 public class RespondToClaimTest extends BaseTest {
 
-    private User claimant;
-
-    @Before
-    public void beforeEachTest() {
-        claimant = idamTestService.createCitizen();
-    }
+    @Autowired
+    private FunctionalTestsUsers functionalTestsUsers;
 
     @Test
     public void shouldBeAbleToSuccessfullySubmitDisputeDefence() {
@@ -47,8 +43,8 @@ public class RespondToClaimTest extends BaseTest {
 
     private void shouldBeAbleToSuccessfullySubmit(Response response) {
         Claim createdCase = commonOperations.submitClaim(
-            claimant.getAuthorisation(),
-            claimant.getUserDetails().getId()
+            functionalTestsUsers.getClaimant().getAuthorisation(),
+            functionalTestsUsers.getClaimant().getUserDetails().getId()
         );
 
         User defendant = idamTestService.createCitizen();
@@ -73,8 +69,8 @@ public class RespondToClaimTest extends BaseTest {
     @Test
     public void shouldReturnUnprocessableEntityWhenInvalidResponseIsSubmitted() {
         Claim createdCase = commonOperations.submitClaim(
-            claimant.getAuthorisation(),
-            claimant.getUserDetails().getId()
+            functionalTestsUsers.getClaimant().getAuthorisation(),
+            functionalTestsUsers.getClaimant().getUserDetails().getId()
         );
 
         User defendant = idamTestService.createCitizen();

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
@@ -43,7 +43,7 @@ public class RespondToClaimTest extends BaseTest {
             bootstrap.getCitizenUser().getUserDetails().getId()
         );
 
-        User defendant = idamTestService.createDefendant();
+        User defendant = idamTestService.createCitizen();
 
         commonOperations.linkDefendant(
             createdCase.getExternalId(),
@@ -69,7 +69,7 @@ public class RespondToClaimTest extends BaseTest {
             bootstrap.getCitizenUser().getUserDetails().getId()
         );
 
-        User defendant = idamTestService.createDefendant();
+        User defendant = idamTestService.createCitizen();
 
         commonOperations.linkDefendant(
             createdCase.getExternalId(),

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
@@ -2,10 +2,12 @@ package uk.gov.hmcts.cmc.claimstore.tests.functional;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import uk.gov.hmcts.cmc.claimstore.idam.models.User;
 import uk.gov.hmcts.cmc.claimstore.tests.BaseTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.ClaimData;
@@ -18,6 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
 public class SubmitClaimTest extends BaseTest {
+
+    private User claimant;
+
+    @Before
+    public void beforeEachTest() {
+        claimant = idamTestService.createCitizen();
+    }
 
     @Test
     public void shouldSuccessfullySubmitClaimDataAndReturnCreatedCase() {
@@ -63,10 +72,10 @@ public class SubmitClaimTest extends BaseTest {
         return RestAssured
             .given()
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header(HttpHeaders.AUTHORIZATION, bootstrap.getSmokeTestCitizen().getAuthorisation())
+            .header(HttpHeaders.AUTHORIZATION, claimant.getAuthorisation())
             .body(jsonMapper.toJson(claimData))
             .when()
-            .post("/claims/" + bootstrap.getSmokeTestCitizen().getUserDetails().getId());
+            .post("/claims/" + claimant.getUserDetails().getId());
     }
 
 }

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
@@ -63,10 +63,10 @@ public class SubmitClaimTest extends BaseTest {
         return RestAssured
             .given()
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header(HttpHeaders.AUTHORIZATION, bootstrap.getCitizenUser().getAuthorisation())
+            .header(HttpHeaders.AUTHORIZATION, bootstrap.getSmokeTestCitizen().getAuthorisation())
             .body(jsonMapper.toJson(claimData))
             .when()
-            .post("/claims/" + bootstrap.getCitizenUser().getUserDetails().getId());
+            .post("/claims/" + bootstrap.getSmokeTestCitizen().getUserDetails().getId());
     }
 
 }

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
@@ -2,12 +2,11 @@ package uk.gov.hmcts.cmc.claimstore.tests.functional;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
-import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import uk.gov.hmcts.cmc.claimstore.idam.models.User;
 import uk.gov.hmcts.cmc.claimstore.tests.BaseTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.ClaimData;
@@ -21,12 +20,8 @@ import static org.assertj.core.api.Assertions.within;
 
 public class SubmitClaimTest extends BaseTest {
 
-    private User claimant;
-
-    @Before
-    public void beforeEachTest() {
-        claimant = idamTestService.createCitizen();
-    }
+    @Autowired
+    private FunctionalTestsUsers functionalTestsUsers;
 
     @Test
     public void shouldSuccessfullySubmitClaimDataAndReturnCreatedCase() {
@@ -72,10 +67,10 @@ public class SubmitClaimTest extends BaseTest {
         return RestAssured
             .given()
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header(HttpHeaders.AUTHORIZATION, claimant.getAuthorisation())
+            .header(HttpHeaders.AUTHORIZATION, functionalTestsUsers.getClaimant().getAuthorisation())
             .body(jsonMapper.toJson(claimData))
             .when()
-            .post("/claims/" + claimant.getUserDetails().getId());
+            .post("/claims/" + functionalTestsUsers.getClaimant().getUserDetails().getId());
     }
 
 }

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/helpers/TestData.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/helpers/TestData.java
@@ -30,7 +30,7 @@ public class TestData {
     }
 
     public String nextUserEmail() {
-        return format(aatConfiguration.getTestUserEmailPattern(), RandomStringUtils.randomAlphanumeric(10));
+        return format(aatConfiguration.getGeneratedUserEmailPattern(), RandomStringUtils.randomAlphanumeric(10));
     }
 
 }

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
@@ -28,7 +28,7 @@ public class IdamTestService {
         this.aatConfiguration = aatConfiguration;
     }
 
-    public User createDefendant() {
+    public User createCitizen() {
         String email = testData.nextUserEmail();
         idamTestApi.createUser(createDefendantRequest(email, aatConfiguration.getSmokeTestCitizen().getPassword()));
         return userService.authenticateUser(email, aatConfiguration.getSmokeTestCitizen().getPassword());

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
@@ -30,8 +30,8 @@ public class IdamTestService {
 
     public User createDefendant() {
         String email = testData.nextUserEmail();
-        idamTestApi.createUser(createDefendantRequest(email, aatConfiguration.getTestCitizenUser().getPassword()));
-        return userService.authenticateUser(email, aatConfiguration.getTestCitizenUser().getPassword());
+        idamTestApi.createUser(createDefendantRequest(email, aatConfiguration.getSmokeTestCitizen().getPassword()));
+        return userService.authenticateUser(email, aatConfiguration.getSmokeTestCitizen().getPassword());
     }
 
     private CreateUserRequest createDefendantRequest(String username, String password) {

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/smoke/RetrieveCaseTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/smoke/RetrieveCaseTest.java
@@ -16,18 +16,18 @@ public class RetrieveCaseTest extends BaseTest {
 
     @Test
     public void shouldBeAbleToRetrieveCasesBySubmitterId() {
-        testCasesRetrievalFor("/claims/claimant/" + bootstrap.getCitizenUser().getUserDetails().getId());
+        testCasesRetrievalFor("/claims/claimant/" + bootstrap.getSmokeTestCitizen().getUserDetails().getId());
     }
 
     @Test
     public void shouldBeAbleToRetrieveCasesByDefendantId() {
-        testCasesRetrievalFor("/claims/defendant/" + bootstrap.getCitizenUser().getUserDetails().getId());
+        testCasesRetrievalFor("/claims/defendant/" + bootstrap.getSmokeTestCitizen().getUserDetails().getId());
     }
 
     private void testCasesRetrievalFor(String uriPath) {
         String response = RestAssured
             .given()
-            .header(HttpHeaders.AUTHORIZATION, bootstrap.getCitizenUser().getAuthorisation())
+            .header(HttpHeaders.AUTHORIZATION, bootstrap.getSmokeTestCitizen().getAuthorisation())
             .when()
             .get(uriPath)
             .then()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,9 +101,8 @@ claim-store:
 spring:
   profiles: 'aat'
 
-aat:
-  test-instance-uri: "${TEST_URL:}"
-  test-citizen-user:
-    password: "${AAT_TEST_USER_PASSWORD:}"
-  test-solicitor-user:
-    password: "${AAT_TEST_USER_PASSWORD:}"
+test-instance-uri: "${TEST_URL:}"
+smoke-test-citizen:
+  password: "${SMOKE_TEST_USER_PASSWORD:}"
+smoke-test-solicitor:
+  password: "${SMOKE_TEST_USER_PASSWORD:}"


### PR DESCRIPTION
### Change description ###

- renames environment variables used by automated tests,
- ensures functional tests claimant user is created only once for all functional tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
