### PR TITLE
ROC-3481: on PDFs total amount should not reflect interests

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimDataContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimDataContentProvider.java
@@ -56,7 +56,6 @@ public class ClaimDataContentProvider {
                 claim.getIssuedOn(),
                 claim.getIssuedOn()
             );
-            totalAmountComponents.add(interestContent.getAmountRealValue());
         }
 
         Optional<StatementOfTruth> optionalStatementOfTruth = claim.getClaimData().getStatementOfTruth();

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/ClaimDataContentProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/ClaimDataContentProviderTest.java
@@ -76,7 +76,7 @@ public class ClaimDataContentProviderTest {
     public void shouldProvideTotalAmount() {
         ClaimContent claimContent = provider.createContent(claim);
 
-        assertThat(claimContent.getClaimTotalAmount()).isEqualTo("£80.89");
+        assertThat(claimContent.getClaimTotalAmount()).isEqualTo("£80.00");
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-3481


### Change description ###
On PDF documents we don't want to display total amount with interest. 
On page interests should be added.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
