### PR TITLE
ROC-3268 Save defendant and letter holder id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ java-rpm-packaging/
 
 .sonarlint
 .scannerwork
+.testcontainers*

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/CCDCase.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/CCDCase.java
@@ -16,6 +16,8 @@ public class CCDCase {
     private Long id;
     private String referenceNumber;
     private String submitterId;
+    private String letterHolderId;
+    private String defendantId;
     private String submittedOn;
     private String externalId;
     private String issuedOn;

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/CaseEvent.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/CaseEvent.java
@@ -13,7 +13,8 @@ public enum CaseEvent {
     OFFER_ACCEPTED_BY_DEFENDANT("OfferAcceptedByDefendant"),
     OFFER_MADE_BY_CLAIMANT("OfferMadeByClaimant"),
     OFFER_MADE_BY_DEFENDANT("OfferMadeByDefendant"),
-    SETTLED_PRE_JUDGMENT("SettledPreJudgment");
+    SETTLED_PRE_JUDGMENT("SettledPreJudgment"),
+    LINK_DEFENDANT("LinkDefendant");
 
     private String value;
 

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapper.java
@@ -62,6 +62,14 @@ public class CaseMapper implements Mapper<CCDCase, Claim> {
             builder.settlementReachedAt(claim.getSettlementReachedAt());
         }
 
+        if (claim.getLetterHolderId() != null) {
+            builder.letterHolderId(claim.getLetterHolderId());
+        }
+
+        if (claim.getDefendantId() != null) {
+            builder.defendantId(claim.getDefendantId());
+        }
+
         return builder
             .id(claim.getId())
             .externalId(claim.getExternalId())
@@ -98,15 +106,15 @@ public class CaseMapper implements Mapper<CCDCase, Claim> {
         return new Claim(
             ccdCase.getId(),
             ccdCase.getSubmitterId(),
-            null,
-            null,
+            ccdCase.getLetterHolderId(),
+            ccdCase.getDefendantId(),
             ccdCase.getExternalId(),
             ccdCase.getReferenceNumber(),
             claimMapper.from(ccdCase.getClaimData()),
             LocalDateTime.parse(ccdCase.getSubmittedOn(), ISO_DATE_TIME),
             LocalDate.parse(ccdCase.getIssuedOn(), ISO_DATE),
             ccdCase.getResponseDeadline(),
-            ccdCase.getMoreTimeRequested() == YES ? true : false,
+            ccdCase.getMoreTimeRequested() == YES,
             ccdCase.getSubmitterEmail(),
             ccdCase.getRespondedAt(),
             response,

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/LinkDefendantTest.java
@@ -10,7 +10,7 @@ import uk.gov.hmcts.cmc.claimstore.idam.models.User;
 import uk.gov.hmcts.cmc.claimstore.tests.BaseTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 
-import static uk.gov.hmcts.cmc.ccd.assertion.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LinkDefendantTest extends BaseTest {
 
@@ -28,7 +28,7 @@ public class LinkDefendantTest extends BaseTest {
             claimant.getUserDetails().getId()
         );
 
-        User defendant = idamTestService.createDefendant(claimant.getUserDetails().getId());
+        User defendant = idamTestService.createDefendant(claim.getLetterHolderId());
 
         linkDefendant(defendant)
             .then()
@@ -46,7 +46,7 @@ public class LinkDefendantTest extends BaseTest {
             .and()
             .extract().body().as(Claim.class);
 
-        assertThat(claim).isEqualTo(response);
+        assertThat(response.getDefendantId()).isEqualTo(defendant.getUserDetails().getId());
     }
 
     private Response linkDefendant(User defendant) {

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
@@ -49,7 +49,7 @@ public class RespondToClaimTest extends BaseTest {
             claimantId
         );
 
-        User defendant = idamTestService.createDefendant(claimantId);
+        User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         commonOperations.linkDefendant(defendant.getAuthorisation());
 
         Claim updatedCase = commonOperations.submitResponse(response, createdCase.getExternalId(), defendant)
@@ -71,7 +71,7 @@ public class RespondToClaimTest extends BaseTest {
             claimantId
         );
 
-        User defendant = idamTestService.createDefendant(claimantId);
+        User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         commonOperations.linkDefendant(defendant.getAuthorisation());
 
         Response invalidResponse = SampleResponse.FullDefence.builder()

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SettlementOfferTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SettlementOfferTest.java
@@ -36,7 +36,7 @@ public class SettlementOfferTest extends BaseTest {
             claimantId
         );
 
-        User defendant = idamTestService.createDefendant(claimantId);
+        User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         Claim updatedCase = createClaimWithResponse(createdCase, defendant);
 
         Offer offer = SampleOffer.validDefaults();
@@ -61,7 +61,7 @@ public class SettlementOfferTest extends BaseTest {
             claimantId
         );
 
-        User defendant = idamTestService.createDefendant(claimantId);
+        User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         Claim updatedCase = createClaimWithResponse(createdCase, defendant);
 
         Offer offer = SampleOffer.validDefaults();
@@ -87,7 +87,7 @@ public class SettlementOfferTest extends BaseTest {
             claimantId
         );
 
-        User defendant = idamTestService.createDefendant(claimantId);
+        User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         Claim updatedCase = createClaimWithResponse(createdCase, defendant);
 
         Offer offer = SampleOffer.validDefaults();
@@ -119,7 +119,7 @@ public class SettlementOfferTest extends BaseTest {
             claimantId
         );
 
-        User defendant = idamTestService.createDefendant(claimantId);
+        User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         Claim updatedCase = createClaimWithResponse(createdCase, defendant);
 
         commonOperations
@@ -136,7 +136,7 @@ public class SettlementOfferTest extends BaseTest {
             claimantId
         );
 
-        User defendant = idamTestService.createDefendant(claimantId);
+        User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         Claim updatedCase = createClaimWithResponse(createdCase, defendant);
 
         Offer offer = SampleOffer.validDefaults();
@@ -168,7 +168,7 @@ public class SettlementOfferTest extends BaseTest {
             claimantId
         );
 
-        User defendant = idamTestService.createDefendant(claimantId);
+        User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         Claim updatedCase = createClaimWithResponse(createdCase, defendant);
 
         commonOperations
@@ -185,7 +185,7 @@ public class SettlementOfferTest extends BaseTest {
             claimantId
         );
 
-        User defendant = idamTestService.createDefendant(claimantId);
+        User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
 
         Claim caseWithCounterSign = countersignAnOffer(createdCase, defendant);
 
@@ -232,7 +232,7 @@ public class SettlementOfferTest extends BaseTest {
             claimantId
         );
 
-        User defendant = idamTestService.createDefendant(claimantId);
+        User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
 
         Claim updatedCase = countersignAnOffer(createdCase, defendant);
 
@@ -250,7 +250,7 @@ public class SettlementOfferTest extends BaseTest {
             claimantId
         );
 
-        User defendant = idamTestService.createDefendant(claimantId);
+        User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
 
         Claim updatedCase = countersignAnOffer(createdCase, defendant);
 

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
@@ -43,10 +43,7 @@ public class IdamTestService {
         return userService.authenticateUser(email, aatConfiguration.getSmokeTestCitizen().getPassword());
     }
 
-    public User createDefendant(final String hackHackHackClaimantId) {
-        // HACK no way to know the letter holder ID currently so we pray claimantId + 1 works for now
-        String letterHolderId = String.valueOf(Integer.valueOf(hackHackHackClaimantId) + 1);
-
+    public User createDefendant(final String letterHolderId) {
         String email = testData.nextUserEmail();
         String password = aatConfiguration.getSmokeTestCitizen().getPassword();
         idamTestApi.createUser(createCitizenRequest(email, password));


### PR DESCRIPTION
Tests were failing on AAT because of the letter holder ID + 1, it was decided that we will save the letter holder and defendant ID now until a better CCD API is available

Spreadsheet changes:
https://github.com/hmcts/cmc-integration-tests/pull/153