### PR TITLE
Removed outdated section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,6 @@ Database will get initiated when you run `docker-compose up` for the first time 
 
 You don't need to migrate database manually since migrations are executed every time `docker-compose up` is executed.
 
-When you need to make ad-hoc connect to the database you can execute following command:
-
-```
-docker-compose exec claim-store-api psql -U postgres -d claimstore
-```
-
 ### API documentation
 
 API documentation is provided with Swagger:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Database will get initiated when you run `docker-compose up` for the first time 
 
 You don't need to migrate database manually since migrations are executed every time `docker-compose up` is executed.
 
+When you need to make ad-hoc connect to the database you can execute following command:
+
+```
+docker exec -it cmc-integration-tests_shared-database_1 psql -U postgres -d claimstore
+```
+
 ### API documentation
 
 API documentation is provided with Swagger:

--- a/README.md
+++ b/README.md
@@ -92,13 +92,7 @@ $ ./gradlew functional
 
 Database will get initiated when you run `docker-compose up` for the first time by execute all scripts from `database` directory.
 
-You don't need to migrate database manually since migrations are executed every time `docker-compose up` is executed.
-
-When you need to make ad-hoc connect to the database you can execute following command:
-
-```
-docker exec -it cmc-integration-tests_shared-database_1 psql -U postgres -d claimstore
-```
+You don't need to migrate database manually since migrations are executed every time the application bootstraps.
 
 ### API documentation
 


### PR DESCRIPTION
The section in the README explaining how to connect to the database from within the claim-store is no longer relevant. 