### PR TITLE
Cleanup counter sign notifications test

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/services/citizen/SettlementReachedCitizenNotificationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/services/citizen/SettlementReachedCitizenNotificationTest.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import static java.lang.String.format;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,23 +36,19 @@ public class SettlementReachedCitizenNotificationTest extends BaseOfferTest {
         defendantRequestFor("countersign");
 
         verify(notificationClient).sendEmail(
-            eq(OFFER_COUNTER_SIGNED_EMAIL_TO_ORIGINATOR),
-            eq(claim.getDefendantEmail()),
-            eq(counterSignedByDefendantEmailData()),
-            eq(
-                NotificationReferenceBuilder.AgreementCounterSigned
-                    .referenceForDefendant(claim.getReferenceNumber(), DEFENDANT.name())
-            )
+            OFFER_COUNTER_SIGNED_EMAIL_TO_ORIGINATOR,
+            claim.getDefendantEmail(),
+            counterSignedByDefendantEmailData(),
+            NotificationReferenceBuilder.AgreementCounterSigned
+                .referenceForDefendant(claim.getReferenceNumber(), DEFENDANT.name())
         );
 
         verify(notificationClient).sendEmail(
-            eq(OFFER_COUNTER_SIGNED_EMAIL_TO_OTHER_PARTY),
-            eq(claim.getSubmitterEmail()),
-            eq(counterSignedByDefendantEmailData()),
-            eq(
-                NotificationReferenceBuilder.AgreementCounterSigned
-                    .referenceForClaimant(claim.getReferenceNumber(), DEFENDANT.name())
-            )
+            OFFER_COUNTER_SIGNED_EMAIL_TO_OTHER_PARTY,
+            claim.getSubmitterEmail(),
+            counterSignedByDefendantEmailData(),
+            NotificationReferenceBuilder.AgreementCounterSigned
+                .referenceForClaimant(claim.getReferenceNumber(), DEFENDANT.name())
         );
     }
 
@@ -79,23 +74,19 @@ public class SettlementReachedCitizenNotificationTest extends BaseOfferTest {
         claimantRequestFor("countersign");
 
         verify(notificationClient).sendEmail(
-            eq(OFFER_COUNTER_SIGNED_EMAIL_TO_ORIGINATOR),
-            eq(claim.getSubmitterEmail()),
-            eq(counterSignedByClaimantEmailData()),
-            eq(
-                NotificationReferenceBuilder.AgreementCounterSigned
-                    .referenceForClaimant(claim.getReferenceNumber(), CLAIMANT.name())
-            )
+            OFFER_COUNTER_SIGNED_EMAIL_TO_ORIGINATOR,
+            claim.getSubmitterEmail(),
+            counterSignedByClaimantEmailData(),
+            NotificationReferenceBuilder.AgreementCounterSigned
+                .referenceForClaimant(claim.getReferenceNumber(), CLAIMANT.name())
         );
 
         verify(notificationClient).sendEmail(
-            eq(OFFER_COUNTER_SIGNED_EMAIL_TO_OTHER_PARTY),
-            eq(claim.getDefendantEmail()),
-            eq(counterSignedByClaimantEmailData()),
-            eq(
-                NotificationReferenceBuilder.AgreementCounterSigned
-                    .referenceForDefendant(claim.getReferenceNumber(), CLAIMANT.name())
-            )
+            OFFER_COUNTER_SIGNED_EMAIL_TO_OTHER_PARTY,
+            claim.getDefendantEmail(),
+            counterSignedByClaimantEmailData(),
+            NotificationReferenceBuilder.AgreementCounterSigned
+                .referenceForDefendant(claim.getReferenceNumber(), CLAIMANT.name())
         );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/services/citizen/SettlementReachedCitizenNotificationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/services/citizen/SettlementReachedCitizenNotificationTest.java
@@ -1,47 +1,32 @@
 package uk.gov.hmcts.cmc.claimstore.controllers.services.citizen;
 
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.cmc.claimstore.BaseOfferTest;
+import uk.gov.hmcts.cmc.claimstore.services.notifications.NotificationReferenceBuilder;
+import uk.gov.hmcts.cmc.claimstore.services.notifications.content.NotificationTemplateParameters;
 import uk.gov.hmcts.cmc.domain.models.offers.MadeBy;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static uk.gov.hmcts.cmc.claimstore.controllers.PathPatterns.CLAIM_REFERENCE_PATTERN;
+import static uk.gov.hmcts.cmc.domain.models.offers.MadeBy.CLAIMANT;
+import static uk.gov.hmcts.cmc.domain.models.offers.MadeBy.DEFENDANT;
 
 public class SettlementReachedCitizenNotificationTest extends BaseOfferTest {
 
-    private static final String CLAIM_REFERENCE_NUMBER = CLAIM_REFERENCE_PATTERN.replace("^", "");
-    private static final String FRONTEND_BASE_URL = "https://civil-money-claims.co.uk";
     private static final String OFFER_COUNTER_SIGNED_EMAIL_TO_ORIGINATOR = "9d1ddac9-d6a7-41f3-bfd4-dcfbcb61dcf1";
-    private static final String OFFER_COUNTERSIGNED_EMAIL_TO_OTHER_PARTY = "cfde3889-e202-4d70-bc64-f54048616be3";
-    private static final String COUNTER_SIGNING_PARTY_KEY = "counterSigningParty";
-    private static final String FRONTEND_BASE_URL_KEY = "frontendBaseUrl";
+    private static final String OFFER_COUNTER_SIGNED_EMAIL_TO_OTHER_PARTY = "cfde3889-e202-4d70-bc64-f54048616be3";
 
-    @Captor
-    private ArgumentCaptor<String> senderArgument;
-
-    @Captor
-    private ArgumentCaptor<String> templateArgument;
-
-    @Captor
-    private ArgumentCaptor<String> referenceArgument;
-
-    @Captor
-    private ArgumentCaptor<Map<String, String>> emailDataArgument;
+    private static final String FRONTEND_BASE_URL = "https://civil-money-claims.co.uk";
 
     @Test
     public void verifyNotificationsWhenCounterSignedByDefendant() throws Exception {
@@ -51,46 +36,36 @@ public class SettlementReachedCitizenNotificationTest extends BaseOfferTest {
         claimantRequestFor("accept");
         defendantRequestFor("countersign");
 
-        verify(notificationClient, atLeast(6))
-            .sendEmail(templateArgument.capture(), senderArgument.capture(), emailDataArgument.capture(),
-                referenceArgument.capture());
+        verify(notificationClient).sendEmail(
+            eq(OFFER_COUNTER_SIGNED_EMAIL_TO_ORIGINATOR),
+            eq(claim.getDefendantEmail()),
+            eq(counterSignedByDefendantEmailData()),
+            eq(
+                NotificationReferenceBuilder.AgreementCounterSigned
+                    .referenceForDefendant(claim.getReferenceNumber(), DEFENDANT.name())
+            )
+        );
 
-        verifyConfirmationToDefendantOnDefendantCounterSign();
-        verifyNotificationToClaimantOnDefendantCounterSign();
-
+        verify(notificationClient).sendEmail(
+            eq(OFFER_COUNTER_SIGNED_EMAIL_TO_OTHER_PARTY),
+            eq(claim.getSubmitterEmail()),
+            eq(counterSignedByDefendantEmailData()),
+            eq(
+                NotificationReferenceBuilder.AgreementCounterSigned
+                    .referenceForClaimant(claim.getReferenceNumber(), DEFENDANT.name())
+            )
+        );
     }
 
-    private void verifyConfirmationToDefendantOnDefendantCounterSign() {
-        assertThat(templateArgument.getValue()).isEqualTo(OFFER_COUNTER_SIGNED_EMAIL_TO_ORIGINATOR);
-
-        assertThat(referenceArgument.getValue())
-            .matches("to-defendant-agreement-counter-signed-by-defendant-notification-"
-                + CLAIM_REFERENCE_NUMBER
-            );
-
+    private Map<String, String> counterSignedByDefendantEmailData() {
         Map<String, String> emailData = new HashMap<>();
-        emailData.put(COUNTER_SIGNING_PARTY_KEY, claim.getClaimData().getDefendant().getName());
-        emailData.put(FRONTEND_BASE_URL_KEY, FRONTEND_BASE_URL);
-
-        verifyEmailData(emailDataArgument.getValue(), emailData);
-
-        assertThat(senderArgument.getValue()).isEqualTo(claim.getDefendantEmail());
-    }
-
-    private void verifyNotificationToClaimantOnDefendantCounterSign() {
-        assertThat(templateArgument.getAllValues().get(4)).isEqualTo(OFFER_COUNTERSIGNED_EMAIL_TO_OTHER_PARTY);
-
-        assertThat(referenceArgument.getAllValues().get(4))
-            .matches("to-claimant-agreement-counter-signed-by-defendant-notification-"
-                + CLAIM_REFERENCE_NUMBER
-            );
-
-        Map<String, String> emailData = new HashMap<>();
-        emailData.put(COUNTER_SIGNING_PARTY_KEY, claim.getClaimData().getDefendant().getName());
-        emailData.put(FRONTEND_BASE_URL_KEY, FRONTEND_BASE_URL);
-
-        verifyEmailData(emailDataArgument.getAllValues().get(4), emailData);
-        assertThat(senderArgument.getAllValues().get(4)).isEqualTo(claim.getSubmitterEmail());
+        emailData.put(
+            NotificationTemplateParameters.COUNTER_SIGNING_PARTY,
+            claim.getClaimData().getDefendant().getName()
+        );
+        emailData.put(NotificationTemplateParameters.CLAIM_REFERENCE_NUMBER, claim.getReferenceNumber());
+        emailData.put(NotificationTemplateParameters.FRONTEND_BASE_URL, FRONTEND_BASE_URL);
+        return emailData;
     }
 
     @Test
@@ -103,70 +78,52 @@ public class SettlementReachedCitizenNotificationTest extends BaseOfferTest {
         defendantRequestFor("accept");
         claimantRequestFor("countersign");
 
-        verify(notificationClient, atLeast(10))
-            .sendEmail(templateArgument.capture(), senderArgument.capture(), emailDataArgument.capture(),
-                referenceArgument.capture());
+        verify(notificationClient).sendEmail(
+            eq(OFFER_COUNTER_SIGNED_EMAIL_TO_ORIGINATOR),
+            eq(claim.getSubmitterEmail()),
+            eq(counterSignedByClaimantEmailData()),
+            eq(
+                NotificationReferenceBuilder.AgreementCounterSigned
+                    .referenceForClaimant(claim.getReferenceNumber(), CLAIMANT.name())
+            )
+        );
 
-        verifyConfirmationToClaimantOnClaimantCounterSign();
-        verifyNotificationToDefendantOnClaimantCounterSign();
+        verify(notificationClient).sendEmail(
+            eq(OFFER_COUNTER_SIGNED_EMAIL_TO_OTHER_PARTY),
+            eq(claim.getDefendantEmail()),
+            eq(counterSignedByClaimantEmailData()),
+            eq(
+                NotificationReferenceBuilder.AgreementCounterSigned
+                    .referenceForDefendant(claim.getReferenceNumber(), CLAIMANT.name())
+            )
+        );
     }
 
-    private void verifyConfirmationToClaimantOnClaimantCounterSign() {
-        assertThat(templateArgument.getValue()).isEqualTo(OFFER_COUNTER_SIGNED_EMAIL_TO_ORIGINATOR);
-
-        assertThat(referenceArgument.getValue())
-            .matches("to-claimant-agreement-counter-signed-by-claimant-notification-"
-                + CLAIM_REFERENCE_NUMBER);
-
+    private Map<String, String> counterSignedByClaimantEmailData() {
         Map<String, String> emailData = new HashMap<>();
-        emailData.put(COUNTER_SIGNING_PARTY_KEY, claim.getClaimData().getClaimant().getName());
-        emailData.put(FRONTEND_BASE_URL_KEY, FRONTEND_BASE_URL);
-
-        verifyEmailData(emailDataArgument.getValue(), emailData);
-        assertThat(senderArgument.getValue()).isEqualTo(claim.getSubmitterEmail());
+        emailData.put(
+            NotificationTemplateParameters.COUNTER_SIGNING_PARTY,
+            claim.getClaimData().getClaimant().getName()
+        );
+        emailData.put(NotificationTemplateParameters.CLAIM_REFERENCE_NUMBER, claim.getReferenceNumber());
+        emailData.put(NotificationTemplateParameters.FRONTEND_BASE_URL, FRONTEND_BASE_URL);
+        return emailData;
     }
 
-    private void verifyNotificationToDefendantOnClaimantCounterSign() {
-        assertThat(templateArgument.getAllValues().get(8)).isEqualTo(OFFER_COUNTERSIGNED_EMAIL_TO_OTHER_PARTY);
-
-        assertThat(referenceArgument.getAllValues().get(8))
-            .matches("to-defendant-agreement-counter-signed-by-claimant-notification-"
-                + CLAIM_REFERENCE_NUMBER
-            );
-
-        Map<String, String> emailData = new HashMap<>();
-        emailData.put(COUNTER_SIGNING_PARTY_KEY, claim.getClaimData().getClaimant().getName());
-        emailData.put(FRONTEND_BASE_URL_KEY, FRONTEND_BASE_URL);
-
-        verifyEmailData(emailDataArgument.getAllValues().get(8), emailData);
-
-        assertThat(senderArgument.getAllValues().get(8)).isEqualTo(claim.getDefendantEmail());
+    private void claimantRequestFor(String endpoint) throws Exception {
+        webClient.perform(
+            post(format("/claims/%s/offers/%s/%s", claim.getExternalId(), MadeBy.CLAIMANT.name(), endpoint))
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, CLAIMANT_AUTH_TOKEN)
+        );
     }
 
-    private void verifyEmailData(Map<String, String> output, Map<String, String> expected) {
-        output.entrySet().stream()
-            .filter(e -> !e.getKey().equals("claimReferenceNumber"))
-            .forEach(e -> assertThat(output.get(e.getKey())).isEqualTo(expected.get(e.getKey())));
-
-        assertThat(output.get("claimReferenceNumber")).matches(CLAIM_REFERENCE_PATTERN);
-
+    private void defendantRequestFor(String endpoint) throws Exception {
+        webClient.perform(
+            post(format("/claims/%s/offers/%s/%s", claim.getExternalId(), MadeBy.DEFENDANT.name(), endpoint))
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, DEFENDANT_AUTH_TOKEN)
+        );
     }
 
-    private ResultActions claimantRequestFor(String endpoint) throws Exception {
-        return webClient
-            .perform(
-                post(format("/claims/%s/offers/%s/%s", claim.getExternalId(), MadeBy.CLAIMANT.name(), endpoint))
-                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                    .header(HttpHeaders.AUTHORIZATION, CLAIMANT_AUTH_TOKEN)
-            );
-    }
-
-    private ResultActions defendantRequestFor(String endpoint) throws Exception {
-        return webClient
-            .perform(
-                post(format("/claims/%s/offers/%s/%s", claim.getExternalId(), MadeBy.DEFENDANT.name(), endpoint))
-                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                    .header(HttpHeaders.AUTHORIZATION, DEFENDANT_AUTH_TOKEN)
-            );
-    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/services/citizen/SettlementReachedCitizenNotificationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/services/citizen/SettlementReachedCitizenNotificationTest.java
@@ -38,7 +38,7 @@ public class SettlementReachedCitizenNotificationTest extends BaseOfferTest {
         verify(notificationClient).sendEmail(
             OFFER_COUNTER_SIGNED_EMAIL_TO_ORIGINATOR,
             claim.getDefendantEmail(),
-            counterSignedByDefendantEmailData(),
+            counterSignedEmailDataFor(claim.getClaimData().getDefendant().getName()),
             NotificationReferenceBuilder.AgreementCounterSigned
                 .referenceForDefendant(claim.getReferenceNumber(), DEFENDANT.name())
         );
@@ -46,17 +46,17 @@ public class SettlementReachedCitizenNotificationTest extends BaseOfferTest {
         verify(notificationClient).sendEmail(
             OFFER_COUNTER_SIGNED_EMAIL_TO_OTHER_PARTY,
             claim.getSubmitterEmail(),
-            counterSignedByDefendantEmailData(),
+            counterSignedEmailDataFor(claim.getClaimData().getDefendant().getName()),
             NotificationReferenceBuilder.AgreementCounterSigned
                 .referenceForClaimant(claim.getReferenceNumber(), DEFENDANT.name())
         );
     }
 
-    private Map<String, String> counterSignedByDefendantEmailData() {
+    private Map<String, String> counterSignedEmailDataFor(String counterSigningPartyName) {
         Map<String, String> emailData = new HashMap<>();
         emailData.put(
             NotificationTemplateParameters.COUNTER_SIGNING_PARTY,
-            claim.getClaimData().getDefendant().getName()
+            counterSigningPartyName
         );
         emailData.put(NotificationTemplateParameters.CLAIM_REFERENCE_NUMBER, claim.getReferenceNumber());
         emailData.put(NotificationTemplateParameters.FRONTEND_BASE_URL, FRONTEND_BASE_URL);
@@ -76,7 +76,7 @@ public class SettlementReachedCitizenNotificationTest extends BaseOfferTest {
         verify(notificationClient).sendEmail(
             OFFER_COUNTER_SIGNED_EMAIL_TO_ORIGINATOR,
             claim.getSubmitterEmail(),
-            counterSignedByClaimantEmailData(),
+            counterSignedEmailDataFor(claim.getClaimData().getClaimant().getName()),
             NotificationReferenceBuilder.AgreementCounterSigned
                 .referenceForClaimant(claim.getReferenceNumber(), CLAIMANT.name())
         );
@@ -84,21 +84,10 @@ public class SettlementReachedCitizenNotificationTest extends BaseOfferTest {
         verify(notificationClient).sendEmail(
             OFFER_COUNTER_SIGNED_EMAIL_TO_OTHER_PARTY,
             claim.getDefendantEmail(),
-            counterSignedByClaimantEmailData(),
+            counterSignedEmailDataFor(claim.getClaimData().getClaimant().getName()),
             NotificationReferenceBuilder.AgreementCounterSigned
                 .referenceForDefendant(claim.getReferenceNumber(), CLAIMANT.name())
         );
-    }
-
-    private Map<String, String> counterSignedByClaimantEmailData() {
-        Map<String, String> emailData = new HashMap<>();
-        emailData.put(
-            NotificationTemplateParameters.COUNTER_SIGNING_PARTY,
-            claim.getClaimData().getClaimant().getName()
-        );
-        emailData.put(NotificationTemplateParameters.CLAIM_REFERENCE_NUMBER, claim.getReferenceNumber());
-        emailData.put(NotificationTemplateParameters.FRONTEND_BASE_URL, FRONTEND_BASE_URL);
-        return emailData;
     }
 
     private void claimantRequestFor(String endpoint) throws Exception {


### PR DESCRIPTION
### Change description ###

That test has shown to be flaky on all kinds of environments (Jenkins, Travis, local). I removed all the assumptions on the total number of `sendEmail` invocations, hopefully this should resolve the problem. I ran the test a number of times on my local and haven't seen it fail so far.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
