### PR TITLE
ROC-4415: Finalise claimant response only when finalise option is provided

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseService.java
@@ -50,7 +50,10 @@ public class ClaimantResponseService {
 
         caseRepository.saveClaimantResponse(claim, response, authorization);
         eventProducer.createClaimantResponseEvent(claim);
-        formaliseResponseAcceptanceService.formalise(claim, response, authorization);
+
+        if (response instanceof ResponseAcceptation && ((ResponseAcceptation) response).getFormaliseOption() != null) {
+            formaliseResponseAcceptanceService.formalise(claim, (ResponseAcceptation) response, authorization);
+        }
 
         appInsights.trackEvent(getAppInsightsEvent(response), claim.getReferenceNumber());
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/FormaliseResponseAcceptanceService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/FormaliseResponseAcceptanceService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
 import uk.gov.hmcts.cmc.domain.models.RepaymentPlan;
-import uk.gov.hmcts.cmc.domain.models.claimantresponse.ClaimantResponse;
 import uk.gov.hmcts.cmc.domain.models.claimantresponse.DeterminationDecisionType;
 import uk.gov.hmcts.cmc.domain.models.claimantresponse.FormaliseOption;
 import uk.gov.hmcts.cmc.domain.models.claimantresponse.ResponseAcceptation;
@@ -43,11 +42,7 @@ public class FormaliseResponseAcceptanceService {
         this.offersService = offersService;
     }
 
-    public void formalise(Claim claim, ClaimantResponse claimantResponse, String authorisation) {
-        if (!(claimantResponse instanceof ResponseAcceptation)) {
-            return;
-        }
-        ResponseAcceptation responseAcceptation = (ResponseAcceptation) claimantResponse;
+    public void formalise(Claim claim, ResponseAcceptation responseAcceptation, String authorisation) {
         FormaliseOption formaliseOption = responseAcceptation.getFormaliseOption();
         if (formaliseOption == null) {
             throw new IllegalArgumentException("formaliseOption must not be null");

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/FormaliseResponseAcceptanceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/FormaliseResponseAcceptanceServiceTest.java
@@ -10,11 +10,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
 import uk.gov.hmcts.cmc.domain.models.RepaymentPlan;
-import uk.gov.hmcts.cmc.domain.models.claimantresponse.ClaimantResponse;
 import uk.gov.hmcts.cmc.domain.models.claimantresponse.CourtDetermination;
 import uk.gov.hmcts.cmc.domain.models.claimantresponse.FormaliseOption;
 import uk.gov.hmcts.cmc.domain.models.claimantresponse.ResponseAcceptation;
-import uk.gov.hmcts.cmc.domain.models.claimantresponse.ResponseRejection;
 import uk.gov.hmcts.cmc.domain.models.offers.Settlement;
 import uk.gov.hmcts.cmc.domain.models.response.FullAdmissionResponse;
 import uk.gov.hmcts.cmc.domain.models.response.PartAdmissionResponse;
@@ -490,17 +488,6 @@ public class FormaliseResponseAcceptanceServiceTest {
             .build();
         assertThatCode(() -> formaliseResponseAcceptanceService
             .formalise(claim, responseAcceptation, AUTH)).doesNotThrowAnyException();
-
-        verifyZeroInteractions(countyCourtJudgmentService);
-        verifyZeroInteractions(offersService);
-    }
-
-    @Test
-    public void doNotFormaliseWhenResponseIsNotAcceptation() {
-        Claim claim = SampleClaim.getWithDefaultResponse();
-        ClaimantResponse response = ResponseRejection.builder().build();
-        assertThatCode(() -> formaliseResponseAcceptanceService
-            .formalise(claim, response, AUTH)).doesNotThrowAnyException();
 
         verifyZeroInteractions(countyCourtJudgmentService);
         verifyZeroInteractions(offersService);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-4415

### Change description ###

This PR makes call to finalise method only when finalise option is provided.

Additionally small refactoring was made to make finalise method accept only certain responses.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```