### PR TITLE
Replace apt deprecated configuration

### DIFF
--- a/ccd-adapter/build.gradle
+++ b/ccd-adapter/build.gradle
@@ -13,8 +13,8 @@ dependencies {
   compile project(':domain-model')
 
   compile group: 'org.springframework.boot', name: 'spring-boot-starter', version: versions.springBoot
+  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.16.20'
   compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.16.20'
-  apt group: 'org.projectlombok', name: 'lombok', version: '1.16.20'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
   testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/domain-model/build.gradle
+++ b/domain-model/build.gradle
@@ -14,8 +14,8 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-json'
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'
   compile group: 'cz.jirutka.validator', name: 'validator-collection', version: '2.2.0'
+  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.16.20'
   compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.16.20'
-  apt group: 'org.projectlombok', name: 'lombok', version: '1.16.20'
 
   testCompile project(':domain-sample-data')
   testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
### Change description ###
This PR replaces the deprecated `apt` configuration with `annotationProcessor`, as apt is deprecated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
