### PR TITLE
Remove empty initilize methods from validators

### DIFF
--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/ClaimantAmountConstraintValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/ClaimantAmountConstraintValidator.java
@@ -8,11 +8,6 @@ import javax.validation.ConstraintValidatorContext;
 public class ClaimantAmountConstraintValidator implements ConstraintValidator<ClaimantAmount, AmountRow> {
 
     @Override
-    public void initialize(ClaimantAmount phone) {
-        // NO-OP
-    }
-
-    @Override
     public boolean isValid(AmountRow amount, ConstraintValidatorContext cxt) {
         if (amount == null) {
             return true;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/DateNotInTheFutureConstraintValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/DateNotInTheFutureConstraintValidator.java
@@ -7,11 +7,6 @@ import javax.validation.ConstraintValidatorContext;
 public class DateNotInTheFutureConstraintValidator implements ConstraintValidator<DateNotInTheFuture, LocalDate> {
 
     @Override
-    public void initialize(DateNotInTheFuture dateNotInTheFuture) {
-        // NO-OP
-    }
-
-    @Override
     public boolean isValid(LocalDate localDate, ConstraintValidatorContext cxt) {
         // Another validator should check for this if required
         if (localDate == null) {

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/DateNotInThePastConstraintValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/DateNotInThePastConstraintValidator.java
@@ -5,12 +5,7 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 public class DateNotInThePastConstraintValidator implements ConstraintValidator<DateNotInThePast, LocalDate> {
-
-    @Override
-    public void initialize(DateNotInThePast dateNotInThePast) {
-        // NO-OP
-    }
-
+    
     @Override
     public boolean isValid(LocalDate localDate, ConstraintValidatorContext cxt) {
         // Another validator should check for this if required

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/FutureDateConstraintValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/FutureDateConstraintValidator.java
@@ -7,11 +7,6 @@ import javax.validation.ConstraintValidatorContext;
 public class FutureDateConstraintValidator implements ConstraintValidator<FutureDate, LocalDate> {
 
     @Override
-    public void initialize(FutureDate constraintAnnotation) {
-        // Nothing to do here
-    }
-
-    @Override
     public boolean isValid(LocalDate value, ConstraintValidatorContext context) {
         return value == null || value.isAfter(LocalDate.now());
     }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/PhoneNumberConstraintValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/PhoneNumberConstraintValidator.java
@@ -7,11 +7,6 @@ import javax.validation.ConstraintValidatorContext;
 public class PhoneNumberConstraintValidator implements ConstraintValidator<PhoneNumber, String> {
 
     @Override
-    public void initialize(PhoneNumber constraintAnnotation) {
-        // Nothing to do
-    }
-
-    @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
         if (value == null) {
             return true;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/ValidCountyCourtJudgmentValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/ValidCountyCourtJudgmentValidator.java
@@ -12,12 +12,7 @@ import static uk.gov.hmcts.cmc.domain.models.ccj.PaymentOption.INSTALMENTS;
 
 public class ValidCountyCourtJudgmentValidator
     implements ConstraintValidator<ValidCountyCourtJudgment, CountyCourtJudgment> {
-
-    @Override
-    public void initialize(ValidCountyCourtJudgment constraintAnnotation) {
-        // nothing to do here
-    }
-
+    
     @Override
     public boolean isValid(CountyCourtJudgment ccj, ConstraintValidatorContext context) {
         if (!isEligibleForThisValidator(ccj)) {

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/ValidInterestConstraintValidator.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/constraints/ValidInterestConstraintValidator.java
@@ -10,14 +10,9 @@ import javax.validation.ConstraintValidatorContext;
 import static uk.gov.hmcts.cmc.domain.constraints.BeanValidator.validate;
 
 /**
- * Intended to replace {@link InterDependentFieldsConstraintValidator}.
  * Validates the BREAKDOWN interest type only for now.
  */
 public class ValidInterestConstraintValidator implements ConstraintValidator<ValidInterest, Interest> {
-    @Override
-    public void initialize(ValidInterest constraintAnnotation) {
-        // Nothing to do
-    }
 
     @Override
     public boolean isValid(Interest interest, ConstraintValidatorContext validatorContext) {
@@ -62,7 +57,7 @@ public class ValidInterestConstraintValidator implements ConstraintValidator<Val
     }
 
     private String[] toArray(Set<String> set) {
-        return set.toArray(new String[] { });
+        return set.toArray(new String[]{});
     }
 
 }


### PR DESCRIPTION
### Change description ###

After updating the validator framework, we don't need to override empty `initialize` method as it comes with default in `ConstraintValidator` interface.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

