### PR TITLE
Fix logstream filtering

### DIFF
--- a/web.config
+++ b/web.config
@@ -5,7 +5,7 @@
       <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
     </handlers>
     <httpPlatform stdoutLogEnabled="true"
-                  stdoutLogFile="%HOME%\LogFiles\stdout"
+                  stdoutLogFile="%HOME%\LogFiles\application\stdout"
                   processPath="%JAVA_HOME%\bin\java.exe"
         arguments="-Djava.net.preferIPv4Stack=true -Dserver.port=%HTTP_PLATFORM_PORT% -jar &quot;%HOME%\site\wwwroot\claim-store.jar&quot;">
     </httpPlatform>


### PR DESCRIPTION
This allows hitting logstream via curl and just showing application logs
```
[timj@reformMgmtDevBastion02 ~]$ curl -k -utimja https://cmc-claim-store-aat.scm.service.core-compute-aat.internal/api/logstream/application
Enter host password for user 'timja':
2018-03-08T09:02:03  Welcome, you are now connected to log-streaming service.


2018-03-08T09:03:03  No new trace in the past 1 min(s).
2018-03-08T09:04:03  No new trace in the past 2 min(s).
AI: INFO 08-03-2018 09:04, 1: Configuration file has been successfully found as resource
AI: INFO 08-03-2018 09:04, 1: Configuration file has been successfully found as resource
```

https://github.com/projectkudu/kudu/wiki/Diagnostic-Log-Stream

Tested via modifying web.config in kudu