### PR TITLE
Remove 404 from root

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/RootTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/RootTest.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.cmc.claimstore.controllers;
+
+import org.junit.Test;
+import uk.gov.hmcts.cmc.claimstore.BaseIntegrationTest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class RootTest extends BaseIntegrationTest {
+
+    @Test
+    public void root() throws Exception {
+        webClient.perform(get("/"))
+            .andExpect(status().isOk());
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/RootController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/RootController.java
@@ -4,9 +4,6 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Collections;
-import java.util.Map;
-
 @RestController
 public class RootController {
 
@@ -15,8 +12,8 @@ public class RootController {
      * Application insights registers that as a 404 and adds it as an exception,
      * This is here to reduce the noise
      */
-    @GetMapping(value = "/", consumes = MediaType.ALL_VALUE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public Map root() {
-        return Collections.singletonMap("hello", "world!");
+    @GetMapping(value = "/", consumes = MediaType.ALL_VALUE)
+    public void root() {
+        // Only used for returning a 200 on /
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/RootController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/RootController.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.cmc.claimstore.controllers;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.Map;
+
+@RestController
+public class RootController {
+
+    /*
+     * Azure hits us on / every 5 seconds to prevent it sleeping the application
+     * Application insights registers that as a 404 and adds it as an exception,
+     * This is here to reduce the noise
+     */
+    @GetMapping(value = "/", consumes = MediaType.ALL_VALUE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public Map root() {
+        return Collections.singletonMap("hello", "world!");
+    }
+}


### PR DESCRIPTION
Application insights was registering lots of failures because of the
azure keep alive which hits the app every 5 seconds on / (its not
configurable)