### PR TITLE
Use UTC for checking timestamps

### DIFF
--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/utils/LocalDateTimeFactory.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/utils/LocalDateTimeFactory.java
@@ -19,4 +19,8 @@ public class LocalDateTimeFactory {
     public static LocalDateTime nowInLocalZone() {
         return LocalDateTime.now(LOCAL_ZONE);
     }
+
+    public static LocalDateTime nowInUTC() {
+        return LocalDateTime.now(UTC_ZONE);
+    }
 }

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RequestCountyCourtJudgementTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RequestCountyCourtJudgementTest.java
@@ -12,9 +12,9 @@ import uk.gov.hmcts.cmc.claimstore.tests.BaseTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleCountyCourtJudgment;
+import uk.gov.hmcts.cmc.domain.utils.LocalDateTimeFactory;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,7 +51,7 @@ public class RequestCountyCourtJudgementTest extends BaseTest {
 
         assertThat(updatedCase.getCountyCourtJudgment()).isEqualTo(ccj);
         assertThat(updatedCase.getCountyCourtJudgmentRequestedAt())
-            .isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.MINUTES));
+            .isCloseTo(LocalDateTimeFactory.nowInUTC(), within(2, ChronoUnit.MINUTES));
     }
 
     @Test

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
@@ -9,8 +9,8 @@ import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.FullDefenceResponse;
 import uk.gov.hmcts.cmc.domain.models.Response;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
+import uk.gov.hmcts.cmc.domain.utils.LocalDateTimeFactory;
 
-import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,7 +60,7 @@ public class RespondToClaimTest extends BaseTest {
 
         assertThat(updatedCase.getResponse().isPresent()).isTrue();
         assertThat(updatedCase.getResponse().get()).isEqualTo(response);
-        assertThat(updatedCase.getRespondedAt()).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.MINUTES));
+        assertThat(updatedCase.getRespondedAt()).isCloseTo(LocalDateTimeFactory.nowInUTC(), within(2, ChronoUnit.MINUTES));
     }
 
     @Test

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/RespondToClaimTest.java
@@ -60,7 +60,8 @@ public class RespondToClaimTest extends BaseTest {
 
         assertThat(updatedCase.getResponse().isPresent()).isTrue();
         assertThat(updatedCase.getResponse().get()).isEqualTo(response);
-        assertThat(updatedCase.getRespondedAt()).isCloseTo(LocalDateTimeFactory.nowInUTC(), within(2, ChronoUnit.MINUTES));
+        assertThat(updatedCase.getRespondedAt()).isCloseTo(LocalDateTimeFactory.nowInUTC(),
+            within(2, ChronoUnit.MINUTES));
     }
 
     @Test

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SettlementOfferTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SettlementOfferTest.java
@@ -12,8 +12,8 @@ import uk.gov.hmcts.cmc.domain.models.offers.MadeBy;
 import uk.gov.hmcts.cmc.domain.models.offers.Offer;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
 import uk.gov.hmcts.cmc.domain.models.sampledata.offers.SampleOffer;
+import uk.gov.hmcts.cmc.domain.utils.LocalDateTimeFactory;
 
-import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -193,7 +193,7 @@ public class SettlementOfferTest extends BaseTest {
         assertThat(caseWithCounterSign.getSettlement().get().getPartyStatements().size()).isEqualTo(3);
 
         assertThat(caseWithCounterSign.getSettlementReachedAt())
-            .isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.MINUTES));
+            .isCloseTo(LocalDateTimeFactory.nowInUTC(), within(2, ChronoUnit.MINUTES));
     }
 
     private Claim countersignAnOffer(Claim createdCase, User defendant) {

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
@@ -45,7 +45,8 @@ public class SubmitClaimTest extends BaseTest {
             .extract().body().as(Claim.class);
 
         assertThat(claimData).isEqualTo(createdCase.getClaimData());
-        assertThat(createdCase.getCreatedAt()).isCloseTo(LocalDateTimeFactory.nowInUTC(), within(2, ChronoUnit.MINUTES));
+        assertThat(createdCase.getCreatedAt()).isCloseTo(LocalDateTimeFactory.nowInUTC(),
+            within(2, ChronoUnit.MINUTES));
     }
 
     @Test

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/SubmitClaimTest.java
@@ -15,8 +15,8 @@ import uk.gov.hmcts.cmc.domain.models.TimelineEvent;
 import uk.gov.hmcts.cmc.domain.models.evidence.EvidenceRow;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleEvidence;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleTimeline;
+import uk.gov.hmcts.cmc.domain.utils.LocalDateTimeFactory;
 
-import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
@@ -45,7 +45,7 @@ public class SubmitClaimTest extends BaseTest {
             .extract().body().as(Claim.class);
 
         assertThat(claimData).isEqualTo(createdCase.getClaimData());
-        assertThat(createdCase.getCreatedAt()).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.MINUTES));
+        assertThat(createdCase.getCreatedAt()).isCloseTo(LocalDateTimeFactory.nowInUTC(), within(2, ChronoUnit.MINUTES));
     }
 
     @Test


### PR DESCRIPTION
Builds are currently failing on jenkins during functional tests because of the DST change