### PR TITLE
BigFix: Fixed unhealthy claim-store container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY build/libs/claim-store.jar /opt/app/
 
 WORKDIR /opt/app
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy="" wget -q http://localhost:4400/health || exit 1
+HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy="" wget -q --spider http://localhost:4400/health || exit 1
 
 EXPOSE 4400
 


### PR DESCRIPTION
### Change description ###
wget was trying to download 'health' from 'http://localhost:4400/health' and failing, leading to an unhealthy container.
By using the --spider command, we check for a 200 response instead. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
