### PR TITLE
Fix NullPointerException

### DIFF
--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/HousingDisrepairMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/HousingDisrepairMapper.java
@@ -23,7 +23,8 @@ public class HousingDisrepairMapper implements Mapper<CCDHousingDisrepair, Housi
         }
 
         DamagesExpectation costOfRepairs = DamagesExpectation.valueOf(ccdHousingDisrepair.getCostOfRepairsDamages());
-        DamagesExpectation otherDamages = DamagesExpectation.valueOf(ccdHousingDisrepair.getOtherDamages());
+        String ccdOtherDamages = ccdHousingDisrepair.getOtherDamages();
+        DamagesExpectation otherDamages = ccdOtherDamages != null ? DamagesExpectation.valueOf(ccdOtherDamages) : null;
         return new HousingDisrepair(costOfRepairs, otherDamages);
     }
 }


### PR DESCRIPTION
This PR fixes the NullPointerException which occurs when user selects HousingDisrepair and no other damages are claimed.

> claim-store-api_1                      | Caused by: java.lang.NullPointerException: Name is null
claim-store-api_1                      |     at java.lang.Enum.valueOf(Enum.java:236)
claim-store-api_1                      |     at uk.gov.hmcts.cmc.domain.models.particulars.DamagesExpectation.valueOf(DamagesExpectation.java:5)
claim-store-api_1                      |     at uk.gov.hmcts.cmc.ccd.mapper.HousingDisrepairMapper.from(HousingDisrepairMapper.java:26)
claim-store-api_1                      |     at uk.gov.hmcts.cmc.ccd.mapper.ClaimMapper.from(ClaimMapper.java:125)
claim-store-api_1                      |     at uk.gov.hmcts.cmc.ccd.mapper.CaseMapper.from(CaseMapper.java:113)
claim-store-api_1                      |     at uk.gov.hmcts.cmc.claimstore.services.ccd.CoreCaseDataService.extractClaim(CoreCaseDataService.java:206)
claim-store-api_1                      |     at uk.gov.hmcts.cmc.claimstore.services.ccd.CoreCaseDataService.save(CoreCaseDataService.java:97)
claim-store-api_1                      |     at uk.gov.hmcts.cmc.claimstore.services.search.CCDCaseRepository.saveClaim(CCDCaseRepository.java:106)
claim-store-api_1                      |     at uk.gov.hmcts.cmc.claimstore.services.ClaimService.saveClaim(ClaimService.java:131)