### PR TITLE
ROC-4713 Mask sensitive data with aspects

### DIFF
--- a/domain-model/build.gradle
+++ b/domain-model/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+  repositories {
+    jcenter()
+    maven { url 'http://repo.spring.io/plugins-release' }
+  }
+  dependencies {
+  }
+}
+
 plugins {
   id 'java'
   id 'jacoco'
@@ -5,10 +14,23 @@ plugins {
 
 apply plugin: 'net.ltgt.apt'
 
+ext {
+  aspectjVersion = '1.8.9'
+  springVersion = '5.1.2.RELEASE'
+}
+
 sourceCompatibility = 1.8
 
 repositories {
   mavenCentral()
+}
+
+configurations {
+  ajc
+  aspects
+  compile {
+    extendsFrom aspects
+  }
 }
 
 dependencies {
@@ -25,4 +47,45 @@ dependencies {
   testCompile group: 'javax.el', name: 'javax.el-api', version: '3.0.0'
   testCompile group: 'org.glassfish.web', name: 'javax.el', version: '2.2.6'
   testCompile group: 'com.google.guava', name: 'guava', version: '20.0'
+
+  compile "org.aspectj:aspectjrt:$aspectjVersion"
+  compile "org.aspectj:aspectjweaver:$aspectjVersion"
+
+  ajc "org.aspectj:aspectjtools:$aspectjVersion"
+  aspects "org.springframework:spring-aspects:$springVersion"
+}
+
+def aspectj = { destDir, aspectPath, inpath, classpath ->
+  ant.taskdef(resource: "org/aspectj/tools/ant/taskdefs/aspectjTaskdefs.properties",
+    classpath: configurations.ajc.asPath)
+
+  ant.iajc(
+    maxmem: "1024m", fork: "true", Xlint: "ignore",
+    destDir: destDir,
+    aspectPath: aspectPath,
+    inpath: inpath,
+    classpath: classpath,
+    source: project.sourceCompatibility,
+    target: project.targetCompatibility
+  )
+}
+
+compileJava {
+  doLast {
+    aspectj project.sourceSets.main.output.classesDir.absolutePath,
+      configurations.aspects.asPath,
+      project.sourceSets.main.output.classesDir.absolutePath,
+      project.sourceSets.main.runtimeClasspath.asPath
+  }
+}
+
+compileTestJava {
+  dependsOn jar
+
+  doLast {
+    aspectj project.sourceSets.test.output.classesDir.absolutePath,
+      configurations.aspects.asPath + jar.archivePath,
+      project.sourceSets.test.output.classesDir.absolutePath,
+      project.sourceSets.test.runtimeClasspath.asPath
+  }
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/Sensitive.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/Sensitive.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.cmc.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface Sensitive {
+}

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/SensitivityAspect.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/SensitivityAspect.java
@@ -6,14 +6,20 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static java.util.stream.Collectors.joining;
 
 @Aspect
 public class SensitivityAspect {
+    private static final String DEFAULT_MASK = "[MASKED]";
+    private static final String UNREADABLE = "[UNREADABLE]";
+    private static final Predicate<Field> isSensitive = field -> field.isAnnotationPresent(Sensitive.class);
 
     @Pointcut("execution(String toString())")
     public void toStringCall() {
@@ -22,41 +28,32 @@ public class SensitivityAspect {
     @Around("toStringCall()")
     public Object maskSensitiveFieldsOrDefault(ProceedingJoinPoint joinPoint) throws Throwable {
         final Object caller = joinPoint.getTarget();
-        List<Field> fields = getAllFields(new LinkedList<>(), caller.getClass());
-        if (fields.stream().map(field -> field.getAnnotationsByType(Sensitive.class)).noneMatch(Objects::nonNull)) {
-            return joinPoint.proceed();
-        }
+        final List<Field> fields = getAllFields(new LinkedList<>(), caller.getClass());
 
-        return maskSensitiveFields(caller, fields);
+        return fields.stream().anyMatch(isSensitive)
+            ? maskSensitiveFields(caller, fields)
+            : joinPoint.proceed();
     }
 
     private String maskSensitiveFields(Object caller, List<Field> fields) {
-        StringBuilder toString = new StringBuilder();
-        for (Field field : fields) {
-            String name = field.getName();
-            Object value;
-            try {
-                if (!Modifier.isPublic(field.getModifiers())) {
-                    field.setAccessible(true);
-                }
-                value = field.isAnnotationPresent(Sensitive.class)
-                    ? getMaskedValue(field.get(caller))
-                    : field.get(caller);
-            } catch (IllegalArgumentException | IllegalAccessException e) {
-                value = "[exception thrown while accessing]";
-            }
-            toString.append(name).append("=").append(value).append(", ");
-        }
-        return "[" + toString.toString().replaceAll(",\\s*$", "") + "]";
+        return fields.stream()
+            .peek(field -> field.setAccessible(true))
+            .map(fieldAsString(caller))
+            .collect(joining(", ", caller.getClass().getSimpleName() + " {", "}"));
     }
 
-    private static String getMaskedValue(Object input) {
-        char[] value = input.toString().toCharArray();
-        StringBuilder output = new StringBuilder();
-        for (int i = 0; i < value.length; i++) {
-            output.append("+");
-        }
-        return output.toString();
+    private static Function<Field, String> fieldAsString(Object caller) {
+        return field -> {
+            String result = field.getName() + "=";
+            try {
+                result += field.isAnnotationPresent(Sensitive.class)
+                    ? DEFAULT_MASK
+                    : Objects.toString(field.get(caller));
+            } catch (IllegalArgumentException | IllegalAccessException e) {
+                result += UNREADABLE;
+            }
+            return result;
+        };
     }
 
     private static List<Field> getAllFields(List<Field> fields, Class<?> type) {

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/SensitivityAspect.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/SensitivityAspect.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.cmc.domain;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+@Aspect
+public class SensitivityAspect {
+
+    @Pointcut("execution(String toString())")
+    public void toStringCall() {
+    }
+
+    @Around("toStringCall()")
+    public Object maskSensitiveFieldsOrDefault(ProceedingJoinPoint joinPoint) throws Throwable {
+        final Object caller = joinPoint.getTarget();
+        List<Field> fields = getAllFields(new LinkedList<>(), caller.getClass());
+        if (fields.stream().map(field -> field.getAnnotationsByType(Sensitive.class)).noneMatch(Objects::nonNull)) {
+            return joinPoint.proceed();
+        }
+
+        return maskSensitiveFields(caller, fields);
+    }
+
+    private String maskSensitiveFields(Object caller, List<Field> fields) {
+        StringBuilder toString = new StringBuilder();
+        for (Field field : fields) {
+            String name = field.getName();
+            Object value;
+            try {
+                if (!Modifier.isPublic(field.getModifiers())) {
+                    field.setAccessible(true);
+                }
+                value = field.isAnnotationPresent(Sensitive.class)
+                    ? getMaskedValue(field.get(caller))
+                    : field.get(caller);
+            } catch (IllegalArgumentException | IllegalAccessException e) {
+                value = "[exception thrown while accessing]";
+            }
+            toString.append(name).append("=").append(value).append(", ");
+        }
+        return "[" + toString.toString().replaceAll(",\\s*$", "") + "]";
+    }
+
+    private static String getMaskedValue(Object input) {
+        char[] value = input.toString().toCharArray();
+        StringBuilder output = new StringBuilder();
+        for (int i = 0; i < value.length; i++) {
+            output.append("+");
+        }
+        return output.toString();
+    }
+
+    private static List<Field> getAllFields(List<Field> fields, Class<?> type) {
+        fields.addAll(Arrays.asList(type.getDeclaredFields()));
+        if (type.getSuperclass() != null) {
+            getAllFields(fields, type.getSuperclass());
+        }
+        return fields;
+    }
+}

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Party.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Party.java
@@ -6,9 +6,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotBlank;
+import uk.gov.hmcts.cmc.domain.Sensitive;
 import uk.gov.hmcts.cmc.domain.models.Address;
 import uk.gov.hmcts.cmc.domain.models.legalrep.Representative;
 
+import java.time.LocalDate;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -34,6 +36,7 @@ public abstract class Party implements NamedParty {
 
     @NotBlank
     @Size(max = 255, message = "may not be longer than {max} characters")
+    @Sensitive
     private final String name;
 
     @Valid
@@ -89,4 +92,9 @@ public abstract class Party implements NamedParty {
         return ReflectionToStringBuilder.toString(this, ourStyle());
     }
 
+    public static void main(String[] args) {
+        System.out.println(new Individual("Should be masked",
+            new Address("line1", "line2", "line3", "city", "postcode"),
+            null, "+447012345678", null, LocalDate.now()));
+    }
 }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Party.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/party/Party.java
@@ -47,6 +47,7 @@ public abstract class Party implements NamedParty {
     private final Address correspondenceAddress;
 
     @Size(max = 30, message = "may not be longer than {max} characters")
+    @Sensitive
     private final String mobilePhone;
 
     @Valid


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-4713

### Change description ###
Candidate strategy to prevent `model.toString()` outputting sensitive data

- mark sensitive fields with `@Sensitive`
- use an aspect to intercept `toString()` calls and sanitise result
  - this example replaces the implementation entirely if any `@Sensitive` fields are found
  - could alternatively search the result and mask any occurrences of the values of any `@Sensitive` fields