### PR TITLE
Enable Restassured filters that log HTTP request, response and errors

### DIFF
--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/Bootstrap.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/Bootstrap.java
@@ -3,6 +3,9 @@ package uk.gov.hmcts.cmc.claimstore.tests;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
+import io.restassured.filter.log.ErrorLoggingFilter;
+import io.restassured.filter.log.RequestLoggingFilter;
+import io.restassured.filter.log.ResponseLoggingFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.cmc.claimstore.idam.models.User;
@@ -38,6 +41,7 @@ public class Bootstrap {
                 ObjectMapperConfig.objectMapperConfig().jackson2ObjectMapperFactory((cls, charset) -> objectMapper)
             );
         RestAssured.useRelaxedHTTPSValidation();
+        RestAssured.filters(new RequestLoggingFilter(), new ResponseLoggingFilter(), new ErrorLoggingFilter());
         smokeTestCitizen = userService.authenticateUser(
             aatConfiguration.getSmokeTestCitizen().getUsername(),
             aatConfiguration.getSmokeTestCitizen().getPassword()


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

PR enables Restassured filters that log HTTP request, response and errors in smoke and functional tests.

Example:

```
Request method:	GET
Request URI:	http://localhost:4400/claims/claimant/16
Proxy:			<none>
Request params:	<none>
Query params:	<none>
Form params:	<none>
Path params:	<none>
Headers:		Authorization=Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJhMTQybnFhdGswczA5OG9wMXFkbWQ4dHVrayIsInN1YiI6IjE2IiwiaWF0IjoxNTM4MDQzMzUwLCJleHAiOjE1MzgwNzIxNTAsImRhdGEiOiJjaXRpemVuLGNtYy1wcml2YXRlLWJldGEsY2xhaW1hbnQsY2l0aXplbi1sb2ExLGNtYy1wcml2YXRlLWJldGEtbG9hMSxjbGFpbWFudC1sb2ExIiwidHlwZSI6IkFDQ0VTUyIsImlkIjoiMTYiLCJmb3JlbmFtZSI6IkRhbWlhbiIsInN1cm5hbWUiOiJEdW5hanNraSIsImRlZmF1bHQtc2VydmljZSI6IkNNQyIsImxvYSI6MSwiZGVmYXVsdC11cmwiOiJodHRwczovL3d3dy1jaXRpemVuLm1vbmV5Y2xhaW0ucmVmb3JtLmhtY3RzLm5ldDozMDAwL2NtYyIsImdyb3VwIjoiY21jLXByaXZhdGUtYmV0YSJ9.w6_xRNL0XZ10P5gk9kFUPhdEb6fbCMUSwp3SlOJULKE
				Accept=*/*
Cookies:		<none>
Multiparts:		<none>
Body:			<none>
HTTP/1.1 500 
Content-Type: application/json;charset=UTF-8
Content-Length: 21
Date: Thu, 27 Sep 2018 10:16:08 GMT
Connection: close

Internal server error
HTTP/1.1 500 
Content-Type: application/json;charset=UTF-8
Content-Length: 21
Date: Thu, 27 Sep 2018 10:16:08 GMT
Connection: close

Internal server error

java.lang.AssertionError: 1 expectation failed.
Expected status code <200> but was <500>.
```

Without filters we would only see last two lines.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```