### PR TITLE
Use builder generated by Lombok in sample domain classes

### DIFF
--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/AmountMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/AmountMapperTest.java
@@ -36,7 +36,7 @@ public class AmountMapperTest {
     @Test
     public void shouldMapAmountRangeToCCD() {
         //given
-        Amount amount = SampleAmountRange.validDefaults();
+        Amount amount = SampleAmountRange.builder().build();
 
         //when
         CCDAmount ccdAmount = amountMapper.to(amount);
@@ -65,7 +65,7 @@ public class AmountMapperTest {
     @Test
     public void shouldMapAmountBreakDownToCCD() {
         //given
-        Amount amount = SampleAmountBreakdown.validDefaults();
+        Amount amount = SampleAmountBreakdown.builder().build();
 
         //when
         CCDAmount ccdAmount = amountMapper.to(amount);

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/ccj/CountyCourtJudgmentMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/ccj/CountyCourtJudgmentMapperTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.cmc.ccd.domain.CCDRepaymentPlan;
 import uk.gov.hmcts.cmc.ccd.domain.CCDStatementOfTruth;
 import uk.gov.hmcts.cmc.ccd.domain.ccj.CCDCountyCourtJudgment;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
 import uk.gov.hmcts.cmc.domain.models.legalrep.StatementOfTruth;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleCountyCourtJudgment;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleRepaymentPlan;
@@ -46,9 +47,9 @@ public class CountyCourtJudgmentMapperTest {
     public void shouldMapCountyCourtJudgmentWithPaymentOptionImmediatelyToCCD() {
         //given
         final CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment.builder()
-            .withPaymentOptionImmediately()
-            .withPaidAmount(BigDecimal.TEN)
-            .withStatementOfTruth(new StatementOfTruth("Tester", "Unit Test"))
+            .paymentOption(PaymentOption.IMMEDIATELY)
+            .paidAmount(BigDecimal.TEN)
+            .statementOfTruth(new StatementOfTruth("Tester", "Unit Test"))
             .build();
 
         //when
@@ -62,8 +63,9 @@ public class CountyCourtJudgmentMapperTest {
     public void shouldMapCountyCourtJudgmentWithPaymentOptionSpecifiedDateToCCD() {
         //given
         final CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment.builder()
-            .withPayBySetDate(now())
-            .withStatementOfTruth(new StatementOfTruth("Tester", "Unit Test"))
+            .paymentOption(PaymentOption.BY_SPECIFIED_DATE)
+            .payBySetDate(now())
+            .statementOfTruth(new StatementOfTruth("Tester", "Unit Test"))
             .build();
 
         //when
@@ -77,8 +79,9 @@ public class CountyCourtJudgmentMapperTest {
     public void shouldMapCountyCourtJudgmentWithPaymentOptionInstalmentsToCCD() {
         //given
         final CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment.builder()
-            .withRepaymentPlan(SampleRepaymentPlan.builder().build())
-            .withStatementOfTruth(new StatementOfTruth("Tester", "Unit Test"))
+            .paymentOption(PaymentOption.INSTALMENTS)
+            .repaymentPlan(SampleRepaymentPlan.builder().build())
+            .statementOfTruth(new StatementOfTruth("Tester", "Unit Test"))
             .build();
 
         //when

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/ccj/RepaymentPlanMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/ccj/RepaymentPlanMapperTest.java
@@ -42,7 +42,7 @@ public class RepaymentPlanMapperTest {
     @Test
     public void shouldMapMonthlyRepaymentPlanToCCD() {
         //given
-        final RepaymentPlan repaymentPlan = SampleRepaymentPlan.builder().withPaymentSchedule(EVERY_MONTH).build();
+        final RepaymentPlan repaymentPlan = SampleRepaymentPlan.builder().paymentSchedule(EVERY_MONTH).build();
 
         //when
         CCDRepaymentPlan ccdRepaymentPlan = repaymentPlanMapper.to(repaymentPlan);
@@ -54,7 +54,7 @@ public class RepaymentPlanMapperTest {
     @Test
     public void shouldMapFortnightlyRepaymentPlanToCCD() {
         //given
-        final RepaymentPlan repaymentPlan = SampleRepaymentPlan.builder().withPaymentSchedule(EVERY_TWO_WEEKS).build();
+        final RepaymentPlan repaymentPlan = SampleRepaymentPlan.builder().paymentSchedule(EVERY_TWO_WEEKS).build();
 
         //when
         CCDRepaymentPlan ccdRepaymentPlan = repaymentPlanMapper.to(repaymentPlan);

--- a/domain-model/build.gradle
+++ b/domain-model/build.gradle
@@ -24,4 +24,5 @@ dependencies {
   testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
   testCompile group: 'javax.el', name: 'javax.el-api', version: '3.0.0'
   testCompile group: 'org.glassfish.web', name: 'javax.el', version: '2.2.6'
+  testCompile group: 'com.google.guava', name: 'guava', version: '20.0'
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Address.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Address.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cmc.domain.models;
 
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.hmcts.cmc.domain.constraints.Postcode;
@@ -7,6 +8,7 @@ import uk.gov.hmcts.cmc.domain.constraints.Postcode;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+@Builder()
 @EqualsAndHashCode
 public class Address {
 

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Payment.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.cmc.domain.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
@@ -11,6 +12,7 @@ import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@Builder
 @EqualsAndHashCode
 @JsonIgnoreProperties(value = {"description", "state"})
 public class Payment {

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/PaymentDeclaration.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/PaymentDeclaration.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cmc.domain.models;
 
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
@@ -11,6 +12,7 @@ import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@Builder
 @EqualsAndHashCode
 public class PaymentDeclaration {
 

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountBreakDown.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountBreakDown.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.cmc.domain.models.amount;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.MinTotalAmount;
@@ -16,6 +17,7 @@ import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@Builder
 @EqualsAndHashCode
 public class AmountBreakDown implements Amount {
 

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountRange.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/amount/AmountRange.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cmc.domain.models.amount;
 
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
@@ -11,6 +12,7 @@ import javax.validation.constraints.NotNull;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@Builder
 @EqualsAndHashCode
 public class AmountRange implements Amount {
 

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/evidence/EvidenceRow.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/evidence/EvidenceRow.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cmc.domain.models.evidence;
 
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
@@ -9,6 +10,7 @@ import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@Builder
 @EqualsAndHashCode
 public class EvidenceRow {
 

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/legalrep/ContactDetails.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/legalrep/ContactDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cmc.domain.models.legalrep;
 
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.Email;
@@ -10,6 +11,7 @@ import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@Builder
 @EqualsAndHashCode
 public class ContactDetails {
 

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/legalrep/Representative.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/legalrep/Representative.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cmc.domain.models.legalrep;
 
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
@@ -12,6 +13,7 @@ import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@Builder
 @EqualsAndHashCode
 public class Representative {
 

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/PartyStatement.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/offers/PartyStatement.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.cmc.domain.models.offers;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
@@ -8,6 +9,7 @@ import java.util.Optional;
 
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
+@Builder
 @EqualsAndHashCode
 public class PartyStatement {
 

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/amount/TotalAmountCalculatorTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/amount/TotalAmountCalculatorTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.cmc.domain.amount;
 
 import org.junit.Test;
 import uk.gov.hmcts.cmc.domain.models.Claim;
+import uk.gov.hmcts.cmc.domain.models.sampledata.SampleAmountBreakdown;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleAmountRange;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
@@ -14,7 +15,6 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.hmcts.cmc.domain.models.sampledata.SampleAmountBreakdown.validDefaults;
 import static uk.gov.hmcts.cmc.domain.models.sampledata.SampleInterest.breakdownInterestBuilder;
 import static uk.gov.hmcts.cmc.domain.models.sampledata.SampleInterest.noInterest;
 import static uk.gov.hmcts.cmc.domain.models.sampledata.SampleInterest.standardInterestBuilder;
@@ -73,7 +73,7 @@ public class TotalAmountCalculatorTest {
         Claim claimNoInterest = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withInterest(noInterest())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .build()
@@ -88,7 +88,7 @@ public class TotalAmountCalculatorTest {
         Claim claimNoInterest = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withInterest(noInterest())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .build()
@@ -104,7 +104,7 @@ public class TotalAmountCalculatorTest {
         Claim claimStandardInterest = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(
                         standardInterestBuilder()
@@ -122,7 +122,7 @@ public class TotalAmountCalculatorTest {
         Claim claimStandardInterest = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(
                         standardInterestBuilder()
@@ -142,7 +142,7 @@ public class TotalAmountCalculatorTest {
         Claim claimStandardInterest = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                         .withInterest(
                             standardInterestBuilder()
@@ -162,7 +162,7 @@ public class TotalAmountCalculatorTest {
         Claim claimStandardInterest = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                         .withInterest(
                             standardInterestBuilder()
@@ -187,7 +187,7 @@ public class TotalAmountCalculatorTest {
         Claim claim = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(
                         breakdownInterestBuilder()
@@ -210,7 +210,7 @@ public class TotalAmountCalculatorTest {
         Claim claim = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(
                         breakdownInterestBuilder()
@@ -234,7 +234,7 @@ public class TotalAmountCalculatorTest {
         Claim claim = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(
                         breakdownInterestBuilder()
@@ -258,7 +258,7 @@ public class TotalAmountCalculatorTest {
         Claim claim = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(
                         breakdownInterestBuilder()
@@ -280,7 +280,7 @@ public class TotalAmountCalculatorTest {
         Claim claim = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                        .withAmount(validDefaults())
+                        .withAmount(SampleAmountBreakdown.builder().build())
                         .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                         .withInterest(
                             breakdownInterestBuilder()
@@ -304,7 +304,7 @@ public class TotalAmountCalculatorTest {
         Claim claim = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(
                         breakdownInterestBuilder()
@@ -328,7 +328,7 @@ public class TotalAmountCalculatorTest {
         Claim claimStandardInterest = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(standardInterestBuilder()
                             .withInterestDate(SampleInterestDate.submission())
@@ -347,7 +347,7 @@ public class TotalAmountCalculatorTest {
         Claim claimStandardInterest = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(standardInterestBuilder()
                             .withInterestDate(SampleInterestDate.submission())
@@ -366,7 +366,7 @@ public class TotalAmountCalculatorTest {
         Claim claimStandardInterest = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(
                         standardInterestBuilder()
@@ -386,7 +386,7 @@ public class TotalAmountCalculatorTest {
         Claim claim = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(
                         breakdownInterestBuilder()
@@ -408,7 +408,7 @@ public class TotalAmountCalculatorTest {
         Claim claim = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(
                         breakdownInterestBuilder()
@@ -430,7 +430,7 @@ public class TotalAmountCalculatorTest {
         Claim claimStandardInterest = SampleClaim.builder()
             .withClaimData(
                 SampleClaimData.builder()
-                    .withAmount(validDefaults())
+                    .withAmount(SampleAmountBreakdown.builder().build())
                     .withFeeAmount(TWENTY_POUNDS_IN_PENNIES)
                     .withInterest(
                         standardInterestBuilder()
@@ -448,7 +448,7 @@ public class TotalAmountCalculatorTest {
     private static Claim claimWithAmountRange() {
         return SampleClaim.builder()
             .withClaimData(
-                SampleClaimData.builder().withAmount(SampleAmountRange.validDefaults()).build()
+                SampleClaimData.builder().withAmount(SampleAmountRange.builder().build()).build()
             ).build();
     }
 

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/constraints/ValidCountyCourtJudgmentValidatorTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/constraints/ValidCountyCourtJudgmentValidatorTest.java
@@ -38,14 +38,18 @@ public class ValidCountyCourtJudgmentValidatorTest {
 
     @Test
     public void shouldReturnTrueForNullPaymentOptionInput() {
-        CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder().withPaymentOption(null).build();
+        CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
+            .paymentOption(null)
+            .build();
         assertThat(validator.isValid(ccj, context)).isTrue();
     }
 
     @Test
     public void shouldReturnTrueForValidModelWithImmediatelyPaymentOption() {
 
-        CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder().withPaymentOptionImmediately().build();
+        CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
+            .paymentOption(PaymentOption.IMMEDIATELY)
+            .build();
 
         assertThat(validator.isValid(ccj, context)).isTrue();
     }
@@ -54,7 +58,8 @@ public class ValidCountyCourtJudgmentValidatorTest {
     public void shouldReturnTrueForValidModelWithPayByInstalmentsPaymentOption() {
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
-            .withRepaymentPlan(
+            .paymentOption(PaymentOption.INSTALMENTS)
+            .repaymentPlan(
                 SampleRepaymentPlan.builder().build()
             ).build();
 
@@ -65,7 +70,8 @@ public class ValidCountyCourtJudgmentValidatorTest {
     public void shouldReturnTrueForValidModelWithPayBySetDatePaymentOption() {
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
-            .withPayBySetDate(
+            .paymentOption(PaymentOption.BY_SPECIFIED_DATE)
+            .payBySetDate(
                 LocalDate.now().plusDays(100)
             ).build();
 
@@ -76,8 +82,9 @@ public class ValidCountyCourtJudgmentValidatorTest {
     public void shouldReturnFalseForImmediatelyWithPopulatedRepaymentPlan() {
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
-            .withRepaymentPlan(SampleRepaymentPlan.builder().build())
-            .withPaymentOption(PaymentOption.IMMEDIATELY).build();
+            .paymentOption(PaymentOption.IMMEDIATELY)
+            .repaymentPlan(SampleRepaymentPlan.builder().build())
+            .build();
 
         assertThat(validator.isValid(ccj, context)).isFalse();
     }
@@ -86,8 +93,9 @@ public class ValidCountyCourtJudgmentValidatorTest {
     public void shouldReturnFalseForImmediatelyWithPopulatedPayBySetDate() {
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
-            .withPayBySetDate(LocalDate.now().plusDays(100))
-            .withPaymentOption(PaymentOption.IMMEDIATELY).build();
+            .paymentOption(PaymentOption.IMMEDIATELY)
+            .payBySetDate(LocalDate.now().plusDays(100))
+            .build();
 
         assertThat(validator.isValid(ccj, context)).isFalse();
     }
@@ -96,8 +104,9 @@ public class ValidCountyCourtJudgmentValidatorTest {
     public void shouldReturnFalseForByInstalmentsWithPopulatedPayBySetDate() {
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
-            .withPayBySetDate(LocalDate.now().plusDays(100))
-            .withPaymentOption(PaymentOption.INSTALMENTS).build();
+            .paymentOption(PaymentOption.INSTALMENTS)
+            .payBySetDate(LocalDate.now().plusDays(100))
+            .build();
 
         assertThat(validator.isValid(ccj, context)).isFalse();
     }
@@ -106,8 +115,9 @@ public class ValidCountyCourtJudgmentValidatorTest {
     public void shouldReturnFalseForBySetDateWithPopulatedRepaymentPlan() {
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
-            .withRepaymentPlan(SampleRepaymentPlan.builder().build())
-            .withPaymentOption(PaymentOption.BY_SPECIFIED_DATE).build();
+            .paymentOption(PaymentOption.BY_SPECIFIED_DATE)
+            .repaymentPlan(SampleRepaymentPlan.builder().build())
+            .build();
 
         assertThat(validator.isValid(ccj, context)).isFalse();
     }

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/constraints/ValidPartAdmissionConstraintValidatorTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/constraints/ValidPartAdmissionConstraintValidatorTest.java
@@ -132,7 +132,7 @@ public class ValidPartAdmissionConstraintValidatorTest {
     @Test
     public void shouldBeInvalidWhenBothPaymentDeclarationAndPaymentIntentionArePopulated() {
         PartAdmissionResponse partAdmissionResponse = builder()
-            .paymentDeclaration(SamplePaymentDeclaration.validDefaults())
+            .paymentDeclaration(SamplePaymentDeclaration.builder().build())
             .paymentIntention(SamplePaymentIntention.immediately())
             .build();
 
@@ -142,7 +142,7 @@ public class ValidPartAdmissionConstraintValidatorTest {
     @Test
     public void shouldInvalidWhenOnlyPaymentDeclarationIsPopulatedAndItIsValid() {
         PartAdmissionResponse partAdmissionResponse = builder()
-            .paymentDeclaration(SamplePaymentDeclaration.validDefaults())
+            .paymentDeclaration(SamplePaymentDeclaration.builder().build())
             .build();
 
         assertThat(validator.isValid(partAdmissionResponse, validatorContext)).isTrue();

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/AddressTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/AddressTest.java
@@ -14,7 +14,7 @@ public class AddressTest {
     @Test
     public void shouldBeSuccessfulValidationForCorrectAddress() {
         //given
-        Address address = SampleAddress.validDefaults();
+        Address address = SampleAddress.builder().build();
         //when
         Set<String> response = validate(address);
         //then
@@ -25,7 +25,7 @@ public class AddressTest {
     public void shouldBeInvalidForNullLineOne() {
         //given
         Address address = SampleAddress.builder()
-            .withLine1(null)
+            .line1(null)
             .build();
         //when
         Set<String> errors = validate(address);
@@ -39,7 +39,7 @@ public class AddressTest {
     public void shouldBeInvalidForEmptyLineOne() {
         //given
         Address address = SampleAddress.builder()
-            .withLine1("")
+            .line1("")
             .build();
         //when
         Set<String> errors = validate(address);
@@ -53,7 +53,7 @@ public class AddressTest {
     public void shouldBeInvalidForTooLongLineOne() {
         //given
         Address address = SampleAddress.builder()
-            .withLine1(StringUtils.repeat("a", 101))
+            .line1(StringUtils.repeat("a", 101))
             .build();
         //when
         Set<String> errors = validate(address);
@@ -67,7 +67,7 @@ public class AddressTest {
     public void shouldBeInvalidForTooLongLineTwo() {
         //given
         Address address = SampleAddress.builder()
-            .withLine2(StringUtils.repeat("a", 101))
+            .line2(StringUtils.repeat("a", 101))
             .build();
         //when
         Set<String> errors = validate(address);
@@ -81,7 +81,7 @@ public class AddressTest {
     public void shouldBeInvalidForTooLongLineThree() {
         //given
         Address address = SampleAddress.builder()
-            .withLine3(StringUtils.repeat("a", 101))
+            .line3(StringUtils.repeat("a", 101))
             .build();
         //when
         Set<String> errors = validate(address);
@@ -95,7 +95,7 @@ public class AddressTest {
     public void shouldBeInvalidForEmptyCity() {
         //given
         Address address = SampleAddress.builder()
-            .withCity("")
+            .city("")
             .build();
         //when
         Set<String> errors = validate(address);
@@ -109,7 +109,7 @@ public class AddressTest {
     public void shouldBeInvalidForTooLongCity() {
         //given
         Address address = SampleAddress.builder()
-            .withCity(StringUtils.repeat("a", 101))
+            .city(StringUtils.repeat("a", 101))
             .build();
         //when
         Set<String> errors = validate(address);
@@ -123,7 +123,7 @@ public class AddressTest {
     public void shouldBeInvalidForNullPostcode() {
         //given
         Address address = SampleAddress.builder()
-            .withPostcode(null)
+            .postcode(null)
             .build();
         //when
         Set<String> errors = validate(address);
@@ -137,7 +137,7 @@ public class AddressTest {
     public void shouldBeInvalidForEmptyPostcode() {
         //given
         Address address = SampleAddress.builder()
-            .withPostcode("")
+            .postcode("")
             .build();
         //when
         Set<String> errors = validate(address);
@@ -151,7 +151,7 @@ public class AddressTest {
     public void shouldBeInvalidForInvalidPostcode() {
         //given
         Address address = SampleAddress.builder()
-            .withPostcode("SW123456")
+            .postcode("SW123456")
             .build();
         //when
         Set<String> errors = validate(address);

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/AmountBreakDownTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/AmountBreakDownTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cmc.domain.models;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import uk.gov.hmcts.cmc.domain.models.amount.AmountBreakDown;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleAmountBreakdown;
@@ -7,7 +8,6 @@ import uk.gov.hmcts.cmc.domain.models.sampledata.SampleAmountBreakdown;
 import java.math.BigDecimal;
 import java.util.Set;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.cmc.domain.BeanValidator.validate;
 
@@ -16,10 +16,7 @@ public class AmountBreakDownTest {
     @Test
     public void shouldBeSuccessfulValidationForFullAmountDetails() {
         //given
-        AmountBreakDown amountBreakDown = SampleAmountBreakdown.builder()
-            .clearRows()
-            .addRow(new AmountRow("reason", new BigDecimal("40")))
-            .build();
+        AmountBreakDown amountBreakDown = SampleAmountBreakdown.builder().build();
         //when
         Set<String> validationMessages = validate(amountBreakDown);
         //then
@@ -30,7 +27,7 @@ public class AmountBreakDownTest {
     public void shouldReturnValidationMessageWhenAmountBreakDownHasNullRows() {
         //given
         AmountBreakDown amountBreakDown = SampleAmountBreakdown.builder()
-            .withRows(null)
+            .rows(null)
             .build();
         //when
         Set<String> validationMessages = validate(amountBreakDown);
@@ -44,9 +41,9 @@ public class AmountBreakDownTest {
     public void shouldReturnValidationMessageWhenHasInvalidAmountRow() {
         //given
         AmountBreakDown amountBreakDown = SampleAmountBreakdown.builder()
-            .clearRows()
-            .addRow(new AmountRow("reason", null))
-            .addRow(new AmountRow("reason", new BigDecimal("10")))
+            .rows(ImmutableList.of(
+                new AmountRow("reason", null),
+                new AmountRow("reason", new BigDecimal("10"))))
             .build();
         //when
         Set<String> validationMessages = validate(amountBreakDown);
@@ -60,7 +57,7 @@ public class AmountBreakDownTest {
     public void shouldReturnValidationMessageWhenBreakdownHasEmptyRowsList() {
         //given
         AmountBreakDown amountBreakDown = SampleAmountBreakdown.builder()
-            .withRows(emptyList())
+            .rows(ImmutableList.of())
             .build();
         //when
         Set<String> validationMessages = validate(amountBreakDown);
@@ -74,8 +71,7 @@ public class AmountBreakDownTest {
     public void shouldReturnValidationMessagesWhenBreakdownHasRowWith0Amount() {
         //given
         AmountBreakDown amountBreakDown = SampleAmountBreakdown.builder()
-            .clearRows()
-            .addRow(new AmountRow("reason", new BigDecimal("0")))
+            .rows(ImmutableList.of(new AmountRow("reason", new BigDecimal("0"))))
             .build();
         //when
         Set<String> validationMessages = validate(amountBreakDown);

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/AmountRangeTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/AmountRangeTest.java
@@ -14,7 +14,7 @@ public class AmountRangeTest {
     @Test
     public void shouldBeSuccessfulValidationForValidAmountDetails() {
         //given
-        AmountRange amountRow = SampleAmountRange.validDefaults();
+        AmountRange amountRow = SampleAmountRange.builder().build();
         //when
         Set<String> errors = validate(amountRow);
         //then
@@ -24,8 +24,10 @@ public class AmountRangeTest {
     @Test
     public void shouldBeSuccessfulValidationForMaximumValue() {
         //given
-        AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(9999999.99))
-            .withLowerValue(valueOf(9999999.99)).build();
+        AmountRange amountRow = SampleAmountRange.builder()
+            .higherValue(valueOf(9999999.99))
+            .lowerValue(valueOf(9999999.99))
+            .build();
 
         //when
         Set<String> errors = validate(amountRow);
@@ -36,8 +38,10 @@ public class AmountRangeTest {
     @Test
     public void shouldBeSuccessfulValidationForMinimum() {
         //given
-        AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(0.01))
-            .withLowerValue(valueOf(0.01)).build();
+        AmountRange amountRow = SampleAmountRange.builder()
+            .higherValue(valueOf(0.01))
+            .lowerValue(valueOf(0.01))
+            .build();
 
         //when
         Set<String> errors = validate(amountRow);
@@ -48,7 +52,9 @@ public class AmountRangeTest {
     @Test
     public void shouldHaveErrorsForValueHigherThanMaximum() {
         //given
-        AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(10000000)).build();
+        AmountRange amountRow = SampleAmountRange.builder()
+            .higherValue(valueOf(10000000))
+            .build();
         //when
         Set<String> errors = validate(amountRow);
         //then
@@ -58,8 +64,10 @@ public class AmountRangeTest {
     @Test
     public void shouldHaveErrorsForValueLowerThanMinimum() {
         //given
-        AmountRange amountRow = SampleAmountRange.builder().withHigherValue(valueOf(0))
-            .withLowerValue(valueOf(0)).build();
+        AmountRange amountRow = SampleAmountRange.builder()
+            .higherValue(valueOf(0))
+            .lowerValue(valueOf(0))
+            .build();
 
         //when
         Set<String> errors = validate(amountRow);

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/CountyCourtJudgmentTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/CountyCourtJudgmentTest.java
@@ -25,8 +25,8 @@ public class CountyCourtJudgmentTest {
     public void shouldBeInvalidForNullLineOne() {
         //given
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
-            .withRepaymentPlan(SampleRepaymentPlan.builder().build())
-            .withPaymentOption(PaymentOption.IMMEDIATELY)
+            .paymentOption(PaymentOption.IMMEDIATELY)
+            .repaymentPlan(SampleRepaymentPlan.builder().build())
             .build();
         //when
         Set<String> errors = validate(ccj);

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/PartyTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/PartyTest.java
@@ -69,7 +69,7 @@ public class PartyTest {
     public void shouldReturnValidationErrorsWhenGivenInvalidAddress() {
         Party party = SampleParty.builder()
             .withAddress(SampleAddress.builder()
-                .withPostcode("")
+                .postcode("")
                 .build())
             .party();
 
@@ -95,7 +95,7 @@ public class PartyTest {
     public void shouldReturnValidationErrorsWhenGivenInvalidCorrespondenceAddress() {
         Party party = SampleParty.builder()
             .withCorrespondenceAddress(SampleAddress.builder()
-                .withPostcode("")
+                .postcode("")
                 .build())
             .party();
 

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/PaymentDeclarationTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/PaymentDeclarationTest.java
@@ -15,7 +15,7 @@ public class PaymentDeclarationTest {
     @Test
     public void shouldHaveNoValidationMessageWhenInstanceIsValid() {
         //given
-        PaymentDeclaration paymentDeclaration = SamplePaymentDeclaration.validDefaults();
+        PaymentDeclaration paymentDeclaration = SamplePaymentDeclaration.builder().build();
         //when
         Set<String> response = validate(paymentDeclaration);
         //then
@@ -26,8 +26,8 @@ public class PaymentDeclarationTest {
     public void shouldHaveValidationMessageWhenPaidDateIsNull() {
         //given
         PaymentDeclaration paymentDeclaration = SamplePaymentDeclaration.builder()
-            .withExplanation("defence")
-            .withPaidDate(null)
+            .explanation("defence")
+            .paidDate(null)
             .build();
         //when
         Set<String> errors = validate(paymentDeclaration);
@@ -41,8 +41,8 @@ public class PaymentDeclarationTest {
     public void shouldHaveValidationMessageWhenPaidDateIsInTheFuture() {
         //given
         PaymentDeclaration paymentDeclaration = SamplePaymentDeclaration.builder()
-            .withExplanation("defence")
-            .withPaidDate(LocalDate.now().plusYears(1))
+            .explanation("defence")
+            .paidDate(LocalDate.now().plusYears(1))
             .build();
         //when
         Set<String> errors = validate(paymentDeclaration);
@@ -56,7 +56,7 @@ public class PaymentDeclarationTest {
     public void shouldHaveValidationMessageWhenExplanationIsNull() {
         //given
         PaymentDeclaration paymentDeclaration = SamplePaymentDeclaration.builder()
-            .withExplanation(null)
+            .explanation(null)
             .build();
         //when
         Set<String> errors = validate(paymentDeclaration);
@@ -70,7 +70,7 @@ public class PaymentDeclarationTest {
     public void shouldHaveValidationMessageWhenExplanationIsEmpty() {
         //given
         PaymentDeclaration paymentDeclaration = SamplePaymentDeclaration.builder()
-            .withExplanation("")
+            .explanation("")
             .build();
         //when
         Set<String> errors = validate(paymentDeclaration);
@@ -84,7 +84,7 @@ public class PaymentDeclarationTest {
     public void shouldHaveValidationMessageWhenExplanationExceedsSizeLimit() {
         //given
         PaymentDeclaration paymentDeclaration = SamplePaymentDeclaration.builder()
-            .withExplanation(randomAlphanumeric(99001))
+            .explanation(randomAlphanumeric(99001))
             .build();
         //when
         Set<String> errors = validate(paymentDeclaration);

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/PaymentTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/PaymentTest.java
@@ -13,7 +13,7 @@ public class PaymentTest {
     @Test
     public void shouldBeSuccessfulValidationForPayment() {
         //given
-        Payment payment = SamplePayment.validDefaults();
+        Payment payment = SamplePayment.builder().build();
         //when
         Set<String> errors = validate(payment);
         //then

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/TheirDetailsTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/TheirDetailsTest.java
@@ -69,7 +69,7 @@ public class TheirDetailsTest {
     public void shouldBeInvalidWhenGivenInvalidAddress() {
         TheirDetails theirDetails = SampleTheirDetails.builder()
             .withAddress(SampleAddress.builder()
-                .withPostcode("")
+                .postcode("")
                 .build())
             .partyDetails();
 
@@ -169,7 +169,7 @@ public class TheirDetailsTest {
     public void shouldBeInvalidWhenGivenInvalidServiceAddress() {
         TheirDetails theirDetails = SampleTheirDetails.builder()
             .withServiceAddress(SampleAddress.builder()
-                .withPostcode("")
+                .postcode("")
                 .build())
             .partyDetails();
 

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/legalrep/ContactDetailsTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/legalrep/ContactDetailsTest.java
@@ -13,7 +13,7 @@ public class ContactDetailsTest {
 
     @Test
     public void shouldBeValidForValidObject() {
-        ContactDetails contactDetails = SampleContactDetails.validDefaults();
+        ContactDetails contactDetails = SampleContactDetails.builder().build();
 
         Set<String> validationErrors = validate(contactDetails);
 
@@ -23,9 +23,9 @@ public class ContactDetailsTest {
     @Test
     public void shouldBeValidForNullValues() {
         ContactDetails contactDetails = SampleContactDetails.builder()
-            .withPhone(null)
-            .withEmail(null)
-            .withDxNumber(null)
+            .phone(null)
+            .email(null)
+            .dxAddress(null)
             .build();
 
         Set<String> validationErrors = validate(contactDetails);
@@ -36,8 +36,8 @@ public class ContactDetailsTest {
     @Test
     public void shouldBeValidForEmptyValues() {
         ContactDetails contactDetails = SampleContactDetails.builder()
-            .withEmail("")
-            .withDxNumber("")
+            .email("")
+            .dxAddress("")
             .build();
 
         Set<String> validationErrors = validate(contactDetails);
@@ -48,7 +48,7 @@ public class ContactDetailsTest {
     @Test
     public void phoneNumberShouldNotBeValidForEmptyValue() {
         ContactDetails contactDetails = SampleContactDetails.builder()
-            .withPhone("")
+            .phone("")
             .build();
 
         Set<String> validationErrors = validate(contactDetails);
@@ -59,7 +59,7 @@ public class ContactDetailsTest {
     @Test
     public void shouldBeInvalidForInvalidPhoneNumber() {
         ContactDetails contactDetails = SampleContactDetails.builder()
-            .withPhone("123")
+            .phone("123")
             .build();
 
         Set<String> validationErrors = validate(contactDetails);
@@ -70,7 +70,7 @@ public class ContactDetailsTest {
     @Test
     public void shouldBeInvalidForInvalidEmail() {
         ContactDetails contactDetails = SampleContactDetails.builder()
-            .withEmail("this is not a valid email")
+            .email("this is not a valid email")
             .build();
 
         Set<String> validationErrors = validate(contactDetails);
@@ -81,7 +81,7 @@ public class ContactDetailsTest {
     @Test
     public void shouldBeValidFor255CharsDxNumber() {
         ContactDetails contactDetails = SampleContactDetails.builder()
-            .withDxNumber(StringUtils.repeat("X", 255))
+            .dxAddress(StringUtils.repeat("X", 255))
             .build();
 
         Set<String> validationErrors = validate(contactDetails);
@@ -92,7 +92,7 @@ public class ContactDetailsTest {
     @Test
     public void shouldBeInvalidForTooLongDxNumber() {
         ContactDetails contactDetails = SampleContactDetails.builder()
-            .withDxNumber(StringUtils.repeat("X", 256))
+            .dxAddress(StringUtils.repeat("X", 256))
             .build();
 
         Set<String> validationErrors = validate(contactDetails);

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/OfferValidationTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/OfferValidationTest.java
@@ -15,7 +15,7 @@ public class OfferValidationTest {
 
     @Test
     public void shouldHaveNoValidationErrorsForValidOffer() {
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
 
         Set<String> validationErrors = validate(offer);
 
@@ -25,7 +25,7 @@ public class OfferValidationTest {
     @Test
     public void shouldBeInvalidIfTextIsNull() {
         Offer offer = SampleOffer.builder()
-            .withContent(null)
+            .content(null)
             .build();
 
         Set<String> validationErrors = validate(offer);
@@ -36,7 +36,7 @@ public class OfferValidationTest {
     @Test
     public void shouldBeInvalidIfTextExceedsLengthLimit() {
         Offer offer = SampleOffer.builder()
-            .withContent(StringUtils.repeat('X', Offer.CONTENT_LENGTH_LIMIT + 1))
+            .content(StringUtils.repeat('X', Offer.CONTENT_LENGTH_LIMIT + 1))
             .build();
 
         Set<String> validationErrors = validate(offer);
@@ -49,7 +49,7 @@ public class OfferValidationTest {
     @Test
     public void shouldBeInvalidIfCompletionDateIsNull() {
         Offer offer = SampleOffer.builder()
-            .withCompletionDate(null)
+            .completionDate(null)
             .build();
 
         Set<String> validationErrors = validate(offer);
@@ -60,7 +60,7 @@ public class OfferValidationTest {
     @Test
     public void shouldBeInvalidIfCompletionDateIsToday() {
         Offer offer = SampleOffer.builder()
-            .withCompletionDate(LocalDate.now())
+            .completionDate(LocalDate.now())
             .build();
 
         Set<String> validationErrors = validate(offer);
@@ -71,7 +71,7 @@ public class OfferValidationTest {
     @Test
     public void shouldBeInvalidIfCompletionDateIsYesterday() {
         Offer offer = SampleOffer.builder()
-            .withCompletionDate(LocalDate.now().minusDays(1))
+            .completionDate(LocalDate.now().minusDays(1))
             .build();
 
         Set<String> validationErrors = validate(offer);

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/SettlementMakeOfferTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/SettlementMakeOfferTest.java
@@ -20,7 +20,7 @@ public class SettlementMakeOfferTest {
 
     @Test
     public void shouldAllowDefendantToMakeAnInitialOffer() {
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
 
         settlement.makeOffer(offer, MadeBy.DEFENDANT);
 
@@ -35,7 +35,7 @@ public class SettlementMakeOfferTest {
 
     @Test(expected = IllegalSettlementStatementException.class)
     public void shouldNotAllowDefendantToMakeTwoOffersInARow() {
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
 
         settlement.makeOffer(offer, MadeBy.DEFENDANT);
         settlement.makeOffer(offer, MadeBy.DEFENDANT);
@@ -43,7 +43,7 @@ public class SettlementMakeOfferTest {
 
     @Test(expected = IllegalSettlementStatementException.class)
     public void shouldNotAllowClaimantToMakeTwoOffersInARow() {
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
 
         settlement.makeOffer(offer, MadeBy.CLAIMANT);
         settlement.makeOffer(offer, MadeBy.CLAIMANT);
@@ -51,7 +51,7 @@ public class SettlementMakeOfferTest {
 
     @Test
     public void shouldAllowToMakeACounterOffers() {
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
 
         settlement.makeOffer(offer, MadeBy.CLAIMANT);
         settlement.makeOffer(offer, MadeBy.DEFENDANT);

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/SettlementTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/offers/SettlementTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SettlementTest {
 
     private static final String COUNTER_OFFER = "Get me a new roof instead";
-    private static final Offer offer = SampleOffer.validDefaults();
+    private static final Offer offer = SampleOffer.builder().build();
 
     @Mock
     private PartyStatement partyStatement;
@@ -44,7 +44,7 @@ public class SettlementTest {
     @Test
     public void getLastStatementShouldReturnLastStatement() {
         Offer counterOffer = SampleOffer.builder()
-            .withContent(COUNTER_OFFER)
+            .content(COUNTER_OFFER)
             .build();
 
         settlement.makeOffer(offer, MadeBy.DEFENDANT);
@@ -176,7 +176,7 @@ public class SettlementTest {
         settlement.reject(MadeBy.DEFENDANT);
 
         Offer counterOffer = SampleOffer.builder()
-            .withContent(COUNTER_OFFER)
+            .content(COUNTER_OFFER)
             .build();
 
         settlement.makeOffer(counterOffer, MadeBy.DEFENDANT);
@@ -210,7 +210,7 @@ public class SettlementTest {
 
     @Test
     public void isSettlementThroughAdmissionsShouldShouldReturnFalseForOffersRoute() {
-        settlement.makeOffer(SampleOffer.validDefaults(), MadeBy.DEFENDANT);
+        settlement.makeOffer(SampleOffer.builder().build(), MadeBy.DEFENDANT);
         settlement.accept(MadeBy.CLAIMANT);
 
         assertThat(settlement.isSettlementThroughAdmissions()).isFalse();

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/serialization/CountyCourtJudgmentSerializationTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/serialization/CountyCourtJudgmentSerializationTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import uk.gov.hmcts.cmc.domain.config.JacksonConfiguration;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
 import uk.gov.hmcts.cmc.domain.models.legalrep.StatementOfTruth;
 import uk.gov.hmcts.cmc.domain.models.otherparty.CompanyDetails;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleCountyCourtJudgment;
@@ -25,8 +26,9 @@ public class CountyCourtJudgmentSerializationTest {
         //given
         CompanyDetails defendant = SampleTheirDetails.builder().companyDetails();
         CountyCourtJudgment expected = SampleCountyCourtJudgment.builder()
-            .withRepaymentPlan(SampleRepaymentPlan.builder().build())
-            .withStatementOfTruth(new StatementOfTruth(defendant.getContactPerson().get(), "Director"))
+            .paymentOption(PaymentOption.INSTALMENTS)
+            .repaymentPlan(SampleRepaymentPlan.builder().build())
+            .statementOfTruth(new StatementOfTruth(defendant.getContactPerson().get(), "Director"))
             .build();
 
         //when

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleAddress.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleAddress.java
@@ -1,49 +1,20 @@
 package uk.gov.hmcts.cmc.domain.models.sampledata;
 
 import uk.gov.hmcts.cmc.domain.models.Address;
+import uk.gov.hmcts.cmc.domain.models.Address.AddressBuilder;
 
 public class SampleAddress {
 
-    private String line1 = "52";
-    private String line2 = "Down Street";
-    private String line3 = "Salford";
-    private String city = "Manchester";
-    private String postcode = "DF1 3LJ";
-
-    public static SampleAddress builder() {
-        return new SampleAddress();
+    private SampleAddress() {
+        super();
     }
 
-    public static Address validDefaults() {
-        return builder().build();
-    }
-
-    public SampleAddress withLine1(String line1) {
-        this.line1 = line1;
-        return this;
-    }
-
-    public SampleAddress withLine2(String line2) {
-        this.line2 = line2;
-        return this;
-    }
-
-    public SampleAddress withLine3(String line3) {
-        this.line3 = line3;
-        return this;
-    }
-
-    public SampleAddress withCity(String city) {
-        this.city = city;
-        return this;
-    }
-
-    public SampleAddress withPostcode(String postcode) {
-        this.postcode = postcode;
-        return this;
-    }
-
-    public Address build() {
-        return new Address(line1, line2, line3, city, postcode);
+    public static AddressBuilder builder() {
+        return Address.builder()
+            .line1("52")
+            .line2("Down Street")
+            .line3("Salford")
+            .city("Manchester")
+            .postcode("DF1 3LJ");
     }
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleAmountBreakdown.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleAmountBreakdown.java
@@ -2,42 +2,20 @@ package uk.gov.hmcts.cmc.domain.models.sampledata;
 
 import uk.gov.hmcts.cmc.domain.models.AmountRow;
 import uk.gov.hmcts.cmc.domain.models.amount.AmountBreakDown;
+import uk.gov.hmcts.cmc.domain.models.amount.AmountBreakDown.AmountBreakDownBuilder;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 
 import static java.util.Collections.singletonList;
 
 public class SampleAmountBreakdown {
 
-    private List<AmountRow> rows = singletonList(new AmountRow("reason", new BigDecimal("40")));
-
-    public SampleAmountBreakdown clearRows() {
-        this.rows = new ArrayList<>();
-        return this;
+    private SampleAmountBreakdown() {
+        super();
     }
 
-    public SampleAmountBreakdown withRows(List<AmountRow> rows) {
-        this.rows = rows;
-        return this;
+    public static AmountBreakDownBuilder builder() {
+        return AmountBreakDown.builder()
+            .rows(singletonList(new AmountRow("reason", new BigDecimal("40"))));
     }
-
-    public SampleAmountBreakdown addRow(AmountRow row) {
-        rows.add(row);
-        return this;
-    }
-
-    public static SampleAmountBreakdown builder() {
-        return new SampleAmountBreakdown();
-    }
-
-    public static AmountBreakDown validDefaults() {
-        return builder().build();
-    }
-
-    public AmountBreakDown build() {
-        return new AmountBreakDown(rows);
-    }
-
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleAmountRange.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleAmountRange.java
@@ -1,33 +1,19 @@
 package uk.gov.hmcts.cmc.domain.models.sampledata;
 
 import uk.gov.hmcts.cmc.domain.models.amount.AmountRange;
+import uk.gov.hmcts.cmc.domain.models.amount.AmountRange.AmountRangeBuilder;
 
 import java.math.BigDecimal;
 
 public class SampleAmountRange {
 
-    private BigDecimal lowerValue = BigDecimal.valueOf(100L);
-    private BigDecimal higherValue = BigDecimal.valueOf(99000L);
-
-    public SampleAmountRange withLowerValue(BigDecimal lowerValue) {
-        this.lowerValue = lowerValue;
-        return this;
+    private SampleAmountRange() {
+        super();
     }
 
-    public SampleAmountRange withHigherValue(BigDecimal higherValue) {
-        this.higherValue = higherValue;
-        return this;
-    }
-
-    public static SampleAmountRange builder() {
-        return new SampleAmountRange();
-    }
-
-    public AmountRange build() {
-        return new AmountRange(lowerValue, higherValue);
-    }
-
-    public static AmountRange validDefaults() {
-        return builder().build();
+    public static AmountRangeBuilder builder() {
+        return AmountRange.builder()
+            .lowerValue(BigDecimal.valueOf(100L))
+            .higherValue(BigDecimal.valueOf(99000L));
     }
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleClaim.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleClaim.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.cmc.domain.models.sampledata;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.ClaimData;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
 import uk.gov.hmcts.cmc.domain.models.claimantresponse.ClaimantResponse;
 import uk.gov.hmcts.cmc.domain.models.offers.Settlement;
 import uk.gov.hmcts.cmc.domain.models.response.DefenceType;
@@ -69,7 +70,7 @@ public final class SampleClaim {
             .withClaimData(SampleClaimData.submittedByClaimant())
             .withCountyCourtJudgment(
                 SampleCountyCourtJudgment.builder()
-                    .withPaymentOptionImmediately()
+                    .paymentOption(PaymentOption.IMMEDIATELY)
                     .build()
             ).withResponse(SampleResponse.FullDefence
                 .builder()
@@ -84,7 +85,7 @@ public final class SampleClaim {
             .withClaimData(SampleClaimData.submittedByClaimant())
             .withCountyCourtJudgment(
                 SampleCountyCourtJudgment.builder()
-                    .withPaymentOptionImmediately()
+                    .paymentOption(PaymentOption.IMMEDIATELY)
                     .build()
             ).withResponse(SampleResponse.FullDefence
                 .builder()

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleClaimData.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleClaimData.java
@@ -26,8 +26,8 @@ public class SampleClaimData {
     private UUID externalId = UUID.randomUUID();
     private List<Party> claimants = singletonList(SampleParty.builder().individual());
     private List<TheirDetails> defendants = singletonList(SampleTheirDetails.builder().individualDetails());
-    private Payment payment = SamplePayment.validDefaults();
-    private Amount amount = SampleAmountBreakdown.validDefaults();
+    private Payment payment = SamplePayment.builder().build();
+    private Amount amount = SampleAmountBreakdown.builder().build();
     private Interest interest = SampleInterest.standard();
     private String reason = "reason";
     private BigInteger feeAmount = new BigInteger("4000");
@@ -222,7 +222,7 @@ public class SampleClaimData {
 
     public static SampleClaimData submittedByLegalRepresentativeBuilder() {
         return new SampleClaimData()
-            .withAmount(SampleAmountRange.validDefaults());
+            .withAmount(SampleAmountRange.builder().build());
     }
 
     public static ClaimData noInterest() {
@@ -235,7 +235,7 @@ public class SampleClaimData {
                             .withReason(null)
                             .build())
                     .build())
-            .withAmount(SampleAmountBreakdown.validDefaults())
+            .withAmount(SampleAmountBreakdown.builder().build())
             .build();
     }
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleCountyCourtJudgment.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleCountyCourtJudgment.java
@@ -1,70 +1,20 @@
 package uk.gov.hmcts.cmc.domain.models.sampledata;
 
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
+import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment.CountyCourtJudgmentBuilder;
 import uk.gov.hmcts.cmc.domain.models.PaymentOption;
-import uk.gov.hmcts.cmc.domain.models.RepaymentPlan;
-import uk.gov.hmcts.cmc.domain.models.legalrep.StatementOfTruth;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 
 public class SampleCountyCourtJudgment {
 
-    private LocalDate defendantDateOfBirth;
-    private BigDecimal paidAmount = BigDecimal.ZERO;
-    private PaymentOption paymentOption = PaymentOption.IMMEDIATELY;
-    private RepaymentPlan repaymentPlan;
-    private LocalDate payBySetDate;
-    private StatementOfTruth statementOfTruth;
-
-    public static SampleCountyCourtJudgment builder() {
-        return new SampleCountyCourtJudgment();
+    private SampleCountyCourtJudgment() {
+        super();
     }
 
-    public SampleCountyCourtJudgment withDefendantDateOfBirth(LocalDate defendantDateOfBirth) {
-        this.defendantDateOfBirth = defendantDateOfBirth;
-        return this;
-    }
-
-    public SampleCountyCourtJudgment withPaidAmount(BigDecimal paidAmount) {
-        this.paidAmount = paidAmount;
-        return this;
-    }
-
-    public SampleCountyCourtJudgment withPaymentOptionImmediately() {
-        this.paymentOption = PaymentOption.IMMEDIATELY;
-        this.repaymentPlan = null;
-        this.payBySetDate = null;
-        return this;
-    }
-
-    public SampleCountyCourtJudgment withRepaymentPlan(RepaymentPlan repaymentPlan) {
-        this.paymentOption = PaymentOption.INSTALMENTS;
-        this.repaymentPlan = repaymentPlan;
-        this.payBySetDate = null;
-        return this;
-    }
-
-    public SampleCountyCourtJudgment withPayBySetDate(LocalDate payBySetDate) {
-        this.paymentOption = PaymentOption.BY_SPECIFIED_DATE;
-        this.payBySetDate = payBySetDate;
-        this.repaymentPlan = null;
-        return this;
-    }
-
-    public SampleCountyCourtJudgment withPaymentOption(PaymentOption paymentOption) {
-        this.paymentOption = paymentOption;
-        return this;
-    }
-
-    public SampleCountyCourtJudgment withStatementOfTruth(StatementOfTruth statementOfTruth) {
-        this.statementOfTruth = statementOfTruth;
-        return this;
-    }
-
-    public CountyCourtJudgment build() {
-        return new CountyCourtJudgment(
-            defendantDateOfBirth, paymentOption, paidAmount, repaymentPlan, payBySetDate, statementOfTruth
-        );
+    public static CountyCourtJudgmentBuilder builder() {
+        return CountyCourtJudgment.builder()
+            .paidAmount(BigDecimal.ZERO)
+            .paymentOption(PaymentOption.IMMEDIATELY);
     }
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleEvidenceRow.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleEvidenceRow.java
@@ -1,34 +1,19 @@
 package uk.gov.hmcts.cmc.domain.models.sampledata;
 
 import uk.gov.hmcts.cmc.domain.models.evidence.EvidenceRow;
-import uk.gov.hmcts.cmc.domain.models.evidence.EvidenceType;
+import uk.gov.hmcts.cmc.domain.models.evidence.EvidenceRow.EvidenceRowBuilder;
 
 import static uk.gov.hmcts.cmc.domain.models.evidence.EvidenceType.CORRESPONDENCE;
 
 public class SampleEvidenceRow {
 
-    private EvidenceType type = CORRESPONDENCE;
-    private String description = "description";
-
-    public static SampleEvidenceRow builder() {
-        return new SampleEvidenceRow();
+    private SampleEvidenceRow() {
+        super();
     }
 
-    public static EvidenceRow validDefaults() {
-        return builder().build();
-    }
-
-    public SampleEvidenceRow withType(EvidenceType type) {
-        this.type = type;
-        return this;
-    }
-
-    public SampleEvidenceRow withDescription(String description) {
-        this.description = description;
-        return this;
-    }
-
-    public EvidenceRow build() {
-        return new EvidenceRow(type, description);
+    public static EvidenceRowBuilder builder() {
+        return EvidenceRow.builder()
+            .type(CORRESPONDENCE)
+            .description("description");
     }
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleParty.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleParty.java
@@ -17,13 +17,12 @@ public class SampleParty {
     private String name = "John Rambo";
     private String businessName = "Trading as name";
     private String contactPerson = "Steven Seagal";
-    private Address address = SampleAddress.validDefaults();
-    private Address correspondenceAddress = SampleAddress.validDefaults();
+    private Address address = SampleAddress.builder().build();
+    private Address correspondenceAddress = SampleAddress.builder().build();
     private String title = "Dr.";
     private String mobilePhone = "07873727165";
     private LocalDate dateOfBirth = LocalDate.of(1968, 1, 2);
-    private Representative representative = SampleRepresentative.builder()
-        .build();
+    private Representative representative = SampleRepresentative.builder().build();
     private String companiesHouseNumber;
 
     public static SampleParty builder() {

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SamplePayment.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SamplePayment.java
@@ -1,25 +1,20 @@
 package uk.gov.hmcts.cmc.domain.models.sampledata;
 
 import uk.gov.hmcts.cmc.domain.models.Payment;
+import uk.gov.hmcts.cmc.domain.models.Payment.PaymentBuilder;
 
 import java.math.BigDecimal;
 
 public class SamplePayment {
 
-    private BigDecimal amount = new BigDecimal("4000");
-    private String reference = "RC-1524-6488-1670-7520";
-    private String status = "success";
-
-    public static SamplePayment builder() {
-        return new SamplePayment();
+    private SamplePayment() {
+        super();
     }
 
-    public static Payment validDefaults() {
-        return builder().build();
+    public static PaymentBuilder builder() {
+        return Payment.builder()
+            .reference("RC-1524-6488-1670-7520")
+            .amount(new BigDecimal("4000"))
+            .status("success");
     }
-
-    public Payment build() {
-        return new Payment(null, amount, reference, null, status);
-    }
-
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SamplePaymentDeclaration.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SamplePaymentDeclaration.java
@@ -1,34 +1,19 @@
 package uk.gov.hmcts.cmc.domain.models.sampledata;
 
 import uk.gov.hmcts.cmc.domain.models.PaymentDeclaration;
+import uk.gov.hmcts.cmc.domain.models.PaymentDeclaration.PaymentDeclarationBuilder;
 import java.time.LocalDate;
 
 public class SamplePaymentDeclaration {
 
-    private LocalDate paidDate = LocalDate.of(2016, 1, 2);
-    private String explanation = "Paid cash";
-
-    public static SamplePaymentDeclaration builder() {
-        return new SamplePaymentDeclaration();
+    private SamplePaymentDeclaration() {
+        super();
     }
 
-    public static PaymentDeclaration validDefaults() {
-        return builder().build();
+    public static PaymentDeclarationBuilder builder() {
+        return PaymentDeclaration.builder()
+            .paidDate(LocalDate.of(2016, 1, 2))
+            .explanation("Paid cash");
     }
-
-    public SamplePaymentDeclaration withPaidDate(LocalDate paidDate) {
-        this.paidDate = paidDate;
-        return this;
-    }
-
-    public SamplePaymentDeclaration withExplanation(String explanation) {
-        this.explanation = explanation;
-        return this;
-    }
-
-    public PaymentDeclaration build() {
-        return new PaymentDeclaration(paidDate, explanation);
-    }
-
 }
 

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleRepaymentPlan.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleRepaymentPlan.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.cmc.domain.models.sampledata;
 
 import uk.gov.hmcts.cmc.domain.models.RepaymentPlan;
+import uk.gov.hmcts.cmc.domain.models.RepaymentPlan.RepaymentPlanBuilder;
 import uk.gov.hmcts.cmc.domain.models.ccj.PaymentSchedule;
 
 import java.math.BigDecimal;
@@ -8,34 +9,14 @@ import java.time.LocalDate;
 
 public class SampleRepaymentPlan {
 
-    private BigDecimal instalmentAmount = BigDecimal.valueOf(100);
-    private LocalDate firstPaymentDate = LocalDate.of(2100, 10, 10);
-    private PaymentSchedule paymentSchedule = PaymentSchedule.EACH_WEEK;
-
-    public static SampleRepaymentPlan builder() {
-        return new SampleRepaymentPlan();
+    private SampleRepaymentPlan() {
+        super();
     }
 
-    public SampleRepaymentPlan withInstalmentAmount(BigDecimal instalmentAmount) {
-        this.instalmentAmount = instalmentAmount;
-        return this;
-    }
-
-    public SampleRepaymentPlan withFirstPaymentDate(LocalDate firstPaymentDate) {
-        this.firstPaymentDate = firstPaymentDate;
-        return this;
-    }
-
-    public SampleRepaymentPlan withPaymentSchedule(PaymentSchedule paymentSchedule) {
-        this.paymentSchedule = paymentSchedule;
-        return this;
-    }
-
-    public RepaymentPlan build() {
+    public static RepaymentPlanBuilder builder() {
         return RepaymentPlan.builder()
-            .paymentSchedule(paymentSchedule)
-            .firstPaymentDate(firstPaymentDate)
-            .instalmentAmount(instalmentAmount)
-            .build();
+            .instalmentAmount(BigDecimal.valueOf(100))
+            .paymentSchedule(PaymentSchedule.EACH_WEEK)
+            .firstPaymentDate(LocalDate.of(2100, 10, 10));
     }
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleRepresentative.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleRepresentative.java
@@ -1,36 +1,19 @@
 package uk.gov.hmcts.cmc.domain.models.sampledata;
 
-import uk.gov.hmcts.cmc.domain.models.Address;
-import uk.gov.hmcts.cmc.domain.models.legalrep.ContactDetails;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
+import uk.gov.hmcts.cmc.domain.models.legalrep.Representative.RepresentativeBuilder;
 import uk.gov.hmcts.cmc.domain.models.sampledata.legalrep.SampleContactDetails;
 
 public class SampleRepresentative {
 
-    private String companyName = "Trading ltd";
-    private ContactDetails companyContactDetails = SampleContactDetails.builder().build();
-    private Address companyAddress = SampleAddress.validDefaults();
-
-    public static SampleRepresentative builder() {
-        return new SampleRepresentative();
+    private SampleRepresentative() {
+        super();
     }
 
-    public SampleRepresentative withContactDetails(ContactDetails companyContactDetails) {
-        this.companyContactDetails = companyContactDetails;
-        return this;
-    }
-
-    public SampleRepresentative withBusinessName(String companyName) {
-        this.companyName = companyName;
-        return this;
-    }
-
-    public SampleRepresentative withCompanyAddress(Address companyAddress) {
-        this.companyAddress = companyAddress;
-        return this;
-    }
-
-    public Representative build() {
-        return new Representative(companyName, companyAddress, companyContactDetails);
+    public static RepresentativeBuilder builder() {
+        return Representative.builder()
+            .organisationName("Trading ltd")
+            .organisationAddress(SampleAddress.builder().build())
+            .organisationContactDetails(SampleContactDetails.builder().build());
     }
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleResponse.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleResponse.java
@@ -62,7 +62,7 @@ public abstract class SampleResponse<T extends SampleResponse<T>> {
                 .defendant(SampleParty.builder().individual())
                 .moreTimeNeeded(YesNoOption.NO)
                 .amount(BigDecimal.valueOf(120))
-                .paymentDeclaration(SamplePaymentDeclaration.validDefaults())
+                .paymentDeclaration(SamplePaymentDeclaration.builder().build())
                 .defence(USER_DEFENCE)
                 .timeline(SampleDefendantTimeline.validDefaults())
                 .evidence(SampleDefendantEvidence.validDefaults())

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleTheirDetails.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleTheirDetails.java
@@ -17,7 +17,7 @@ public class SampleTheirDetails {
     public static final String DEFENDANT_EMAIL = "j.smith@example.com";
 
     private String name = "John Smith";
-    private Address address = SampleAddress.validDefaults();
+    private Address address = SampleAddress.builder().build();
     private String email = DEFENDANT_EMAIL;
     private String contactPerson = "Arnold Schwarzenegger";
     private String businessName = "Sole Trading & Sons";

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/legalrep/SampleContactDetails.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/legalrep/SampleContactDetails.java
@@ -1,38 +1,18 @@
 package uk.gov.hmcts.cmc.domain.models.sampledata.legalrep;
 
 import uk.gov.hmcts.cmc.domain.models.legalrep.ContactDetails;
+import uk.gov.hmcts.cmc.domain.models.legalrep.ContactDetails.ContactDetailsBuilder;
 
 public class SampleContactDetails {
 
-    private String phone = "7873738547";
-    private String email = "representative@example.org";
-    private String dxNumber = "DX123456";
-
-    public static SampleContactDetails builder() {
-        return new SampleContactDetails();
+    private SampleContactDetails() {
+        super();
     }
 
-    public static ContactDetails validDefaults() {
-        return builder().build();
+    public static ContactDetailsBuilder builder() {
+        return ContactDetails.builder()
+            .phone("7873738547")
+            .email("representative@example.org")
+            .dxAddress("DX123456");
     }
-
-    public SampleContactDetails withPhone(String phone) {
-        this.phone = phone;
-        return this;
-    }
-
-    public SampleContactDetails withEmail(String email) {
-        this.email = email;
-        return this;
-    }
-
-    public SampleContactDetails withDxNumber(String dxNumber) {
-        this.dxNumber = dxNumber;
-        return this;
-    }
-
-    public ContactDetails build() {
-        return new ContactDetails(phone, email, dxNumber);
-    }
-
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/offers/SampleOffer.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/offers/SampleOffer.java
@@ -1,41 +1,19 @@
 package uk.gov.hmcts.cmc.domain.models.sampledata.offers;
 
 import uk.gov.hmcts.cmc.domain.models.offers.Offer;
-import uk.gov.hmcts.cmc.domain.models.response.PaymentIntention;
+import uk.gov.hmcts.cmc.domain.models.offers.Offer.OfferBuilder;
 
 import java.time.LocalDate;
 
 public class SampleOffer {
 
-    private String content = "I will fix the leaking roof";
-    private LocalDate completionDate = LocalDate.now().plusDays(14);
-    private PaymentIntention paymentIntention;
-
-    public static Offer validDefaults() {
-        return builder().build();
+    private SampleOffer() {
+        super();
     }
 
-    public static SampleOffer builder() {
-        return new SampleOffer();
+    public static OfferBuilder builder() {
+        return Offer.builder()
+            .content("I will fix the leaking roof")
+            .completionDate(LocalDate.now().plusDays(14));
     }
-
-    public Offer build() {
-        return new Offer(content, completionDate, paymentIntention);
-    }
-
-    public SampleOffer withContent(String content) {
-        this.content = content;
-        return this;
-    }
-
-    public SampleOffer withCompletionDate(LocalDate completionDate) {
-        this.completionDate = completionDate;
-        return this;
-    }
-
-    public SampleOffer withPaymentIntention(PaymentIntention paymentIntention) {
-        this.paymentIntention = paymentIntention;
-        return this;
-    }
-
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/offers/SamplePartyStatement.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/offers/SamplePartyStatement.java
@@ -1,42 +1,20 @@
 package uk.gov.hmcts.cmc.domain.models.sampledata.offers;
 
 import uk.gov.hmcts.cmc.domain.models.offers.MadeBy;
-import uk.gov.hmcts.cmc.domain.models.offers.Offer;
 import uk.gov.hmcts.cmc.domain.models.offers.PartyStatement;
+import uk.gov.hmcts.cmc.domain.models.offers.PartyStatement.PartyStatementBuilder;
 import uk.gov.hmcts.cmc.domain.models.offers.StatementType;
 
 public class SamplePartyStatement {
 
-    private StatementType statementType = StatementType.OFFER;
-    private MadeBy madeBy = MadeBy.DEFENDANT;
-    private Offer offer = SampleOffer.validDefaults();
-
-    public static PartyStatement validDefaults() {
-        return builder().build();
+    private SamplePartyStatement() {
+        super();
     }
 
-    public static SamplePartyStatement builder() {
-        return new SamplePartyStatement();
-    }
-
-    public PartyStatement build() {
-        return offer != null
-            ? new PartyStatement(statementType, madeBy, offer)
-            : new PartyStatement(statementType, madeBy);
-    }
-
-    public SamplePartyStatement withStatementType(StatementType statementType) {
-        this.statementType = statementType;
-        return this;
-    }
-
-    public SamplePartyStatement withMadeBy(MadeBy madeBy) {
-        this.madeBy = madeBy;
-        return this;
-    }
-
-    public SamplePartyStatement withOffer(Offer offer) {
-        this.offer = offer;
-        return this;
+    public static PartyStatementBuilder builder() {
+        return PartyStatement.builder()
+            .type(StatementType.OFFER)
+            .madeBy(MadeBy.DEFENDANT)
+            .offer(SampleOffer.builder().build());
     }
 }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/offers/SampleSettlement.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/offers/SampleSettlement.java
@@ -12,25 +12,24 @@ import java.util.List;
 
 public class SampleSettlement {
 
-    public static final PartyStatement offerPartyStatement
-        = SamplePartyStatement.validDefaults();
+    public static final PartyStatement offerPartyStatement = SamplePartyStatement.builder().build();
 
     public static final PartyStatement rejectPartyStatement = SamplePartyStatement.builder()
-        .withStatementType(StatementType.REJECTION)
-        .withMadeBy(MadeBy.CLAIMANT)
-        .withOffer(null)
+        .type(StatementType.REJECTION)
+        .madeBy(MadeBy.CLAIMANT)
+        .offer(null)
         .build();
 
     public static final PartyStatement acceptPartyStatement = SamplePartyStatement.builder()
-        .withStatementType(StatementType.ACCEPTATION)
-        .withMadeBy(MadeBy.CLAIMANT)
-        .withOffer(null)
+        .type(StatementType.ACCEPTATION)
+        .madeBy(MadeBy.CLAIMANT)
+        .offer(null)
         .build();
 
     public static final PartyStatement counterSignPartyStatement = SamplePartyStatement.builder()
-        .withStatementType(StatementType.COUNTERSIGNATURE)
-        .withMadeBy(MadeBy.DEFENDANT)
-        .withOffer(null)
+        .type(StatementType.COUNTERSIGNATURE)
+        .madeBy(MadeBy.DEFENDANT)
+        .offer(null)
         .build();
 
     private List<PartyStatement> partyStatements = new ArrayList<>(Collections.singletonList(offerPartyStatement));

--- a/rpa-mapper/src/test/java/uk/gov/hmcts/cmc/rpa/mapper/DefenceResponseJsonMapperTest.java
+++ b/rpa-mapper/src/test/java/uk/gov/hmcts/cmc/rpa/mapper/DefenceResponseJsonMapperTest.java
@@ -46,7 +46,7 @@ public class DefenceResponseJsonMapperTest {
     public void shouldMapIndividualDefenceResponseToRPA() throws JSONException {
         Claim claim = withCommonDefEmailAndRespondedAt()
             .withResponse(SampleResponse.FullDefence.builder().withDefendantDetails(SampleParty.builder()
-                .withCorrespondenceAddress(SampleAddress.builder().withLine1("102").build()).individual()).build())
+                .withCorrespondenceAddress(SampleAddress.builder().line1("102").build()).individual()).build())
             .withClaimData(SampleClaimData.builder()
                 .withDefendant(SampleTheirDetails.builder().individualDetails())
                 .build())
@@ -78,7 +78,7 @@ public class DefenceResponseJsonMapperTest {
         Claim claim = withCommonDefEmailAndRespondedAt()
             .withResponse(SampleResponse.FullDefence.builder()
                 .withDefendantDetails(SampleParty.builder().withAddress(SampleAddress.builder()
-                    .withPostcode("MK3 0AL").build()).withCorrespondenceAddress(null).individual()).build())
+                    .postcode("MK3 0AL").build()).withCorrespondenceAddress(null).individual()).build())
             .withClaimData(SampleClaimData.builder()
                 .withDefendant(SampleTheirDetails.builder().individualDetails())
                 .build())

--- a/rpa-mapper/src/test/java/uk/gov/hmcts/cmc/rpa/mapper/RequestForJudgementJsonMapperTest.java
+++ b/rpa-mapper/src/test/java/uk/gov/hmcts/cmc/rpa/mapper/RequestForJudgementJsonMapperTest.java
@@ -9,6 +9,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
+import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment.CountyCourtJudgmentBuilder;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
 import uk.gov.hmcts.cmc.domain.models.RepaymentPlan;
 import uk.gov.hmcts.cmc.domain.models.ccj.PaymentSchedule;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
@@ -42,7 +44,7 @@ public class RequestForJudgementJsonMapperTest {
     public void shouldMapRequestForJudgementImmediatelyWithPaidAlready() throws JSONException {
         CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment
             .builder()
-            .withPaidAmount(PAID_ALREADY)
+            .paidAmount(PAID_ALREADY)
             .build();
 
         Claim claim = SampleClaim.builder()
@@ -59,7 +61,7 @@ public class RequestForJudgementJsonMapperTest {
     public void shouldMapRequestForJudgementImmediatelyButNothingPaid() throws JSONException {
         CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment
             .builder()
-            .withPaidAmount(null)
+            .paidAmount(null)
             .build();
 
         Claim claim = SampleClaim.builder()
@@ -76,8 +78,9 @@ public class RequestForJudgementJsonMapperTest {
     public void shouldMapRequestForJudgementPaidInFull() throws JSONException {
         CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment
             .builder()
-            .withPaidAmount(PAID_ALREADY)
-            .withPayBySetDate(PAY_BY_SET_DATE)
+            .paidAmount(PAID_ALREADY)
+            .paymentOption(PaymentOption.BY_SPECIFIED_DATE)
+            .payBySetDate(PAY_BY_SET_DATE)
             .build();
 
         Claim claim = SampleClaim.builder()
@@ -94,14 +97,15 @@ public class RequestForJudgementJsonMapperTest {
     public void shouldMapRequestForJudgementPayingFortnightly() throws JSONException {
         RepaymentPlan repaymentPlan = SampleRepaymentPlan
             .builder()
-            .withPaymentSchedule(PaymentSchedule.EVERY_TWO_WEEKS)
-            .withFirstPaymentDate(FIRST_PAYMENT_DATE)
-            .withInstalmentAmount(BigDecimal.valueOf(100.00))
+            .paymentSchedule(PaymentSchedule.EVERY_TWO_WEEKS)
+            .firstPaymentDate(FIRST_PAYMENT_DATE)
+            .instalmentAmount(BigDecimal.valueOf(100.00))
             .build();
 
-        SampleCountyCourtJudgment countyCourtJudgment = new SampleCountyCourtJudgment()
-            .withPaidAmount(PAID_ALREADY)
-            .withRepaymentPlan(repaymentPlan);
+        CountyCourtJudgmentBuilder countyCourtJudgment = SampleCountyCourtJudgment.builder()
+            .paidAmount(PAID_ALREADY)
+            .paymentOption(PaymentOption.INSTALMENTS)
+            .repaymentPlan(repaymentPlan);
 
         Claim claim = SampleClaim.builder()
             .withCountyCourtJudgmentRequestedAt(CCJ_REQUESTED_AT)
@@ -117,14 +121,14 @@ public class RequestForJudgementJsonMapperTest {
     public void shouldMapRequestForJudgementPayingWeekly() throws JSONException {
         RepaymentPlan repaymentPlan = SampleRepaymentPlan
             .builder()
-            .withPaymentSchedule(PaymentSchedule.EACH_WEEK)
-            .withFirstPaymentDate(PAY_BY_SET_DATE)
+            .paymentSchedule(PaymentSchedule.EACH_WEEK)
+            .firstPaymentDate(PAY_BY_SET_DATE)
             .build();
 
-        CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment
-            .builder()
-            .withPaidAmount(PAID_ALREADY)
-            .withRepaymentPlan(repaymentPlan)
+        CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment.builder()
+            .paidAmount(PAID_ALREADY)
+            .paymentOption(PaymentOption.INSTALMENTS)
+            .repaymentPlan(repaymentPlan)
             .build();
 
         Claim claim = SampleClaim.builder().withDefendantEmail("defendant@email.com")
@@ -139,16 +143,15 @@ public class RequestForJudgementJsonMapperTest {
 
     @Test
     public void shouldMapRequestForJudgementPayingMonthly() throws JSONException {
-        RepaymentPlan replaymentPlan = SampleRepaymentPlan
-            .builder()
-            .withPaymentSchedule(PaymentSchedule.EVERY_MONTH)
-            .withFirstPaymentDate(PAY_BY_SET_DATE)
+        RepaymentPlan repaymentPlan = SampleRepaymentPlan.builder()
+            .paymentSchedule(PaymentSchedule.EVERY_MONTH)
+            .firstPaymentDate(PAY_BY_SET_DATE)
             .build();
 
-        CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment
-            .builder()
-            .withPaidAmount(PAID_ALREADY)
-            .withRepaymentPlan(replaymentPlan)
+        CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment.builder()
+            .paidAmount(PAID_ALREADY)
+            .paymentOption(PaymentOption.INSTALMENTS)
+            .repaymentPlan(repaymentPlan)
             .build();
 
         Claim claim = SampleClaim.builder()

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/citizen/CountyCourtJudgementTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/citizen/CountyCourtJudgementTest.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.cmc.claimstore.idam.models.User;
 import uk.gov.hmcts.cmc.claimstore.tests.BaseTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleCountyCourtJudgment;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse.FullAdmission;
 import uk.gov.hmcts.cmc.domain.utils.LocalDateTimeFactory;
@@ -39,7 +40,7 @@ public class CountyCourtJudgementTest extends BaseTest {
         updateResponseDeadlineToEnableCCJ(createdCase.getReferenceNumber());
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
-            .withPaymentOptionImmediately()
+            .paymentOption(PaymentOption.IMMEDIATELY)
             .build();
 
         Claim updatedCase = commonOperations.requestCCJ(createdCase.getExternalId(), ccj, false, claimant)
@@ -74,7 +75,7 @@ public class CountyCourtJudgementTest extends BaseTest {
             .statusCode(HttpStatus.OK.value());
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
-            .withPaymentOptionImmediately()
+            .paymentOption(PaymentOption.IMMEDIATELY)
             .build();
 
         Claim updatedCase = commonOperations.requestCCJ(externalId, ccj, true, claimant)
@@ -104,7 +105,7 @@ public class CountyCourtJudgementTest extends BaseTest {
         updateResponseDeadlineToEnableCCJ(createdCase.getReferenceNumber());
 
         CountyCourtJudgment invalidCCJ = SampleCountyCourtJudgment.builder()
-            .withPaymentOption(null)
+            .paymentOption(null)
             .build();
 
         commonOperations.requestCCJ(createdCase.getExternalId(), invalidCCJ, false, claimant)
@@ -121,7 +122,7 @@ public class CountyCourtJudgementTest extends BaseTest {
         );
 
         CountyCourtJudgment ccj = SampleCountyCourtJudgment.builder()
-            .withPaymentOptionImmediately()
+            .paymentOption(PaymentOption.IMMEDIATELY)
             .build();
 
         commonOperations.requestCCJ(createdCase.getExternalId(), ccj, false, claimant)

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/citizen/CountyCourtJudgmentIssuePdfTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/citizen/CountyCourtJudgmentIssuePdfTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.cmc.claimstore.services.staff.content.countycourtjudgment.Am
 import uk.gov.hmcts.cmc.claimstore.tests.functional.BasePdfTest;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
 import uk.gov.hmcts.cmc.domain.models.RepaymentPlan;
 import uk.gov.hmcts.cmc.domain.models.response.Response;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
@@ -49,7 +50,7 @@ public class CountyCourtJudgmentIssuePdfTest extends BasePdfTest {
 
         CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment
             .builder()
-            .withPaymentOptionImmediately()
+            .paymentOption(PaymentOption.IMMEDIATELY)
             .build();
 
         claim = submitCCJByAdmission(countyCourtJudgment);
@@ -64,7 +65,8 @@ public class CountyCourtJudgmentIssuePdfTest extends BasePdfTest {
 
         CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment
             .builder()
-            .withRepaymentPlan(SampleRepaymentPlan.builder().build())
+            .paymentOption(PaymentOption.INSTALMENTS)
+            .repaymentPlan(SampleRepaymentPlan.builder().build())
             .build();
 
         claim = submitCCJByAdmission(countyCourtJudgment);
@@ -79,7 +81,8 @@ public class CountyCourtJudgmentIssuePdfTest extends BasePdfTest {
 
         CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment
             .builder()
-            .withRepaymentPlan(SampleRepaymentPlan.builder().build())
+            .paymentOption(PaymentOption.INSTALMENTS)
+            .repaymentPlan(SampleRepaymentPlan.builder().build())
             .build();
 
         claim = submitCCJByAdmission(countyCourtJudgment);
@@ -94,7 +97,8 @@ public class CountyCourtJudgmentIssuePdfTest extends BasePdfTest {
 
         CountyCourtJudgment countyCourtJudgment = SampleCountyCourtJudgment
             .builder()
-            .withPayBySetDate(LocalDate.now().plusDays(20))
+            .paymentOption(PaymentOption.BY_SPECIFIED_DATE)
+            .payBySetDate(LocalDate.now().plusDays(20))
             .build();
 
         claim = submitCCJByAdmission(countyCourtJudgment);

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/citizen/SettlementOfferTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/citizen/SettlementOfferTest.java
@@ -41,7 +41,7 @@ public class SettlementOfferTest extends BaseTest {
         User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         Claim updatedCase = createClaimWithDisputeResponse(createdCase, defendant);
 
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
 
         Claim caseWithOffer = commonOperations
             .submitOffer(offer, updatedCase.getExternalId(), defendant.getAuthorisation(), MadeBy.DEFENDANT)
@@ -66,7 +66,7 @@ public class SettlementOfferTest extends BaseTest {
         User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         Claim updatedCase = createClaimWithDisputeResponse(createdCase, defendant);
 
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
 
         commonOperations
             .submitOffer(offer, updatedCase.getExternalId(), defendant.getAuthorisation(), MadeBy.DEFENDANT)
@@ -91,7 +91,7 @@ public class SettlementOfferTest extends BaseTest {
         User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         Claim updatedCase = createClaimWithDisputeResponse(createdCase, defendant);
 
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
 
         Claim caseWithOffer = commonOperations
             .submitOffer(offer, updatedCase.getExternalId(), defendant.getAuthorisation(), MadeBy.DEFENDANT)
@@ -140,7 +140,7 @@ public class SettlementOfferTest extends BaseTest {
         User defendant = idamTestService.createDefendant(createdCase.getLetterHolderId());
         Claim updatedCase = createClaimWithDisputeResponse(createdCase, defendant);
 
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
 
         Claim caseWithOffer = commonOperations
             .submitOffer(offer, updatedCase.getExternalId(), defendant.getAuthorisation(), MadeBy.DEFENDANT)
@@ -201,7 +201,7 @@ public class SettlementOfferTest extends BaseTest {
 
         Claim updatedCase = createClaimWithDisputeResponse(createdCase, defendant);
 
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
 
         Claim caseWithOffer = commonOperations
             .submitOffer(offer, updatedCase.getExternalId(), defendant.getAuthorisation(), MadeBy.DEFENDANT)

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/BaseOfferTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/BaseOfferTest.java
@@ -56,7 +56,7 @@ public abstract class BaseOfferTest extends BaseIntegrationTest {
                 post(format("/claims/%s/offers/%s", claim.getExternalId(), MadeBy.DEFENDANT.name()))
                     .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     .header(HttpHeaders.AUTHORIZATION, DEFENDANT_AUTH_TOKEN)
-                    .content(jsonMapper.toJson(SampleOffer.validDefaults()))
+                    .content(jsonMapper.toJson(SampleOffer.builder().build()))
             )
             .andExpect(status().isCreated());
     }
@@ -67,7 +67,7 @@ public abstract class BaseOfferTest extends BaseIntegrationTest {
                 post(format("/claims/%s/offers/%s", claim.getExternalId(), MadeBy.CLAIMANT.name()))
                     .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     .header(HttpHeaders.AUTHORIZATION, CLAIMANT_AUTH_TOKEN)
-                    .content(jsonMapper.toJson(SampleOffer.validDefaults()))
+                    .content(jsonMapper.toJson(SampleOffer.builder().build()))
             )
             .andExpect(status().isCreated());
     }

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateSettlementAgreementCopyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateSettlementAgreementCopyTest.java
@@ -31,7 +31,7 @@ public class GenerateSettlementAgreementCopyTest extends BaseGetTest {
         claimStore.saveResponse(claim, SampleResponse.FullDefence.builder().build());
 
         Settlement settlement = new Settlement();
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
 
         settlement.makeOffer(offer, MadeBy.DEFENDANT);
 

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/MakeOfferTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/MakeOfferTest.java
@@ -58,21 +58,21 @@ public class MakeOfferTest extends BaseIntegrationTest {
 
     @Test
     public void shouldAcceptValidOfferByDefendantAndReturnCreatedStatus() throws Exception {
-        makeOffer(DEFENDANT_AUTH_TOKEN, SampleOffer.validDefaults(), MadeBy.DEFENDANT.name())
+        makeOffer(DEFENDANT_AUTH_TOKEN, SampleOffer.builder().build(), MadeBy.DEFENDANT.name())
             .andExpect(status().isCreated())
             .andReturn();
     }
 
     @Test
     public void shouldReturnBadRequestIfPartyIsIncorrectlySpecified() throws Exception {
-        makeOffer(DEFENDANT_AUTH_TOKEN, SampleOffer.validDefaults(), "I'm not a valid enum value")
+        makeOffer(DEFENDANT_AUTH_TOKEN, SampleOffer.builder().build(), "I'm not a valid enum value")
             .andExpect(status().isBadRequest())
             .andReturn();
     }
 
     @Test
     public void shouldSendNotifications() throws Exception {
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
         given(notificationClient.sendEmail(any(), any(), any(), any()))
             .willReturn(null);
 
@@ -88,7 +88,7 @@ public class MakeOfferTest extends BaseIntegrationTest {
 
     @Test
     public void shouldRetrySendNotifications() throws Exception {
-        Offer offer = SampleOffer.validDefaults();
+        Offer offer = SampleOffer.builder().build();
         given(notificationClient.sendEmail(any(), any(), any(), any()))
             .willThrow(new NotificationClientException(new RuntimeException("first attempt fails")))
             .willThrow(new NotificationClientException(new RuntimeException("1st email, 2nd attempt fails")))

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveCountyCourtJudgementTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveCountyCourtJudgementTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.cmc.claimstore.idam.models.UserDetails;
 import uk.gov.hmcts.cmc.claimstore.services.notifications.fixtures.SampleUserDetails;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.CountyCourtJudgment;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleCountyCourtJudgment;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
@@ -75,7 +76,7 @@ public class SaveCountyCourtJudgementTest extends BaseIntegrationTest {
         claimStore.updateResponseDeadline(claim.getExternalId());
 
         CountyCourtJudgment countyCourtJudgment
-            = SampleCountyCourtJudgment.builder().withPaymentOptionImmediately().build();
+            = SampleCountyCourtJudgment.builder().paymentOption(PaymentOption.IMMEDIATELY).build();
 
         makeRequest(claim.getExternalId(), countyCourtJudgment, false)
             .andExpect(status().isOk());
@@ -91,7 +92,7 @@ public class SaveCountyCourtJudgementTest extends BaseIntegrationTest {
         claimStore.saveResponse(claim, SampleResponse.PartAdmission.builder().build());
 
         CountyCourtJudgment countyCourtJudgment
-            = SampleCountyCourtJudgment.builder().withPaymentOptionImmediately().build();
+            = SampleCountyCourtJudgment.builder().paymentOption(PaymentOption.IMMEDIATELY).build();
 
         makeRequest(claim.getExternalId(), countyCourtJudgment, true)
             .andExpect(status().isOk());
@@ -107,7 +108,7 @@ public class SaveCountyCourtJudgementTest extends BaseIntegrationTest {
         claimStore.saveResponse(claim, SampleResponse.PartAdmission.builder().build());
 
         CountyCourtJudgment countyCourtJudgment
-            = SampleCountyCourtJudgment.builder().withPaymentOptionImmediately().build();
+            = SampleCountyCourtJudgment.builder().paymentOption(PaymentOption.IMMEDIATELY).build();
 
         makeRequest(claim.getExternalId(), countyCourtJudgment, true)
             .andExpect(status().isOk());
@@ -124,7 +125,7 @@ public class SaveCountyCourtJudgementTest extends BaseIntegrationTest {
         claimStore.saveResponse(claim, SampleResponse.PartAdmission.builder().build());
 
         CountyCourtJudgment countyCourtJudgment
-            = SampleCountyCourtJudgment.builder().withPaymentOptionImmediately().build();
+            = SampleCountyCourtJudgment.builder().paymentOption(PaymentOption.IMMEDIATELY).build();
 
         makeRequest(claim.getExternalId(), countyCourtJudgment, true)
             .andExpect(status().isOk());

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/StaffEmailServiceWithNotificationDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/StaffEmailServiceWithNotificationDisabledTest.java
@@ -103,7 +103,7 @@ public class StaffEmailServiceWithNotificationDisabledTest extends BaseSaveTest 
     @Test
     public void shouldNotSendStaffNotificationWhenCounterSignRequestSubmitted() throws Exception {
         Settlement settlement = new Settlement();
-        settlement.makeOffer(SampleOffer.validDefaults(), MadeBy.DEFENDANT);
+        settlement.makeOffer(SampleOffer.builder().build(), MadeBy.DEFENDANT);
         claim = claimStore.makeOffer(claim.getExternalId(), settlement);
 
         settlement.accept(MadeBy.CLAIMANT);

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/services/staff/CCJStaffNotificationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/services/staff/CCJStaffNotificationServiceTest.java
@@ -46,7 +46,9 @@ public class CCJStaffNotificationServiceTest extends MockSpringTest {
         claim = SampleClaim
             .builder()
             .withCountyCourtJudgmentRequestedAt(LocalDateTime.now())
-            .withCountyCourtJudgment(SampleCountyCourtJudgment.builder().paymentOption(PaymentOption.IMMEDIATELY).build())
+            .withCountyCourtJudgment(SampleCountyCourtJudgment.builder()
+                .paymentOption(PaymentOption.IMMEDIATELY)
+                .build())
             .withClaimData(SampleClaimData.submittedByClaimant())
             .build();
         when(pdfServiceClient.generateFromHtml(any(byte[].class), anyMap()))

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/services/staff/CCJStaffNotificationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/services/staff/CCJStaffNotificationServiceTest.java
@@ -7,8 +7,8 @@ import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.cmc.claimstore.MockSpringTest;
 import uk.gov.hmcts.cmc.claimstore.config.properties.emails.StaffEmailProperties;
-import uk.gov.hmcts.cmc.claimstore.services.staff.CCJStaffNotificationService;
 import uk.gov.hmcts.cmc.domain.models.Claim;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleCountyCourtJudgment;
@@ -46,7 +46,7 @@ public class CCJStaffNotificationServiceTest extends MockSpringTest {
         claim = SampleClaim
             .builder()
             .withCountyCourtJudgmentRequestedAt(LocalDateTime.now())
-            .withCountyCourtJudgment(SampleCountyCourtJudgment.builder().withPaymentOptionImmediately().build())
+            .withCountyCourtJudgment(SampleCountyCourtJudgment.builder().paymentOption(PaymentOption.IMMEDIATELY).build())
             .withClaimData(SampleClaimData.submittedByClaimant())
             .build();
         when(pdfServiceClient.generateFromHtml(any(byte[].class), anyMap()))

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/services/staff/SettlementReachedStaffNotificationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/services/staff/SettlementReachedStaffNotificationServiceTest.java
@@ -45,7 +45,7 @@ public class SettlementReachedStaffNotificationServiceTest extends MockSpringTes
     @Before
     public void setup() {
         Settlement settlement = new Settlement();
-        settlement.makeOffer(SampleOffer.validDefaults(), MadeBy.DEFENDANT);
+        settlement.makeOffer(SampleOffer.builder().build(), MadeBy.DEFENDANT);
         settlement.accept(MadeBy.CLAIMANT);
 
         claim = SampleClaim

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/CountyCourtJudgmentPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/CountyCourtJudgmentPdfServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.cmc.claimstore.config.properties.pdf.DocumentTemplates;
 import uk.gov.hmcts.cmc.claimstore.services.staff.content.countycourtjudgment.ContentProvider;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleCountyCourtJudgment;
@@ -57,7 +58,7 @@ public class CountyCourtJudgmentPdfServiceTest {
             .withClaimData(SampleClaimData.submittedByClaimant())
             .withCountyCourtJudgment(
                 SampleCountyCourtJudgment.builder()
-                    .withPaymentOptionImmediately()
+                    .paymentOption(PaymentOption.IMMEDIATELY)
                     .build()
             ).build());
         verify(documentTemplates).getCountyCourtJudgmentIssued();

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/PartyDetailsContentProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/PartyDetailsContentProviderTest.java
@@ -25,8 +25,8 @@ public class PartyDetailsContentProviderTest {
         .individualDetails();
 
     private final Address correspondenceAddress = SampleAddress.builder()
-        .withLine1("Correspondence Road 1")
-        .withPostcode("BB 127NQ")
+        .line1("Correspondence Road 1")
+        .postcode("BB 127NQ")
         .build();
 
     private Individual notAmendedDetails() {
@@ -45,9 +45,9 @@ public class PartyDetailsContentProviderTest {
             .withName("John Doe")
             .withAddress(
                 SampleAddress.builder()
-                    .withLine1("Somewhere")
-                    .withCity("Manchester")
-                    .withPostcode("BB12 7NQ")
+                    .line1("Somewhere")
+                    .city("Manchester")
+                    .postcode("BB12 7NQ")
                     .build()
             )
             .withDateOfBirth(

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/StatementOfValueProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/StatementOfValueProviderTest.java
@@ -35,8 +35,9 @@ public class StatementOfValueProviderTest {
             SampleClaimData.builder()
                 .withAmount(
                     SampleAmountRange.builder()
-                        .withHigherValue(BigDecimal.valueOf(100.50))
-                        .withLowerValue(BigDecimal.valueOf(200.95)).build()
+                        .lowerValue(BigDecimal.valueOf(200.95))
+                        .higherValue(BigDecimal.valueOf(100.50))
+                        .build()
                 ).build());
 
         //when
@@ -54,8 +55,8 @@ public class StatementOfValueProviderTest {
             SampleClaimData.builder()
                 .withAmount(
                     SampleAmountRange.builder()
-                        .withLowerValue(null)
-                        .withHigherValue(BigDecimal.valueOf(100.50))
+                        .lowerValue(null)
+                        .higherValue(BigDecimal.valueOf(100.50))
                         .build()
                 ).build());
 
@@ -97,8 +98,9 @@ public class StatementOfValueProviderTest {
             SampleClaimData.builder()
                 .withAmount(
                     SampleAmountRange.builder()
-                        .withHigherValue(BigDecimal.valueOf(100.50))
-                        .withLowerValue(BigDecimal.valueOf(200.95)).build()
+                        .lowerValue(BigDecimal.valueOf(200.95))
+                        .higherValue(BigDecimal.valueOf(100.50))
+                        .build()
                 )
                 .withPersonalInjury(new PersonalInjury(MORE_THAN_THOUSAND_POUNDS))
                 .withHousingDisrepair(null)
@@ -121,8 +123,8 @@ public class StatementOfValueProviderTest {
             SampleClaimData.builder()
                 .withPersonalInjury(null)
                 .withAmount(SampleAmountRange.builder()
-                    .withHigherValue(BigDecimal.valueOf(100.50))
-                    .withLowerValue(BigDecimal.valueOf(200.95))
+                    .lowerValue(BigDecimal.valueOf(200.95))
+                    .higherValue(BigDecimal.valueOf(100.50))
                     .build()
                 ).build());
 
@@ -140,8 +142,8 @@ public class StatementOfValueProviderTest {
             SampleClaimData.builder()
                 .withAmount(
                     SampleAmountRange.builder()
-                        .withHigherValue(BigDecimal.valueOf(100.50))
-                        .withLowerValue(BigDecimal.valueOf(200.95))
+                        .lowerValue(BigDecimal.valueOf(200.95))
+                        .higherValue(BigDecimal.valueOf(100.50))
                         .build()
                 ).build());
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/processors/JsonMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/processors/JsonMapperTest.java
@@ -144,13 +144,13 @@ public class JsonMapperTest {
                             .build())
             .withAmount(
                 SampleAmountRange.builder()
-                    .withHigherValue(BigDecimal.valueOf(123.56))
-                    .withLowerValue(BigDecimal.valueOf(123.56))
+                    .lowerValue(BigDecimal.valueOf(123.56))
+                    .higherValue(BigDecimal.valueOf(123.56))
                     .build())
             .withDefendant(
                 SampleTheirDetails.builder()
                     .withRepresentative(SampleRepresentative.builder().build())
-                    .withServiceAddress(SampleAddress.validDefaults())
+                    .withServiceAddress(SampleAddress.builder().build())
                     .individualDetails())
             .withTimeline(null)
             .withPayment(null)

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRuleTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/rules/CountyCourtJudgmentRuleTest.java
@@ -9,6 +9,7 @@ import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.cmc.claimstore.exceptions.ForbiddenActionException;
 import uk.gov.hmcts.cmc.domain.models.Claim;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleCountyCourtJudgment;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
@@ -78,7 +79,7 @@ public class CountyCourtJudgmentRuleTest {
             .withCountyCourtJudgmentRequestedAt(now())
             .withCountyCourtJudgment(
                 SampleCountyCourtJudgment.builder()
-                    .withPaymentOptionImmediately()
+                    .paymentOption(PaymentOption.IMMEDIATELY)
                     .build()
             ).build();
         countyCourtJudgmentRule.assertCountyCourtJudgementCanBeRequested(claim, issue);
@@ -91,7 +92,7 @@ public class CountyCourtJudgmentRuleTest {
             .withCountyCourtJudgmentRequestedAt(now())
             .withCountyCourtJudgment(
                 SampleCountyCourtJudgment.builder()
-                    .withPaymentOptionImmediately()
+                    .paymentOption(PaymentOption.IMMEDIATELY)
                     .build()
             ).build();
         countyCourtJudgmentRule.assertCountyCourtJudgementCanBeRequested(claim, true);

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/OfferServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/OfferServiceTest.java
@@ -189,14 +189,14 @@ public class OfferServiceTest {
 
     private static Claim buildClaimWithOffer() {
         Settlement settlement = new Settlement();
-        settlement.makeOffer(SampleOffer.validDefaults(), madeBy);
+        settlement.makeOffer(SampleOffer.builder().build(), madeBy);
 
         return SampleClaim.builder().withSettlement(settlement).build();
     }
 
     private static Claim buildClaimWithAcceptedOffer() {
         Settlement settlement = new Settlement();
-        settlement.makeOffer(SampleOffer.validDefaults(), madeBy);
+        settlement.makeOffer(SampleOffer.builder().build(), madeBy);
         settlement.accept(MadeBy.CLAIMANT);
 
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/ResponseNeededNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/ResponseNeededNotificationServiceTest.java
@@ -11,6 +11,7 @@ import org.quartz.JobDetail;
 import uk.gov.hmcts.cmc.claimstore.appinsights.AppInsights;
 import uk.gov.hmcts.cmc.claimstore.services.ClaimService;
 import uk.gov.hmcts.cmc.domain.models.Claim;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleCountyCourtJudgment;
@@ -58,7 +59,7 @@ public class ResponseNeededNotificationServiceTest extends BaseNotificationServi
             .withDefendantEmail(DEFENDANT_EMAIL)
             .withCountyCourtJudgment(
                 SampleCountyCourtJudgment.builder()
-                    .withPaymentOptionImmediately()
+                    .paymentOption(PaymentOption.IMMEDIATELY)
                     .build()
             ).build();
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/PersonContentProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/PersonContentProviderTest.java
@@ -25,16 +25,16 @@ public class PersonContentProviderTest {
         partyType = "individual";
         name = "John James Smith";
         address = SampleAddress.builder()
-            .withLine1("28 Somewhere Homes")
-            .withLine2("75 That Way Road")
-            .withLine3("")
-            .withCity("London")
-            .withPostcode("AQ9 5FS")
+            .line1("28 Somewhere Homes")
+            .line2("75 That Way Road")
+            .line3("")
+            .city("London")
+            .postcode("AQ9 5FS")
             .build();
         correspondenceAddress = SampleAddress.builder()
-            .withLine1("Correspondence Road")
-            .withCity("Manchester")
-            .withPostcode("CQ9 6FS")
+            .line1("Correspondence Road")
+            .city("Manchester")
+            .postcode("CQ9 6FS")
             .build();
         emailAddress = "blah@blah.com";
         mobileNumber = "07786556746";

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/RepaymentPlanContentProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/RepaymentPlanContentProviderTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.cmc.claimstore.services.staff.content;
 import org.junit.Test;
 import uk.gov.hmcts.cmc.claimstore.services.staff.models.RepaymentPlanContent;
 import uk.gov.hmcts.cmc.domain.models.RepaymentPlan;
+import uk.gov.hmcts.cmc.domain.models.ccj.PaymentSchedule;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleRepaymentPlan;
 
 import java.math.BigDecimal;
@@ -29,8 +30,9 @@ public class RepaymentPlanContentProviderTest {
     public void createRepaymentPlanPaymentOption() {
         LocalDate firstPaymentDate = now().plusDays(1);
         RepaymentPlan repaymentPlan = SampleRepaymentPlan.builder()
-            .withInstalmentAmount(BigDecimal.valueOf(80))
-            .withFirstPaymentDate(firstPaymentDate)
+            .instalmentAmount(BigDecimal.valueOf(80))
+            .paymentSchedule(PaymentSchedule.EVERY_MONTH)
+            .firstPaymentDate(firstPaymentDate)
             .build();
 
         RepaymentPlanContent repaymentPlanContent = create(INSTALMENTS, repaymentPlan, null);

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/AmountContentProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/staff/content/countycourtjudgment/AmountContentProviderTest.java
@@ -39,7 +39,7 @@ public class AmountContentProviderTest {
         Claim claim = SampleClaim.builder()
             .withClaimData(SampleClaimData.validDefaults())
             .withCountyCourtJudgment(SampleCountyCourtJudgment.builder()
-                .withPaidAmount(null).build())
+                .paidAmount(null).build())
             .withCountyCourtJudgmentRequestedAt(LocalDateTime.now())
             .build();
 
@@ -58,7 +58,7 @@ public class AmountContentProviderTest {
         Claim claim = SampleClaim.builder()
             .withClaimData(SampleClaimData.validDefaults())
             .withCountyCourtJudgment(SampleCountyCourtJudgment.builder()
-                .withPaidAmount(BigDecimal.valueOf(10)).build())
+                .paidAmount(BigDecimal.valueOf(10)).build())
             .withCountyCourtJudgmentRequestedAt(LocalDateTime.now())
             .build();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

This PR uses builder generated by Lombok in sample domain classes. The main purpose for that change is to reduce code duplicates and make maintenance easier. Due to the size of the domain model this is part one that applies change to roughly half of the sample domain model classes.

Logic behind changes:
- builder classes generated by Lombok can be used if instance has to be built from scratch
- sample classes offer builder instances pre-populated with reasonable defaults that can be customised further

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
