### PR TITLE
fix dockerhub builds

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/CCDCaseApi.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/CCDCaseApi.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.cmc.claimstore.repositories;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/DBCaseRepository.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/DBCaseRepository.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.cmc.claimstore.repositories;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.cmc.claimstore.exceptions.ConflictException;


### PR DESCRIPTION
### Change description ###

A quick fix for our broken dockerhub builds:

```> Task :compileJava

[91m/home/gradle/src/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/CCDCaseApi.java:4: error: package org.apache.commons.lang does not exist
import org.apache.commons.lang.StringUtils;
                              ^
/home/gradle/src/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/DBCaseRepository.java:3: error: package org.apache.commons.lang does not exist
import org.apache.commons.lang.StringUtils;
                              ^
[0m
[91m2 errors
[0m

> Task :compileJava FAILED```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
