### PR TITLE
Clean up pdf service base url config in tests

### DIFF
--- a/src/integrationTest/resources/environment.properties
+++ b/src/integrationTest/resources/environment.properties
@@ -3,7 +3,7 @@ spring.datasource.claimstore.url=jdbc:tc:postgresql:9.6-alpine://localhost/claim
 spring.datasource.cmc.url=jdbc:tc:postgresql:10.3-alpine://localhost/cmc
 spring.datasource.cmc.driverClassName=org.testcontainers.jdbc.ContainerDatabaseDriver
 
-pdf_service.url = http://some-test-host/api/v1/pdf-generator
+pdf_service.url = http://some-test-host
 document_management.url = http://document-management-api
 core_case_data.api.url=false
 send-letter.url=http://send-letter

--- a/src/test/resources/environment.properties
+++ b/src/test/resources/environment.properties
@@ -1,4 +1,4 @@
-pdf_service.url = http://some-test-host/api/v1/pdf-generator
+pdf_service.url = http://some-test-host
 document_management.url = http://document-management-api
 
 staff-notifications.sender = sender@example.com


### PR DESCRIPTION
As stated in this repos README:
>- `PDF_SERVICE_URL`, the base url of PDF Service instance, `http://localhost:5500` for the dockerized local environment
