### PR TITLE
ROC-4719: remove dummy app_setting

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,6 +2,13 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
     <suppress>
         <notes><![CDATA[
+         Specific to deserialisation of AtomicDoubleArray and CompoundOrdering classes: https://github.com/google/guava/wiki/CVE-2018-10237
+        ]]></notes>
+        <gav regex="true">^com\.google\.guava:guava:.*$</gav>
+        <cve>CVE-2018-10237</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
             Related to PostgreSQL server startup script, also up to 9.4 while we are using 9.6
         ]]></notes>
         <gav regex="true">^org\.postgresql:postgresql:.*$</gav>

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -119,7 +119,6 @@ module "claim-store-api" {
   instance_size = "${local.sku_size}"
 
   app_settings = {
-    DUMMY = "fix-broken-apply-stage"
     //    logging vars
     REFORM_TEAM = "${var.product}"
     REFORM_SERVICE_NAME = "${var.microservice}"


### PR DESCRIPTION

### Change description ###

Cleanup post SIDAM testing. The pipeline failed once reverted changes at apply stage. I added this dummy value to ensure the next pipeline run would re-apply! There was a case before where state was out of sync - I think when this sequence of events happen:

--> SIDAM changes to terraform --> plan --> apply --> all good
--> Revert --> plan --> apply X failed (but state has been updated with reverted values, but deployment still has SIDAM changes
--> If we make no changes to terraform --> apply thinks no changes so essentially skips - this is why we need the forced apply with a dummy setting.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
