### PR TITLE
Replace boiler point code with lombok for equals and hhashcode

### DIFF
--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Address.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Address.java
@@ -1,12 +1,13 @@
 package uk.gov.hmcts.cmc.domain.models;
 
+import lombok.EqualsAndHashCode;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.hmcts.cmc.domain.constraints.Postcode;
 
-import java.util.Objects;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+@EqualsAndHashCode
 public class Address {
 
     @NotBlank(message = "Address Line1 should not be empty")
@@ -57,27 +58,6 @@ public class Address {
 
     public String getPostcode() {
         return postcode;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Address address = (Address) other;
-        return Objects.equals(line1, address.line1)
-            && Objects.equals(line2, address.line2)
-            && Objects.equals(line3, address.line3)
-            && Objects.equals(city, address.city)
-            && Objects.equals(postcode, address.postcode);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(line1, line2, line3, city, postcode);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/AmountRow.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/AmountRow.java
@@ -1,16 +1,17 @@
 package uk.gov.hmcts.cmc.domain.models;
 
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.ClaimantAmount;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import javax.validation.constraints.DecimalMin;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @ClaimantAmount
+@EqualsAndHashCode
 public class AmountRow {
     private final String reason;
 
@@ -29,24 +30,6 @@ public class AmountRow {
 
     public BigDecimal getAmount() {
         return amount;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        AmountRow amountRow = (AmountRow) other;
-        return Objects.equals(reason, amountRow.reason)
-            && Objects.equals(amount, amountRow.amount);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(reason, amount);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Claim.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Claim.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.amount.TotalAmountCalculator;
 import uk.gov.hmcts.cmc.domain.models.offers.Settlement;
@@ -13,7 +14,6 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
@@ -25,6 +25,7 @@ import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
     allowGetters = true
 )
 @Builder
+@EqualsAndHashCode
 public class Claim {
 
     private final Long id;
@@ -193,47 +194,6 @@ public class Claim {
 
     public Optional<BigDecimal> getTotalInterest() {
         return TotalAmountCalculator.calculateInterestForClaim(this);
-    }
-
-    @Override
-    @SuppressWarnings("squid:S1067") // Its generated code for equals sonar
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        Claim claim = (Claim) obj;
-        return moreTimeRequested == claim.moreTimeRequested
-            && Objects.equals(id, claim.id)
-            && Objects.equals(submitterId, claim.submitterId)
-            && Objects.equals(letterHolderId, claim.letterHolderId)
-            && Objects.equals(defendantId, claim.defendantId)
-            && Objects.equals(externalId, claim.externalId)
-            && Objects.equals(referenceNumber, claim.referenceNumber)
-            && Objects.equals(claimData, claim.claimData)
-            && Objects.equals(createdAt, claim.createdAt)
-            && Objects.equals(issuedOn, claim.issuedOn)
-            && Objects.equals(responseDeadline, claim.responseDeadline)
-            && Objects.equals(submitterEmail, claim.submitterEmail)
-            && Objects.equals(respondedAt, claim.respondedAt)
-            && Objects.equals(response, claim.response)
-            && Objects.equals(defendantEmail, claim.defendantEmail)
-            && Objects.equals(countyCourtJudgment, claim.countyCourtJudgment)
-            && Objects.equals(countyCourtJudgmentRequestedAt, claim.countyCourtJudgmentRequestedAt)
-            && Objects.equals(settlement, claim.settlement)
-            && Objects.equals(settlementReachedAt, claim.settlementReachedAt)
-            && Objects.equals(sealedClaimDocument, claim.sealedClaimDocument);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, submitterId, letterHolderId, defendantId, externalId, referenceNumber,
-            claimData, createdAt, issuedOn, responseDeadline, moreTimeRequested, submitterEmail,
-            respondedAt, response, defendantEmail, countyCourtJudgment, countyCourtJudgmentRequestedAt,
-            settlement, settlementReachedAt, sealedClaimDocument
-        );
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/ClaimData.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/ClaimData.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.cmc.domain.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -18,7 +19,6 @@ import uk.gov.hmcts.cmc.domain.utils.MonetaryConversions;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import javax.validation.Valid;
@@ -29,6 +29,7 @@ import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ClaimData {
     @Valid
@@ -224,57 +225,6 @@ public class ClaimData {
 
     public Optional<Evidence> getEvidence() {
         return Optional.ofNullable(evidence);
-    }
-
-    @Override
-    @SuppressWarnings("squid:S1067") // Its generated code for equals sonar
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        ClaimData that = (ClaimData) other;
-        return Objects.equals(claimants, that.claimants)
-            && Objects.equals(defendants, that.defendants)
-            && Objects.equals(payment, that.payment)
-            && Objects.equals(amount, that.amount)
-            && Objects.equals(feeAmountInPennies, that.feeAmountInPennies)
-            && Objects.equals(interest, that.interest)
-            && Objects.equals(personalInjury, that.personalInjury)
-            && Objects.equals(housingDisrepair, that.housingDisrepair)
-            && Objects.equals(reason, that.reason)
-            && Objects.equals(statementOfTruth, that.statementOfTruth)
-            && Objects.equals(feeAccountNumber, that.feeAccountNumber)
-            && Objects.equals(externalId, that.externalId)
-            && Objects.equals(externalReferenceNumber, that.externalReferenceNumber)
-            && Objects.equals(preferredCourt, that.preferredCourt)
-            && Objects.equals(feeCode, that.feeCode)
-            && Objects.equals(timeline, that.timeline)
-            && Objects.equals(evidence, that.evidence);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-            claimants,
-            defendants,
-            payment,
-            amount,
-            feeAmountInPennies,
-            interest,
-            personalInjury,
-            housingDisrepair,
-            reason,
-            statementOfTruth,
-            feeAccountNumber,
-            externalId,
-            externalReferenceNumber,
-            preferredCourt,
-            feeCode,
-            timeline,
-            evidence);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/CountyCourtJudgment.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/CountyCourtJudgment.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cmc.domain.models;
 
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.AgeRangeValidator;
 import uk.gov.hmcts.cmc.domain.constraints.DateNotInThePast;
@@ -9,7 +10,6 @@ import uk.gov.hmcts.cmc.domain.models.legalrep.StatementOfTruth;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
@@ -17,6 +17,7 @@ import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 @ValidCountyCourtJudgment
 public class CountyCourtJudgment {
 
@@ -81,30 +82,6 @@ public class CountyCourtJudgment {
 
     public Optional<StatementOfTruth> getStatementOfTruth() {
         return Optional.ofNullable(statementOfTruth);
-    }
-
-    @Override
-    @SuppressWarnings("squid:S1067") // Its generated code for equals sonar
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        CountyCourtJudgment that = (CountyCourtJudgment) other;
-        return Objects.equals(defendantDateOfBirth, that.defendantDateOfBirth)
-            && Objects.equals(paymentOption, that.paymentOption)
-            && Objects.equals(paidAmount, that.paidAmount)
-            && Objects.equals(repaymentPlan, that.repaymentPlan)
-            && Objects.equals(payBySetDate, that.payBySetDate)
-            && Objects.equals(statementOfTruth, that.statementOfTruth);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(defendantDateOfBirth, paymentOption, paidAmount, repaymentPlan, payBySetDate,
-            statementOfTruth);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Interest.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Interest.java
@@ -1,16 +1,17 @@
 package uk.gov.hmcts.cmc.domain.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.ValidInterest;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 @ValidInterest
 public class Interest {
     public enum InterestType {
@@ -75,28 +76,6 @@ public class Interest {
 
     public InterestDate getInterestDate() {
         return interestDate;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Interest interest = (Interest) o;
-        return Objects.equals(type, interest.type)
-                && Objects.equals(interestBreakdown, interest.interestBreakdown)
-                && Objects.equals(rate, interest.rate)
-                && Objects.equals(reason, interest.reason)
-                && Objects.equals(specificDailyAmount, interest.specificDailyAmount)
-                && Objects.equals(interestDate, interest.interestDate);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, interestBreakdown, rate, reason, specificDailyAmount, interestDate);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/InterestAmount.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/InterestAmount.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.cmc.domain.models;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.EqualsAndHashCode;
 
 import java.math.BigDecimal;
 
+@EqualsAndHashCode
 public class InterestAmount {
 
     private final BigDecimal amount;

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/InterestBreakdown.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/InterestBreakdown.java
@@ -1,16 +1,17 @@
 package uk.gov.hmcts.cmc.domain.models;
 
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class InterestBreakdown {
     @NotNull
     @Money
@@ -31,24 +32,6 @@ public class InterestBreakdown {
 
     public String getExplanation() {
         return explanation;
-    }
-
-    @Override
-    public boolean equals(Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (object == null || getClass() != object.getClass()) {
-            return false;
-        }
-        InterestBreakdown other = (InterestBreakdown) object;
-        return Objects.equals(totalAmount, other.totalAmount)
-            && Objects.equals(explanation, other.explanation);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(totalAmount, explanation);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/InterestDate.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/InterestDate.java
@@ -3,15 +3,16 @@ package uk.gov.hmcts.cmc.domain.models;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.DateNotInTheFuture;
 import uk.gov.hmcts.cmc.domain.constraints.ValidInterestDate;
 
 import java.time.LocalDate;
-import java.util.Objects;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 @ValidInterestDate
 public class InterestDate {
     public enum InterestDateType {
@@ -81,26 +82,6 @@ public class InterestDate {
     @JsonIgnore
     public boolean isValid() {
         return type != null || date != null || reason != null;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        InterestDate that = (InterestDate) other;
-        return Objects.equals(type, that.type)
-            && Objects.equals(date, that.date)
-            && Objects.equals(reason, that.reason)
-            && Objects.equals(endDateType, that.endDateType);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, date, reason);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
@@ -2,15 +2,16 @@ package uk.gov.hmcts.cmc.domain.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 @JsonIgnoreProperties(value = {"description", "state"})
 public class Payment {
     private final String id;
@@ -57,28 +58,6 @@ public class Payment {
 
     public String getDateCreated() {
         return dateCreated;
-    }
-
-    @Override
-    @SuppressWarnings("squid:S1067") // Its generated code for equals sonar
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        Payment payment = (Payment) obj;
-        return Objects.equals(id, payment.id)
-            && Objects.equals(amount, payment.amount)
-            && Objects.equals(reference, payment.reference)
-            && Objects.equals(dateCreated, payment.dateCreated)
-            && Objects.equals(status, payment.status);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, amount, reference, dateCreated, status);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/PaymentDeclaration.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/PaymentDeclaration.java
@@ -1,16 +1,17 @@
 package uk.gov.hmcts.cmc.domain.models;
 
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.hmcts.cmc.domain.constraints.DateNotInTheFuture;
 
 import java.time.LocalDate;
-import java.util.Objects;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class PaymentDeclaration {
 
     @NotNull
@@ -32,26 +33,6 @@ public class PaymentDeclaration {
 
     public String getExplanation() {
         return explanation;
-    }
-
-    @Override
-    public boolean equals(final Object other) {
-        if (this == other) {
-            return true;
-        }
-
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-
-        final PaymentDeclaration that = (PaymentDeclaration) other;
-        return Objects.equals(paidDate, that.paidDate)
-            && Objects.equals(explanation, that.explanation);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(paidDate, explanation);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/RepaymentPlan.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/RepaymentPlan.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.cmc.domain.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.DateNotInThePast;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
@@ -8,12 +9,12 @@ import uk.gov.hmcts.cmc.domain.models.ccj.PaymentSchedule;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.Objects;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 @JsonIgnoreProperties(value = {"firstPayment"})
 public class RepaymentPlan {
 
@@ -49,26 +50,6 @@ public class RepaymentPlan {
 
     public PaymentSchedule getPaymentSchedule() {
         return paymentSchedule;
-    }
-
-    @Override
-    @SuppressWarnings("squid:S1067") // Its generated code for equals sonar
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        RepaymentPlan that = (RepaymentPlan) other;
-        return Objects.equals(instalmentAmount, that.instalmentAmount)
-            && Objects.equals(firstPaymentDate, that.firstPaymentDate)
-            && Objects.equals(paymentSchedule, that.paymentSchedule);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(instalmentAmount, firstPaymentDate, paymentSchedule);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Timeline.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Timeline.java
@@ -2,15 +2,16 @@ package uk.gov.hmcts.cmc.domain.models;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import java.util.List;
-import java.util.Objects;
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class Timeline {
 
     @Valid
@@ -25,23 +26,6 @@ public class Timeline {
 
     public List<TimelineEvent> getEvents() {
         return events;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Timeline timeline = (Timeline) other;
-        return Objects.equals(events, timeline.events);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(events);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/TimelineEvent.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/TimelineEvent.java
@@ -1,15 +1,15 @@
 package uk.gov.hmcts.cmc.domain.models;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 
-import java.util.Objects;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
-
+@EqualsAndHashCode
 public class TimelineEvent {
 
     @NotBlank
@@ -32,25 +32,6 @@ public class TimelineEvent {
 
     public String getDescription() {
         return description;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        TimelineEvent that = (TimelineEvent) other;
-
-        return Objects.equals(date, that.date)
-            && Objects.equals(description, that.description);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(date, description);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountBreakDown.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountBreakDown.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.cmc.domain.models.amount;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.MinTotalAmount;
 import uk.gov.hmcts.cmc.domain.models.AmountRow;
@@ -15,6 +16,7 @@ import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class AmountBreakDown implements Amount {
 
     @Valid
@@ -38,23 +40,6 @@ public class AmountBreakDown implements Amount {
 
     public List<AmountRow> getRows() {
         return rows;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        AmountBreakDown that = (AmountBreakDown) other;
-        return Objects.equals(rows, that.rows);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(rows);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountRange.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountRange.java
@@ -1,16 +1,17 @@
 package uk.gov.hmcts.cmc.domain.models.amount;
 
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class AmountRange implements Amount {
 
     @Money
@@ -33,24 +34,6 @@ public class AmountRange implements Amount {
 
     public BigDecimal getHigherValue() {
         return higherValue;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        AmountRange that = (AmountRange) obj;
-        return Objects.equals(lowerValue, that.lowerValue)
-            && Objects.equals(higherValue, that.higherValue);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(lowerValue, higherValue);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/evidence/DefendantEvidence.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/evidence/DefendantEvidence.java
@@ -1,14 +1,15 @@
 package uk.gov.hmcts.cmc.domain.models.evidence;
 
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode(callSuper = true)
 public class DefendantEvidence extends Evidence {
 
     @Size(max = 99000)
@@ -21,26 +22,6 @@ public class DefendantEvidence extends Evidence {
 
     public Optional<String> getComment() {
         return Optional.ofNullable(comment);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        if (!super.equals(other)) {
-            return false;
-        }
-        DefendantEvidence that = (DefendantEvidence) other;
-        return Objects.equals(comment, that.comment);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), comment);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/evidence/Evidence.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/evidence/Evidence.java
@@ -1,15 +1,16 @@
 package uk.gov.hmcts.cmc.domain.models.evidence;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import java.util.List;
-import java.util.Objects;
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class Evidence {
 
     @Valid
@@ -23,23 +24,6 @@ public class Evidence {
 
     public List<EvidenceRow> getRows() {
         return rows;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Evidence evidence = (Evidence) other;
-        return Objects.equals(rows, evidence.rows);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(rows);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/evidence/EvidenceRow.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/evidence/EvidenceRow.java
@@ -1,14 +1,15 @@
 package uk.gov.hmcts.cmc.domain.models.evidence;
 
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class EvidenceRow {
 
     @NotNull
@@ -28,25 +29,6 @@ public class EvidenceRow {
 
     public Optional<String> getDescription() {
         return Optional.ofNullable(description);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        EvidenceRow that = (EvidenceRow) other;
-
-        return Objects.equals(type, that.type)
-            && Objects.equals(description, that.description);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, description);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/legalrep/ContactDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/legalrep/ContactDetails.java
@@ -1,15 +1,16 @@
 package uk.gov.hmcts.cmc.domain.models.legalrep;
 
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.Email;
 import uk.gov.hmcts.cmc.domain.constraints.PhoneNumber;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class ContactDetails {
 
     @PhoneNumber
@@ -37,27 +38,6 @@ public class ContactDetails {
 
     public Optional<String> getDxAddress() {
         return Optional.ofNullable(dxAddress);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        ContactDetails that = (ContactDetails) obj;
-
-        return Objects.equals(this.phone, that.phone)
-            && Objects.equals(this.email, that.email)
-            && Objects.equals(this.dxAddress, that.dxAddress);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(phone, email, dxAddress);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/legalrep/Representative.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/legalrep/Representative.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.cmc.domain.models.legalrep;
 
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.hmcts.cmc.domain.models.Address;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -12,6 +12,7 @@ import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class Representative {
 
     @NotBlank
@@ -45,32 +46,6 @@ public class Representative {
 
     public Optional<ContactDetails> getOrganisationContactDetails() {
         return Optional.ofNullable(organisationContactDetails);
-    }
-
-    @Override
-    @SuppressWarnings("squid:S1067") // Its generated code for equals sonar
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        Representative that = (Representative) obj;
-
-        return Objects.equals(this.organisationName, that.organisationName)
-            && Objects.equals(this.organisationAddress, that.organisationAddress)
-            && Objects.equals(this.organisationContactDetails, that.organisationContactDetails);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-            organisationName,
-            organisationAddress,
-            organisationContactDetails
-        );
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/legalrep/StatementOfTruth.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/legalrep/StatementOfTruth.java
@@ -1,12 +1,13 @@
 package uk.gov.hmcts.cmc.domain.models.legalrep;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.hibernate.validator.constraints.NotBlank;
 
-import java.util.Objects;
 import javax.validation.constraints.Size;
 
 @Builder
+@EqualsAndHashCode
 public class StatementOfTruth {
 
     @NotBlank
@@ -28,25 +29,6 @@ public class StatementOfTruth {
 
     public String getSignerRole() {
         return signerRole;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        StatementOfTruth that = (StatementOfTruth) obj;
-
-        return Objects.equals(this.signerName, that.signerName) && Objects.equals(this.signerRole, that.signerRole);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(signerName, signerRole);
     }
 
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/Offer.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/Offer.java
@@ -1,16 +1,17 @@
 package uk.gov.hmcts.cmc.domain.models.offers;
 
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.hmcts.cmc.domain.constraints.FutureDate;
 
 import java.time.LocalDate;
-import java.util.Objects;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class Offer {
 
     static final int CONTENT_LENGTH_LIMIT = 99000;
@@ -34,25 +35,6 @@ public class Offer {
 
     public LocalDate getCompletionDate() {
         return completionDate;
-    }
-
-    @Override
-    public boolean equals(Object input) {
-        if (this == input) {
-            return true;
-        }
-        if (input == null || getClass() != input.getClass()) {
-            return false;
-        }
-
-        Offer other = (Offer) input;
-        return Objects.equals(content, other.content)
-            && Objects.equals(completionDate, other.completionDate);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(content, completionDate);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/PartyStatement.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/PartyStatement.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.cmc.domain.models.offers;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class PartyStatement {
 
     private StatementType type;
@@ -36,28 +37,6 @@ public class PartyStatement {
 
     public Optional<Offer> getOffer() {
         return Optional.ofNullable(offer);
-    }
-
-    @Override
-    public boolean equals(Object input) {
-        if (this == input) {
-            return true;
-        }
-
-        if (input == null || getClass() != input.getClass()) {
-            return false;
-        }
-
-        PartyStatement that = (PartyStatement) input;
-
-        return type == that.type
-            && madeBy == that.madeBy
-            && Objects.equals(offer, that.offer);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, madeBy, offer);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/Settlement.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/Settlement.java
@@ -1,17 +1,18 @@
 package uk.gov.hmcts.cmc.domain.models.offers;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.exceptions.IllegalSettlementStatementException;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import static java.lang.String.format;
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class Settlement {
 
     private static final String NO_STATEMENTS_MADE = "No statements have yet been made during that settlement";
@@ -109,20 +110,4 @@ public class Settlement {
         return ReflectionToStringBuilder.toString(this, ourStyle());
     }
 
-    @Override
-    public boolean equals(Object input) {
-        if (this == input) {
-            return true;
-        }
-        if (input == null || getClass() != input.getClass()) {
-            return false;
-        }
-        Settlement that = (Settlement) input;
-        return Objects.equals(partyStatements, that.partyStatements);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(partyStatements);
-    }
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/CompanyDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/CompanyDetails.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.cmc.domain.models.otherparty;
 
+import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.cmc.domain.models.Address;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
 import uk.gov.hmcts.cmc.domain.models.party.HasContactPerson;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.Size;
 
+@EqualsAndHashCode(callSuper = true)
 public class CompanyDetails extends TheirDetails implements HasContactPerson {
 
     @Size(max = 255, message = "may not be longer than {max} characters")
@@ -27,26 +28,6 @@ public class CompanyDetails extends TheirDetails implements HasContactPerson {
 
     public Optional<String> getContactPerson() {
         return Optional.ofNullable(contactPerson);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        CompanyDetails that = (CompanyDetails) obj;
-
-        return super.equals(that)
-            && Objects.equals(this.contactPerson, that.contactPerson);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), this.contactPerson);
     }
 
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/IndividualDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/IndividualDetails.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.cmc.domain.models.otherparty;
 
+import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.cmc.domain.constraints.AgeRangeValidator;
 import uk.gov.hmcts.cmc.domain.models.Address;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
 
 import java.time.LocalDate;
-import java.util.Objects;
 import java.util.Optional;
 
+@EqualsAndHashCode(callSuper = true)
 public class IndividualDetails extends TheirDetails {
 
     @AgeRangeValidator
@@ -29,24 +30,4 @@ public class IndividualDetails extends TheirDetails {
         return Optional.ofNullable(dateOfBirth);
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        if (!super.equals(obj)) {
-            return false;
-        }
-        IndividualDetails that = (IndividualDetails) obj;
-        return Objects.equals(dateOfBirth, that.dateOfBirth);
-    }
-
-    @Override
-    public int hashCode() {
-
-        return Objects.hash(super.hashCode(), dateOfBirth);
-    }
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/OrganisationDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/OrganisationDetails.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.cmc.domain.models.otherparty;
 
+import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.cmc.domain.models.Address;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
 import uk.gov.hmcts.cmc.domain.models.party.HasContactPerson;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.Size;
 
+@EqualsAndHashCode(callSuper = true)
 public class OrganisationDetails extends TheirDetails implements HasContactPerson {
 
     @Size(max = 35, message = "may not be longer than {max} characters")
@@ -34,26 +35,6 @@ public class OrganisationDetails extends TheirDetails implements HasContactPerso
 
     public Optional<String> getCompaniesHouseNumber() {
         return Optional.ofNullable(companiesHouseNumber);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        OrganisationDetails that = (OrganisationDetails) obj;
-
-        return super.equals(that)
-            && Objects.equals(this.contactPerson, that.contactPerson);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), this.contactPerson);
     }
 
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/SoleTraderDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/SoleTraderDetails.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.cmc.domain.models.otherparty;
 
+import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.cmc.domain.models.Address;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
 import uk.gov.hmcts.cmc.domain.models.party.TitledParty;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.Size;
 
+@EqualsAndHashCode(callSuper = true)
 public class SoleTraderDetails extends TheirDetails implements TitledParty {
 
     @Size(max = 35, message = "must be at most {max} characters")
@@ -37,27 +38,6 @@ public class SoleTraderDetails extends TheirDetails implements TitledParty {
 
     public Optional<String> getBusinessName() {
         return Optional.ofNullable(businessName);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        SoleTraderDetails that = (SoleTraderDetails) obj;
-
-        return super.equals(that)
-            && Objects.equals(this.title, that.title)
-            && Objects.equals(this.businessName, that.businessName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), this.title, this.businessName);
     }
 
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/TheirDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/otherparty/TheirDetails.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.cmc.domain.models.otherparty;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotBlank;
@@ -10,7 +11,6 @@ import uk.gov.hmcts.cmc.domain.models.Address;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
 import uk.gov.hmcts.cmc.domain.models.party.NamedParty;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -31,6 +31,7 @@ import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
         @JsonSubTypes.Type(value = OrganisationDetails.class, name = "organisation")
     }
 )
+@EqualsAndHashCode
 public abstract class TheirDetails implements NamedParty {
 
     @NotBlank
@@ -83,30 +84,6 @@ public abstract class TheirDetails implements NamedParty {
 
     public Optional<Address> getServiceAddress() {
         return Optional.ofNullable(serviceAddress);
-    }
-
-    @Override
-    @SuppressWarnings("squid:S1067") // Its generated code for equals sonar
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        TheirDetails that = (TheirDetails) obj;
-
-        return Objects.equals(this.name, that.name)
-            && Objects.equals(this.address, that.address)
-            && Objects.equals(this.email, that.email)
-            && Objects.equals(this.representative, that.representative)
-            && Objects.equals(this.serviceAddress, that.serviceAddress);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, address, email, representative, serviceAddress);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/particulars/HousingDisrepair.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/particulars/HousingDisrepair.java
@@ -1,9 +1,14 @@
 package uk.gov.hmcts.cmc.domain.models.particulars;
 
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+
 import java.util.Optional;
 import javax.validation.constraints.NotNull;
 
+import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
+
+@EqualsAndHashCode
 public class HousingDisrepair {
 
     @NotNull
@@ -25,23 +30,7 @@ public class HousingDisrepair {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        HousingDisrepair that = (HousingDisrepair) obj;
-
-        return Objects.equals(this.costOfRepairsDamages, that.costOfRepairsDamages)
-            && Objects.equals(this.otherDamages, that.otherDamages);
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this, ourStyle());
     }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(costOfRepairsDamages, otherDamages);
-    }
-
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/particulars/PersonalInjury.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/particulars/PersonalInjury.java
@@ -1,10 +1,14 @@
 package uk.gov.hmcts.cmc.domain.models.particulars;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-import java.util.Objects;
 import javax.validation.constraints.NotNull;
 
+import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
+
+@EqualsAndHashCode
 public class PersonalInjury {
 
     @NotNull
@@ -20,22 +24,8 @@ public class PersonalInjury {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        PersonalInjury that = (PersonalInjury) obj;
-
-        return Objects.equals(this.generalDamages, that.generalDamages);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(generalDamages);
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this, ourStyle());
     }
 
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Company.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Company.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.cmc.domain.models.party;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.cmc.domain.models.Address;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
 
-import java.util.Objects;
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode(callSuper = true)
 public class Company extends Party implements HasContactPerson {
 
     private final String contactPerson;
@@ -26,25 +27,6 @@ public class Company extends Party implements HasContactPerson {
 
     public Optional<String> getContactPerson() {
         return Optional.ofNullable(contactPerson);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        Company other = (Company) obj;
-
-        return super.equals(other) && Objects.equals(contactPerson, other.contactPerson);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), contactPerson);
     }
 
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Individual.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Individual.java
@@ -2,14 +2,15 @@ package uk.gov.hmcts.cmc.domain.models.party;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.cmc.domain.constraints.AgeRangeValidator;
 import uk.gov.hmcts.cmc.domain.models.Address;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
 
 import java.time.LocalDate;
-import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode(callSuper = true)
 public class Individual extends Party {
 
     @JsonUnwrapped
@@ -30,26 +31,6 @@ public class Individual extends Party {
 
     public LocalDate getDateOfBirth() {
         return dateOfBirth;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        Individual other = (Individual) obj;
-
-        return super.equals(other)
-            && Objects.equals(dateOfBirth, other.dateOfBirth);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), dateOfBirth);
     }
 
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Organisation.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Organisation.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.cmc.domain.models.party;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.cmc.domain.models.Address;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
 
-import java.util.Objects;
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode(callSuper = true)
 public class Organisation extends Party implements HasContactPerson {
 
     private final String contactPerson;
@@ -33,25 +34,6 @@ public class Organisation extends Party implements HasContactPerson {
 
     public Optional<String> getCompaniesHouseNumber() {
         return Optional.ofNullable(companiesHouseNumber);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        Organisation other = (Organisation) obj;
-
-        return super.equals(other) && Objects.equals(contactPerson, other.contactPerson);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), contactPerson);
     }
 
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Party.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Party.java
@@ -3,12 +3,12 @@ package uk.gov.hmcts.cmc.domain.models.party;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.hmcts.cmc.domain.models.Address;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -29,6 +29,7 @@ import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
         @JsonSubTypes.Type(value = Organisation.class, name = "organisation")
     }
 )
+@EqualsAndHashCode
 public abstract class Party implements NamedParty {
 
     @NotBlank
@@ -81,30 +82,6 @@ public abstract class Party implements NamedParty {
 
     public Optional<Representative> getRepresentative() {
         return Optional.ofNullable(representative);
-    }
-
-    @SuppressWarnings("squid:S1067") // Number of conditional operators in boolean expression
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        Party other = (Party) obj;
-
-        return Objects.equals(name, other.name)
-            && Objects.equals(address, other.address)
-            && Objects.equals(correspondenceAddress, other.correspondenceAddress)
-            && Objects.equals(mobilePhone, other.mobilePhone)
-            && Objects.equals(representative, other.representative);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, address, correspondenceAddress, mobilePhone, representative);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/SoleTrader.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/SoleTrader.java
@@ -1,14 +1,15 @@
 package uk.gov.hmcts.cmc.domain.models.party;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.cmc.domain.models.Address;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.Size;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode(callSuper = true)
 public class SoleTrader extends Party implements TitledParty {
 
     @Size(max = 35, message = "must be at most {max} characters")
@@ -37,27 +38,6 @@ public class SoleTrader extends Party implements TitledParty {
 
     public Optional<String> getBusinessName() {
         return Optional.ofNullable(businessName);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        SoleTrader other = (SoleTrader) obj;
-
-        return super.equals(other)
-            && Objects.equals(title, other.title)
-            && Objects.equals(businessName, other.businessName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), title, businessName);
     }
 
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/CaseReference.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/CaseReference.java
@@ -2,12 +2,12 @@ package uk.gov.hmcts.cmc.domain.models.response;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
-import java.util.Objects;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class CaseReference {
     @JsonProperty("case_reference")
     private String caseReference;
@@ -23,26 +23,6 @@ public class CaseReference {
 
     public void setCaseReference(String caseReference) {
         this.caseReference = caseReference;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-
-        CaseReference obj = (CaseReference) other;
-
-        return caseReference != null && caseReference.equals(obj.caseReference);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(caseReference);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/ClaimState.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/ClaimState.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.cmc.domain.models.response;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
-import java.util.Objects;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class ClaimState {
 
     private final boolean isOnHold;
@@ -18,24 +18,6 @@ public class ClaimState {
 
     public boolean isOnHold() {
         return isOnHold;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        ClaimState status1 = (ClaimState) other;
-
-        return isOnHold == status1.isOnHold;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(isOnHold);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/DefendantLinkStatus.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/DefendantLinkStatus.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.cmc.domain.models.response;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
-import java.util.Objects;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class DefendantLinkStatus {
 
     private final boolean linked;
@@ -18,23 +18,6 @@ public class DefendantLinkStatus {
 
     public boolean isLinked() {
         return linked;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        DefendantLinkStatus status1 = (DefendantLinkStatus) other;
-        return linked == status1.linked;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(linked);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/DefendantTimeline.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/DefendantTimeline.java
@@ -1,18 +1,19 @@
 package uk.gov.hmcts.cmc.domain.models.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.models.TimelineEvent;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode
 public class DefendantTimeline {
 
     @Valid
@@ -34,25 +35,6 @@ public class DefendantTimeline {
 
     public List<TimelineEvent> getEvents() {
         return this.events == null ? Collections.emptyList() : this.events;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        DefendantTimeline that = (DefendantTimeline) other;
-        return Objects.equals(events, that.events)
-            && Objects.equals(comment, that.comment);
-    }
-
-    @Override
-    public int hashCode() {
-
-        return Objects.hash(events, comment);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/FullAdmissionResponse.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/FullAdmissionResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.cmc.domain.models.response;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.DateNotInThePast;
 import uk.gov.hmcts.cmc.domain.constraints.ValidFullAdmission;
@@ -11,7 +12,6 @@ import uk.gov.hmcts.cmc.domain.models.party.Party;
 import uk.gov.hmcts.cmc.domain.models.statementofmeans.StatementOfMeans;
 
 import java.time.LocalDate;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -20,6 +20,7 @@ import static uk.gov.hmcts.cmc.domain.models.response.ResponseType.FULL_ADMISSIO
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @ValidFullAdmission
+@EqualsAndHashCode(callSuper = true)
 public class FullAdmissionResponse extends Response {
 
     @NotNull
@@ -70,29 +71,6 @@ public class FullAdmissionResponse extends Response {
 
     public Optional<StatementOfMeans> getStatementOfMeans() {
         return Optional.ofNullable(statementOfMeans);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        if (!super.equals(other)) {
-            return false;
-        }
-        FullAdmissionResponse that = (FullAdmissionResponse) other;
-        return paymentOption == that.paymentOption
-            && Objects.equals(paymentDate, that.paymentDate)
-            && Objects.equals(repaymentPlan, that.repaymentPlan)
-            && Objects.equals(statementOfMeans, that.statementOfMeans);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), paymentOption, paymentDate, repaymentPlan, statementOfMeans);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/FullDefenceResponse.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/FullDefenceResponse.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.cmc.domain.models.response;
 
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.models.PaymentDeclaration;
 import uk.gov.hmcts.cmc.domain.models.evidence.DefendantEvidence;
 import uk.gov.hmcts.cmc.domain.models.legalrep.StatementOfTruth;
 import uk.gov.hmcts.cmc.domain.models.party.Party;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -15,6 +15,7 @@ import javax.validation.constraints.Size;
 import static uk.gov.hmcts.cmc.domain.models.response.ResponseType.FULL_DEFENCE;
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@EqualsAndHashCode(callSuper = true)
 public class FullDefenceResponse extends Response {
 
     @NotNull
@@ -69,30 +70,6 @@ public class FullDefenceResponse extends Response {
 
     public Optional<DefendantEvidence> getEvidence() {
         return Optional.ofNullable(evidence);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-
-        FullDefenceResponse other = (FullDefenceResponse) obj;
-
-        return super.equals(other)
-            && Objects.equals(defenceType, other.defenceType)
-            && Objects.equals(defence, other.defence)
-            && Objects.equals(paymentDeclaration, other.paymentDeclaration)
-            && Objects.equals(timeline, other.timeline)
-            && Objects.equals(evidence, other.evidence);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), defenceType, defence, paymentDeclaration, timeline, evidence);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/Response.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/Response.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.models.legalrep.StatementOfTruth;
 import uk.gov.hmcts.cmc.domain.models.party.Party;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -24,6 +24,7 @@ import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
     @JsonSubTypes.Type(value = FullDefenceResponse.class, name = "FULL_DEFENCE"),
     @JsonSubTypes.Type(value = FullAdmissionResponse.class, name = "FULL_ADMISSION")
 })
+@EqualsAndHashCode
 public abstract class Response {
 
     @NotNull
@@ -73,30 +74,6 @@ public abstract class Response {
 
     public Optional<StatementOfTruth> getStatementOfTruth() {
         return Optional.ofNullable(statementOfTruth);
-    }
-
-    @Override
-    @SuppressWarnings("squid:S1067") // Its generated code for equals sonar
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-
-        Response that = (Response) other;
-        return Objects.equals(responseType, that.responseType)
-            && Objects.equals(freeMediation, that.freeMediation)
-            && Objects.equals(moreTimeNeeded, that.moreTimeNeeded)
-            && Objects.equals(defendant, that.defendant)
-            && Objects.equals(statementOfTruth, that.statementOfTruth);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(responseType, freeMediation, moreTimeNeeded, defendant);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/BankAccount.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/BankAccount.java
@@ -1,16 +1,17 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class BankAccount {
 
     public enum BankAccountType {
@@ -55,25 +56,6 @@ public class BankAccount {
 
     public BigDecimal getBalance() {
         return balance;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        BankAccount that = (BankAccount) other;
-        return joint == that.joint
-            && type == that.type
-            && Objects.equals(balance, that.balance);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, joint, balance);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Child.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Child.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -11,6 +11,7 @@ import javax.validation.constraints.NotNull;
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class Child {
 
     public enum AgeGroupType {
@@ -59,25 +60,6 @@ public class Child {
 
     public Optional<Integer> getNumberOfChildrenLivingWithYou() {
         return Optional.ofNullable(numberOfChildrenLivingWithYou);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Child child = (Child) other;
-        return ageGroupType == child.ageGroupType
-            && Objects.equals(numberOfChildren, child.numberOfChildren)
-            && Objects.equals(numberOfChildrenLivingWithYou, child.numberOfChildrenLivingWithYou);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(ageGroupType, numberOfChildren, numberOfChildrenLivingWithYou);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/CourtOrder.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/CourtOrder.java
@@ -1,18 +1,19 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class CourtOrder {
 
     @NotBlank
@@ -44,25 +45,6 @@ public class CourtOrder {
 
     public BigDecimal getMonthlyInstalmentAmount() {
         return monthlyInstalmentAmount;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        CourtOrder that = (CourtOrder) other;
-        return Objects.equals(claimNumber, that.claimNumber)
-            && Objects.equals(amountOwed, that.amountOwed)
-            && Objects.equals(monthlyInstalmentAmount, that.monthlyInstalmentAmount);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(claimNumber, amountOwed, monthlyInstalmentAmount);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Debt.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Debt.java
@@ -1,18 +1,19 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class Debt {
 
     @NotBlank
@@ -44,25 +45,6 @@ public class Debt {
 
     public BigDecimal getMonthlyPayments() {
         return monthlyPayments;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Debt debt = (Debt) other;
-        return Objects.equals(description, debt.description)
-            && Objects.equals(totalOwed, debt.totalOwed)
-            && Objects.equals(monthlyPayments, debt.monthlyPayments);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(description, totalOwed, monthlyPayments);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Dependant.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Dependant.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
@@ -13,6 +13,7 @@ import static java.util.Collections.emptyList;
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class Dependant {
 
     @Valid
@@ -43,25 +44,6 @@ public class Dependant {
 
     public Optional<OtherDependants> getOtherDependants() {
         return Optional.ofNullable(otherDependants);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Dependant dependant = (Dependant) other;
-        return Objects.equals(children, dependant.children)
-            && Objects.equals(numberOfMaintainedChildren, dependant.numberOfMaintainedChildren)
-            && Objects.equals(otherDependants, dependant.otherDependants);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(children, numberOfMaintainedChildren, otherDependants);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Employer.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Employer.java
@@ -1,14 +1,14 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
-
-import java.util.Objects;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class Employer {
 
     @NotBlank
@@ -28,24 +28,6 @@ public class Employer {
 
     public String getName() {
         return name;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Employer employer = (Employer) other;
-        return Objects.equals(jobTitle, employer.jobTitle)
-            && Objects.equals(name, employer.name);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(jobTitle, name);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Employment.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Employment.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.EachNotNull;
 import uk.gov.hmcts.cmc.domain.constraints.ValidEmployment;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 
@@ -14,6 +14,7 @@ import static java.util.Collections.emptyList;
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 @ValidEmployment
 public class Employment {
 
@@ -47,25 +48,6 @@ public class Employment {
 
     public Optional<Unemployment> getUnemployment() {
         return Optional.ofNullable(unemployment);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Employment that = (Employment) other;
-        return Objects.equals(employers, that.employers)
-            && Objects.equals(selfEmployment, that.selfEmployment)
-            && Objects.equals(unemployment, that.unemployment);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(employers, selfEmployment, unemployment);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Expense.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Expense.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
 import uk.gov.hmcts.cmc.domain.constraints.ValidExpense;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotNull;
@@ -14,6 +14,7 @@ import javax.validation.constraints.NotNull;
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 @ValidExpense
 public class Expense {
 
@@ -83,26 +84,6 @@ public class Expense {
 
     public BigDecimal getAmountPaid() {
         return amountPaid;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Expense expense = (Expense) other;
-        return type == expense.type
-            && Objects.equals(otherExpense, expense.otherExpense)
-            && frequency == expense.frequency
-            && Objects.equals(amountPaid, expense.amountPaid);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, otherExpense, frequency, amountPaid);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Income.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Income.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
 import uk.gov.hmcts.cmc.domain.constraints.ValidIncome;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotNull;
@@ -14,6 +14,7 @@ import javax.validation.constraints.NotNull;
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 @ValidIncome
 public class Income {
 
@@ -79,26 +80,6 @@ public class Income {
 
     public BigDecimal getAmountReceived() {
         return amountReceived;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Income income = (Income) other;
-        return type == income.type
-            && Objects.equals(otherSource, income.otherSource)
-            && frequency == income.frequency
-            && Objects.equals(amountReceived, income.amountReceived);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, otherSource, frequency, amountReceived);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/OnTaxPayments.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/OnTaxPayments.java
@@ -1,18 +1,19 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class OnTaxPayments {
 
     @NotNull
@@ -34,24 +35,6 @@ public class OnTaxPayments {
 
     public String getReason() {
         return reason;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        OnTaxPayments that = (OnTaxPayments) other;
-        return Objects.equals(amountYouOwe, that.amountYouOwe)
-            && Objects.equals(reason, that.reason);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(amountYouOwe, reason);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/OtherDependants.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/OtherDependants.java
@@ -1,16 +1,17 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 
-import java.util.Objects;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class OtherDependants {
 
     @NotNull
@@ -31,24 +32,6 @@ public class OtherDependants {
 
     public String getDetails() {
         return details;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        OtherDependants that = (OtherDependants) other;
-        return Objects.equals(numberOfPeople, that.numberOfPeople)
-            && Objects.equals(details, that.details);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(numberOfPeople, details);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Residence.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Residence.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.cmc.domain.constraints.ValidResidence;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.NotNull;
 
 @Builder
+@EqualsAndHashCode
 @ValidResidence
 public class Residence {
 
@@ -47,21 +48,4 @@ public class Residence {
         return Optional.ofNullable(otherDetail);
     }
 
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Residence residence = (Residence) other;
-        return type == residence.type
-            && Objects.equals(otherDetail, residence.otherDetail);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, otherDetail);
-    }
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/SelfEmployment.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/SelfEmployment.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
@@ -15,6 +15,7 @@ import javax.validation.constraints.NotNull;
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class SelfEmployment {
 
     @NotBlank
@@ -48,25 +49,6 @@ public class SelfEmployment {
 
     public Optional<OnTaxPayments> getOnTaxPayments() {
         return Optional.ofNullable(onTaxPayments);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        SelfEmployment that = (SelfEmployment) other;
-        return Objects.equals(jobTitle, that.jobTitle)
-            && Objects.equals(annualTurnover, that.annualTurnover)
-            && Objects.equals(onTaxPayments, that.onTaxPayments);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(jobTitle, annualTurnover, onTaxPayments);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/StatementOfMeans.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/StatementOfMeans.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.NotEmpty;
 import uk.gov.hmcts.cmc.domain.constraints.EachNotNull;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -16,6 +16,7 @@ import static java.util.Collections.emptyList;
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class StatementOfMeans {
 
     @Valid
@@ -109,32 +110,6 @@ public class StatementOfMeans {
 
     public String getReason() {
         return reason;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        StatementOfMeans that = (StatementOfMeans) other;
-        return Objects.equals(residence, that.residence)
-            && Objects.equals(dependant, that.dependant)
-            && Objects.equals(employment, that.employment)
-            && Objects.equals(bankAccounts, that.bankAccounts)
-            && Objects.equals(debts, that.debts)
-            && Objects.equals(incomes, that.incomes)
-            && Objects.equals(expenses, that.expenses)
-            && Objects.equals(courtOrders, that.courtOrders)
-            && Objects.equals(reason, that.reason);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(residence, dependant, employment, bankAccounts, debts, incomes, expenses,
-            courtOrders, reason);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Unemployed.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Unemployed.java
@@ -1,16 +1,17 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-import java.util.Objects;
 import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class Unemployed {
-    
+
     @NotNull
     private final Integer numberOfYears;
     @NotNull
@@ -27,23 +28,6 @@ public class Unemployed {
 
     public Integer getNumberOfMonths() {
         return numberOfMonths;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Unemployed that = (Unemployed) other;
-        return Objects.equals(numberOfYears, that.numberOfYears) && Objects.equals(numberOfMonths, that.numberOfMonths);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(numberOfYears, numberOfMonths);
     }
 
     @Override

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Unemployment.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/statementofmeans/Unemployment.java
@@ -1,15 +1,16 @@
 package uk.gov.hmcts.cmc.domain.models.statementofmeans;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Builder
+@EqualsAndHashCode
 public class Unemployment {
 
     @Valid
@@ -34,26 +35,6 @@ public class Unemployment {
 
     public Optional<String> getOther() {
         return Optional.ofNullable(other);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        Unemployment that = (Unemployment) other;
-        return retired == that.retired
-            && Objects.equals(unemployed, that.unemployed)
-            && Objects.equals(this.other, that.other);
-    }
-
-    @Override
-    public int hashCode() {
-
-        return Objects.hash(unemployed, retired, other);
     }
 
     @Override


### PR DESCRIPTION
### Change description ###

This PR replaces manually written `equals` and `hashcode` methods with `lombok` generated ones. It reduces the boiler point code, keeping domain models cleaner and avoids human errors while adding/removing new properties in class.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

