### PR TITLE
Set interest to 0 if not calculating

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/InterestContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/InterestContentProvider.java
@@ -72,9 +72,6 @@ public class InterestContentProvider {
         boolean customInterestDate = interestDate.getType().equals(InterestDate.InterestDateType.CUSTOM);
         LocalDate fromDate;
         String interestDateReason = null;
-        BigDecimal amountUpToNowRealValue;
-        String amountUpToNow;
-        LocalDate endDate;
         if (customInterestDate) {
             fromDate = interestDate.getDate();
             interestDateReason = interestDate.getReason();
@@ -82,12 +79,15 @@ public class InterestContentProvider {
             fromDate = issuedOn;
         }
 
+        LocalDate endDate;
         if (interestDate.getEndDateType() == SUBMISSION) {
             endDate = issuedOn;
         } else {
             endDate = interestEndDate;
         }
 
+        BigDecimal amountUpToNowRealValue;
+        String amountUpToNow;
         if (!fromDate.isAfter(LocalDateTimeFactory.nowInLocalZone().toLocalDate())) {
             amountUpToNowRealValue = interestCalculationService.calculateInterestUpToDate(
                 claimAmount, interest.getRate(), fromDate, endDate

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/InterestContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/InterestContentProvider.java
@@ -69,8 +69,8 @@ public class InterestContentProvider {
         boolean customInterestDate = interestDate.getType().equals(InterestDate.InterestDateType.CUSTOM);
         LocalDate fromDate;
         String interestDateReason = null;
-        BigDecimal amountUpToNowRealValue = null;
-        String amountUpToNow = null;
+        BigDecimal amountUpToNowRealValue;
+        String amountUpToNow;
         if (customInterestDate) {
             fromDate = interestDate.getDate();
             interestDateReason = interestDate.getReason();
@@ -82,8 +82,10 @@ public class InterestContentProvider {
             amountUpToNowRealValue = interestCalculationService.calculateInterestUpToNow(
                 claimAmount, interest.getRate(), fromDate
             );
-            amountUpToNow = formatMoney(amountUpToNowRealValue);
+        } else {
+            amountUpToNowRealValue = BigDecimal.ZERO;
         }
+        amountUpToNow = formatMoney(amountUpToNowRealValue);
 
         BigDecimal dailyAmount = interestCalculationService.calculateDailyAmountFor(claimAmount, interest.getRate());
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/InterestProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/InterestProviderTest.java
@@ -149,11 +149,11 @@ public class InterestProviderTest {
     }
 
     @Test
-    public void amountUpToNowShouldBeNullWhenSubmissionDateIsUsed() {
+    public void amountUpToNowShouldBeZeroWhenSubmissionDateIsUsed() {
         InterestContent content = provider.createContent(interest, issuedOnDate(), claimAmount, issuedOn, issuedOn);
 
-        assertThat(content.getAmount()).isNull();
-        assertThat(content.getAmountRealValue()).isNull();
+        assertThat(content.getAmount()).isEqualTo("£0.00");
+        assertThat(content.getAmountRealValue()).isEqualTo(BigDecimal.ZERO);
     }
 
     @Test


### PR DESCRIPTION
This happens when issue date is in the future
Prevents empty field from showing in the pdf amount total section