### PR TITLE
Relax time assertions

### DIFF
--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RequestCountyCourtJudgementTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RequestCountyCourtJudgementTest.java
@@ -51,7 +51,7 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
 
         assertThat(updatedCase.getCountyCourtJudgment()).isEqualTo(ccj);
         assertThat(updatedCase.getCountyCourtJudgmentRequestedAt())
-            .isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS));
+            .isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.MINUTES));
     }
 
     @Test

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
@@ -60,7 +60,7 @@ public class RespondToClaimTest extends BaseTest {
 
         assertThat(updatedCase.getResponse().isPresent()).isTrue();
         assertThat(updatedCase.getResponse().get()).isEqualTo(response);
-        assertThat(updatedCase.getRespondedAt()).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS));
+        assertThat(updatedCase.getRespondedAt()).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.MINUTES));
     }
 
     @Test

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SettlementOfferTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SettlementOfferTest.java
@@ -193,7 +193,7 @@ public class SettlementOfferTest extends BaseTest {
         assertThat(caseWithCounterSign.getSettlement().get().getPartyStatements().size()).isEqualTo(3);
 
         assertThat(caseWithCounterSign.getSettlementReachedAt())
-            .isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS));
+            .isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.MINUTES));
     }
 
     private Claim countersignAnOffer(Claim createdCase, User defendant) {

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
@@ -45,7 +45,7 @@ public class SubmitClaimTest extends BaseTest {
             .extract().body().as(Claim.class);
 
         assertThat(claimData).isEqualTo(createdCase.getClaimData());
-        assertThat(createdCase.getCreatedAt()).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS));
+        assertThat(createdCase.getCreatedAt()).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.MINUTES));
     }
 
     @Test


### PR DESCRIPTION
### Change description ###

We've noticed quite high delays on AAT environment (~40 seconds), relaxing time related assertions to accommodate for this.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
