### PR TITLE
Stop using payment amount from payment object as it is deprecated

### DIFF
--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
@@ -15,7 +15,7 @@ import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 public class Payment {
     private final String id;
     /**
-     * The amount which was paid, in pennies regardless payments v1 or payments v2 is used.
+     * The amount which was paid, in pennies for payments v1 or pounds with payments v2.
      */
     @NotNull
     private final BigDecimal amount;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.cmc.domain.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
@@ -10,7 +9,6 @@ import java.math.BigDecimal;
 import java.util.Objects;
 import javax.validation.constraints.NotNull;
 
-import static uk.gov.hmcts.cmc.domain.utils.MonetaryConversions.penniesToPounds;
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @JsonIgnoreProperties(value = {"description", "state"})
@@ -47,11 +45,6 @@ public class Payment {
 
     public BigDecimal getAmount() {
         return amount;
-    }
-
-    @JsonIgnore
-    public BigDecimal getAmountInPounds() {
-        return penniesToPounds(amount);
     }
 
     public String getReference() {

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
@@ -15,7 +15,7 @@ import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 public class Payment {
     private final String id;
     /**
-     * The amount which was paid, in pennies for payments v1 or pounds with payments v2.
+     * The amount which was paid, in pennies regardless payments v1 or payments v2 is used.
      */
     @NotNull
     private final BigDecimal amount;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimDataContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimDataContentProvider.java
@@ -39,7 +39,7 @@ public class ClaimDataContentProvider {
 
         List<BigDecimal> totalAmountComponents = new ArrayList<>();
         totalAmountComponents.add(((AmountBreakDown) claim.getClaimData().getAmount()).getTotalAmount());
-        totalAmountComponents.add(claim.getClaimData().getPayment().getAmountInPounds());
+        totalAmountComponents.add(claim.getClaimData().getFeesPaidInPound());
 
         InterestContent interestContent = null;
         if (!claim.getClaimData().getInterest().getType().equals(Interest.InterestType.NO_INTEREST)) {
@@ -68,7 +68,7 @@ public class ClaimDataContentProvider {
             formatDate(claim.getIssuedOn()),
             claim.getClaimData().getReason(),
             formatMoney(((AmountBreakDown) claim.getClaimData().getAmount()).getTotalAmount()),
-            formatMoney(claim.getClaimData().getPayment().getAmountInPounds()),
+            formatMoney(claim.getClaimData().getFeesPaidInPound()),
             interestContent,
             formatMoney(
                 totalAmountComponents.stream()

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/DefendantPinLetterContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/DefendantPinLetterContentProvider.java
@@ -43,8 +43,7 @@ public class DefendantPinLetterContentProvider {
             .getAmount())
             .getTotalAmount());
         totalAmountComponents.add(claim.getClaimData()
-            .getPayment()
-            .getAmountInPounds());
+            .getFeesPaidInPound());
 
         if (!claim.getClaimData()
             .getInterest()


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-3059

### Change description ###

Amount value from payment object now will contain either pennies or pounds. We cannot relay on it anymore and it will be removed in the future completely. Instead we should relay on `ClaimData#feeAmountInPennies` which can be transformed into pounds. That PR uses `feeAmountInPennies` for PDF's

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```