### PR TITLE
ROC-3535 Update to hmcts org for dockerhub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-    image: hmctsgov/cmc-claim-store
+    image: hmcts/cmc-claim-store
     environment:
       - CLAIM_STORE_DB_HOST=claim-store-database
       - CLAIM_STORE_DB_PORT=5432
@@ -38,7 +38,7 @@ services:
   claim-store-database:
     build:
       context: docker/database
-    image: hmctsgov/cmc-claim-store-database
+    image: hmcts/cmc-claim-store-database
     healthcheck:
       interval: 10s
       timeout: 10s


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-3525


### Change description ###
HMCTS org is now available, using that instead

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
