### PR TITLE
Fix error when evidence is not provided

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimDataContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimDataContentProvider.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.cmc.domain.models.legalrep.StatementOfTruth;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -68,8 +69,10 @@ public class ClaimDataContentProvider {
         List<EvidenceContent> evidences = null;
         Optional<Evidence> evidence = claim.getClaimData().getEvidence();
         if (evidence.isPresent()) {
-            evidences = evidence.get().getRows()
+            evidences = Optional.ofNullable(evidence.get().getRows())
+                .orElseGet(Collections::emptyList)
                 .stream()
+                .filter(Objects::nonNull)
                 .map(e -> new EvidenceContent(e.getType().getDescription(), e.getDescription().orElse(null)))
                 .collect(Collectors.toList());
         }


### PR DESCRIPTION
This PR fixes the below error in case no evidence was provided.

```
claim-store-api_1                      | 2018-03-20T13:45:22.921+0000 ERROR [http-nio-4400-exec-2] uk.gov.hmcts.cmc.claimstore.controllers.advices.ResourceExceptionHandler:41: null
claim-store-api_1                      |     at uk.gov.hmcts.cmc.claimstore.documents.ClaimDataContentProvider.createContent(ClaimDataContentProvider.java:72)
claim-store-api_1                      |     at uk.gov.hmcts.cmc.claimstore.documents.ClaimContentProvider.createContent(ClaimContentProvider.java:58)
claim-store-api_1
```