### PR TITLE
Generate event once claimant response successfully saved

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseService.java
@@ -49,12 +49,12 @@ public class ClaimantResponseService {
         claimantResponseRule.assertCanBeRequested(claim, claimantId);
 
         caseRepository.saveClaimantResponse(claim, response, authorization);
-        eventProducer.createClaimantResponseEvent(claim);
 
         if (response instanceof ResponseAcceptation && ((ResponseAcceptation) response).getFormaliseOption() != null) {
             formaliseResponseAcceptanceService.formalise(claim, (ResponseAcceptation) response, authorization);
         }
 
+        eventProducer.createClaimantResponseEvent(claim);
         appInsights.trackEvent(getAppInsightsEvent(response), claim.getReferenceNumber());
     }
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseServiceTest.java
@@ -1,0 +1,121 @@
+package uk.gov.hmcts.cmc.claimstore.services;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.cmc.claimstore.appinsights.AppInsights;
+import uk.gov.hmcts.cmc.claimstore.events.EventProducer;
+import uk.gov.hmcts.cmc.claimstore.repositories.CaseRepository;
+import uk.gov.hmcts.cmc.claimstore.rules.ClaimantResponseRule;
+import uk.gov.hmcts.cmc.domain.models.Claim;
+import uk.gov.hmcts.cmc.domain.models.claimantresponse.ClaimantResponse;
+import uk.gov.hmcts.cmc.domain.models.claimantresponse.ResponseAcceptation;
+import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
+import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimantResponse;
+import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsightsEvent.CLAIMANT_RESPONSE_ACCEPTED;
+import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsightsEvent.CLAIMANT_RESPONSE_REJECTED;
+import static uk.gov.hmcts.cmc.claimstore.utils.VerificationModeUtils.once;
+import static uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim.EXTERNAL_ID;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClaimantResponseServiceTest {
+
+    private static final String AUTHORISATION = "Bearer: aaa";
+
+    private ClaimantResponseService claimantResponseService;
+
+    @Mock
+    private ClaimService claimService;
+
+    @Mock
+    private CaseRepository caseRepository;
+
+    @Mock
+    private EventProducer eventProducer;
+
+    @Mock
+    private AppInsights appInsights;
+
+    @Mock
+    FormaliseResponseAcceptanceService formaliseResponseAcceptanceService;
+
+    @Before
+    public void setup() {
+        claimantResponseService = new ClaimantResponseService(
+            claimService,
+            appInsights,
+            caseRepository,
+            new ClaimantResponseRule(),
+            eventProducer,
+            formaliseResponseAcceptanceService
+        );
+    }
+
+    @Test
+    public void saveResponseRejection() {
+
+        Claim claim = SampleClaim.builder()
+            .withResponseDeadline(LocalDate.now().minusMonths(2))
+            .withResponse(SampleResponse.FullAdmission.validDefaults())
+            .withRespondedAt(LocalDateTime.now().minusDays(32))
+            .build();
+
+        ClaimantResponse claimantResponse = SampleClaimantResponse.validDefaultRejection();
+
+        when(claimService.getClaimByExternalId(eq(EXTERNAL_ID), eq(AUTHORISATION))).thenReturn(claim);
+
+        InOrder inOrder = inOrder(caseRepository, eventProducer, appInsights);
+
+        claimantResponseService.save(EXTERNAL_ID, claim.getSubmitterId(), claimantResponse, AUTHORISATION);
+
+        inOrder.verify(caseRepository, once()).saveClaimantResponse(any(Claim.class), eq(claimantResponse), any());
+        inOrder.verify(eventProducer, once()).createClaimantResponseEvent(any(Claim.class));
+        inOrder.verify(appInsights, once()).trackEvent(eq(CLAIMANT_RESPONSE_REJECTED), eq(claim.getReferenceNumber()));
+        verify(formaliseResponseAcceptanceService, times(0))
+            .formalise(any(), any(), anyString());
+    }
+
+    @Test
+    public void saveResponseAcceptation() {
+
+        Claim claim = SampleClaim.builder()
+            .withResponseDeadline(LocalDate.now().minusMonths(2))
+            .withResponse(SampleResponse.FullAdmission.validDefaults())
+            .withRespondedAt(LocalDateTime.now().minusDays(32))
+            .build();
+
+        ClaimantResponse claimantResponse = SampleClaimantResponse
+            .ClaimantResponseAcceptation
+            .builder()
+            .buildAcceptationIssueCCJWithDefendantPaymentIntention();
+
+        when(claimService.getClaimByExternalId(eq(EXTERNAL_ID), eq(AUTHORISATION))).thenReturn(claim);
+
+        InOrder inOrder = inOrder(caseRepository, formaliseResponseAcceptanceService, eventProducer, appInsights);
+
+        claimantResponseService.save(EXTERNAL_ID, claim.getSubmitterId(), claimantResponse, AUTHORISATION);
+
+        inOrder.verify(caseRepository, once()).saveClaimantResponse(any(Claim.class), eq(claimantResponse), any());
+        inOrder.verify(formaliseResponseAcceptanceService, once())
+            .formalise(any(Claim.class), any(ResponseAcceptation.class), eq(AUTHORISATION));
+        inOrder.verify(eventProducer, once()).createClaimantResponseEvent(any(Claim.class));
+        inOrder.verify(appInsights, once()).trackEvent(eq(CLAIMANT_RESPONSE_ACCEPTED), eq(claim.getReferenceNumber()));
+
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseServiceTest.java
@@ -52,10 +52,10 @@ public class ClaimantResponseServiceTest {
     private AppInsights appInsights;
 
     @Mock
-    FormaliseResponseAcceptanceService formaliseResponseAcceptanceService;
+    private FormaliseResponseAcceptanceService formaliseResponseAcceptanceService;
 
     @Before
-    public void setup() {
+    public void setUp() {
         claimantResponseService = new ClaimantResponseService(
             claimService,
             appInsights,


### PR DESCRIPTION
### JIRA link (if applicable) ###

[ROC-4413](https://tools.hmcts.net/jira/browse/ROC-4413)

### Change description ###
This PR fixes the issue where event was generated before preserving the data in repository.

**Does this PR introduce a breaking change?** (check one with "x")


- [ ] Yes
- [x] No
