### PR TITLE
ROC-4836 full defence directions questionnaire deadlines migration

### DIFF
--- a/src/main/resources/db/migration/claimstore/V2018_11_28_1148__Define_directions_questionnaire_deadline_for_full_defence.sql
+++ b/src/main/resources/db/migration/claimstore/V2018_11_28_1148__Define_directions_questionnaire_deadline_for_full_defence.sql
@@ -1,0 +1,4 @@
+UPDATE claim
+  SET directions_questionnaire_deadline = responded_at + INTERVAL '19 days'
+  WHERE response->>'responseType' = 'FULL_DEFENCE'
+    AND directions_questionnaire_deadline IS NULL;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-4836

### Change description ###
Add migration script to populate the `directions_questionnaire_deadline` column of the `claims` table when a full defence has been submitted and the column is still `NULL`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
### Associated PR
https://github.com/hmcts/cmc-citizen-frontend/pull/1189
