### PR TITLE
Much faster docker build locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre-alpine
 
-COPY build/libs/claim-store.jar /opt/app/
+COPY claim-store.jar /opt/app/
 
 WORKDIR /opt/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ version: '2.1'
 services:
   claim-store-api:
     build:
-      context: .
+      context: build/libs
+      dockerfile: ../../Dockerfile
       args:
         - http_proxy
         - https_proxy


### PR DESCRIPTION
### Change description ###
Most of the local docker build was spent waiting for the build context to be sent to the docker daemon, that took awhile because of the large file size of all the jars in the context we were sending, I've restricted it down to only the directory with the jar in it, sample of large files before:

```
$ find . -type f -exec du -a {} + | sort -n -r | less
163856  ./ccd-claim-migration/build/distributions/ccd-claim-migration-1.1.0.tar
134816  ./build/distributions/claim-store-boot-1.1.0.tar
131088  ./build/distributions/claim-store-1.1.0.tar
131080  ./build/libs/claim-store.jar
122888  ./ccd-claim-migration/build/distributions/ccd-claim-migration-1.1.0.zip
116744  ./build/distributions/claim-store-boot-1.1.0.zip
116744  ./build/distributions/claim-store-1.1.0.zip
69648   ./ccd-claim-migration/build/distributions/ccd-claim-migration-boot-1.1.0.tar
68752   ./ccd-claim-migration/build/libs/ccd-claim-migration-1.1.0.jar
61448   ./ccd-claim-migration/build/distributions/ccd-claim-migration-boot-1.1.0.zip
```

