### PR TITLE
ROC-4520: increase unit test coverage

### DIFF
--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/rules/ClaimantResponseRuleTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/rules/ClaimantResponseRuleTest.java
@@ -6,9 +6,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.cmc.claimstore.exceptions.ClaimantLinkException;
 import uk.gov.hmcts.cmc.claimstore.exceptions.ClaimantResponseAlreadySubmittedException;
 import uk.gov.hmcts.cmc.claimstore.exceptions.ForbiddenActionException;
+import uk.gov.hmcts.cmc.domain.exceptions.BadRequestException;
 import uk.gov.hmcts.cmc.domain.models.Claim;
+import uk.gov.hmcts.cmc.domain.models.claimantresponse.ClaimantResponse;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
+import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimData;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaimantResponse;
+import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
+import uk.gov.hmcts.cmc.domain.models.sampledata.SampleTheirDetails;
 
 import java.time.LocalDate;
 
@@ -48,5 +53,110 @@ public class ClaimantResponseRuleTest {
             .withClaimantRespondedAt(now())
             .build();
         claimantResponseRule.assertCanBeRequested(claim, USER_ID);
+    }
+
+    @Test()
+    public void shouldBeValidWhenClaimantIsBusiness() {
+        Claim claim = SampleClaim.builder()
+            .withClaimData(
+                SampleClaimData.builder().withDefendant(
+                    SampleTheirDetails.builder().companyDetails()
+                ).build()
+            )
+            .withRespondedAt(now().minusDays(2))
+            .withResponse(SampleResponse.validDefaults())
+            .withClaimantResponse(SampleClaimantResponse.validDefaultAcceptation())
+            .withClaimantRespondedAt(now())
+            .build();
+        assertThatCode(() ->
+            claimantResponseRule.isValid(claim)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test()
+    public void shouldBeValidWhenNoFormaliseOptionExpected() {
+        Claim claim = SampleClaim.builder()
+            .withClaimData(SampleClaimData.builder().build())
+            .withRespondedAt(now().minusDays(2))
+            .withResponse(SampleResponse.validDefaults())
+            .withClaimantResponse(SampleClaimantResponse.validDefaultAcceptation())
+            .withClaimantRespondedAt(now())
+            .build();
+        assertThatCode(() ->
+            claimantResponseRule.isValid(claim)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test()
+    public void shouldBeValidWhenFormaliseOptionExpected() {
+        Claim claim = SampleClaim.builder()
+            .withClaimData(
+                SampleClaimData.builder().build()
+            )
+            .withRespondedAt(now().minusDays(2))
+            .withResponse(SampleResponse.PartAdmission.builder().buildWithPaymentOptionBySpecifiedDate())
+            .withClaimantResponse(SampleClaimantResponse.validDefaultAcceptation())
+            .withClaimantRespondedAt(now())
+            .build();
+        assertThatCode(() ->
+            claimantResponseRule.isValid(claim)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldThrowBadRequestExceptionWhenFormaliseOptionExpectedButCourtDeterminationMissing() {
+        ClaimantResponse claimantResponse = SampleClaimantResponse
+            .ClaimantResponseAcceptation
+            .builder()
+            .buildAcceptationIssueSettlementWithClaimantPaymentIntention();
+        Claim claim = SampleClaim.builder()
+            .withClaimData(
+                SampleClaimData.builder().build()
+            )
+            .withRespondedAt(now().minusDays(2))
+            .withResponse(SampleResponse.PartAdmission.builder().buildWithPaymentOptionBySpecifiedDate())
+            .withClaimantResponse(claimantResponse)
+            .withClaimantRespondedAt(now())
+            .build();
+        claimantResponseRule.isValid(claim);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldThrowBadRequestExceptionWhenFormaliseOptionExpectedMissing() {
+        ClaimantResponse claimantResponse = SampleClaimantResponse
+            .ClaimantResponseAcceptation
+            .builder()
+            .withFormaliseOption(null)
+            .build();
+        Claim claim = SampleClaim.builder()
+            .withClaimData(
+                SampleClaimData.builder().build()
+            )
+            .withRespondedAt(now().minusDays(2))
+            .withResponse(SampleResponse.PartAdmission.builder().buildWithPaymentOptionBySpecifiedDate())
+            .withClaimantResponse(claimantResponse)
+            .withClaimantRespondedAt(now())
+            .build();
+        claimantResponseRule.isValid(claim);
+    }
+
+    @Test
+    public void shouldBeValidWhenFormaliseOptionExpectedAndValidClaimantResponseState() {
+        ClaimantResponse claimantResponse = SampleClaimantResponse
+            .ClaimantResponseAcceptation
+            .builder()
+            .buildAcceptationIssueSettlementWithCourtDetermination();
+        Claim claim = SampleClaim.builder()
+            .withClaimData(
+                SampleClaimData.builder().build()
+            )
+            .withRespondedAt(now().minusDays(2))
+            .withResponse(SampleResponse.PartAdmission.builder().buildWithPaymentOptionBySpecifiedDate())
+            .withClaimantResponse(claimantResponse)
+            .withClaimantRespondedAt(now())
+            .build();
+        assertThatCode(() ->
+            claimantResponseRule.isValid(claim)
+        ).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
### Change description ###

Sonar failing with 79.92% coverage - I'm hoping this will push us past 80%. Worth a visit to see where we are lacking: https://sonarcloud.io/dashboard?id=uk.gov.hmcts.cmc%3Aclaim-store

**Does this PR introduce a breaking change?** (check one with "x")

[ ] Yes
[ X ] No
