### PR TITLE
ROC-4892 Enumerate the "reason" text in the generated sealed claim PDF

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimDataContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/ClaimDataContentProvider.java
@@ -14,14 +14,17 @@ import uk.gov.hmcts.cmc.domain.models.Timeline;
 import uk.gov.hmcts.cmc.domain.models.TimelineEvent;
 import uk.gov.hmcts.cmc.domain.models.amount.AmountBreakDown;
 import uk.gov.hmcts.cmc.domain.models.evidence.Evidence;
+import uk.gov.hmcts.cmc.domain.models.evidence.EvidenceRow;
 import uk.gov.hmcts.cmc.domain.models.legalrep.StatementOfTruth;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.math.BigDecimal.ZERO;
@@ -32,6 +35,9 @@ import static uk.gov.hmcts.cmc.claimstore.utils.Formatting.formatMoney;
 
 @Component
 public class ClaimDataContentProvider {
+
+    private static final Function<EvidenceRow, EvidenceContent> toEvidenceContent =
+        e -> new EvidenceContent(e.getType().getDescription(), e.getDescription().orElse(null));
 
     private final InterestContentProvider interestContentProvider;
 
@@ -50,7 +56,7 @@ public class ClaimDataContentProvider {
 
         InterestContent interestContent = null;
 
-        if (!claim.getClaimData().getInterest().getType().equals(Interest.InterestType.NO_INTEREST)) {
+        if (!Objects.equals(claim.getClaimData().getInterest().getType(), Interest.InterestType.NO_INTEREST)) {
             interestContent = interestContentProvider.createContent(
                 claim.getClaimData().getInterest(),
                 claim.getClaimData().getInterest().getInterestDate(),
@@ -66,28 +72,21 @@ public class ClaimDataContentProvider {
         String signerName = optionalStatementOfTruth.map((StatementOfTruth::getSignerName)).orElse(null);
         String signerRole = optionalStatementOfTruth.map((StatementOfTruth::getSignerRole)).orElse(null);
 
-        List<TimelineEvent> events = null;
-        Optional<Timeline> timeline = claim.getClaimData().getTimeline();
-        if (timeline.isPresent()) {
-            events = timeline.get().getEvents();
-        }
+        List<TimelineEvent> events = claim.getClaimData().getTimeline().map(Timeline::getEvents).orElse(null);
 
-        List<EvidenceContent> evidences = null;
-        Optional<Evidence> evidence = claim.getClaimData().getEvidence();
-        if (evidence.isPresent()) {
-            evidences = Optional.ofNullable(evidence.get().getRows())
-                .orElseGet(Collections::emptyList)
-                .stream()
-                .filter(Objects::nonNull)
-                .map(e -> new EvidenceContent(e.getType().getDescription(), e.getDescription().orElse(null)))
-                .collect(Collectors.toList());
-        }
+        List<EvidenceContent> evidences = claim.getClaimData().getEvidence()
+            .map(Evidence::getRows)
+            .orElseGet(Collections::emptyList)
+            .stream()
+            .filter(Objects::nonNull)
+            .map(toEvidenceContent)
+            .collect(Collectors.toList());
 
         return new ClaimContent(
             claim.getReferenceNumber(),
             formatDateTime(claim.getCreatedAt()),
             formatDate(claim.getIssuedOn()),
-            claim.getClaimData().getReason(),
+            split(claim.getClaimData().getReason()),
             formatMoney(amountBreakDown.getTotalAmount()),
             formatMoney(claim.getClaimData().getFeesPaidInPound()),
             interestContent,
@@ -104,11 +103,27 @@ public class ClaimDataContentProvider {
         );
     }
 
+    private static List<String> split(String reason) {
+        return Arrays.stream(reason.split("(?<=[.!?])|\\n|\\r"))
+            .map(String::trim)
+            .filter(line -> !line.isEmpty())
+            .collect(Collectors.toList());
+    }
+
     private static List<AmountRowContent> mapToAmountRowContent(List<AmountRow> rows) {
         return rows
             .stream()
-            .filter(row -> row != null && row.getAmount() != null)
+            .filter(Objects::nonNull)
+            .filter(row -> row.getAmount() != null)
             .map(AmountRowContent::new)
             .collect(Collectors.toList());
+    }
+
+    public static void main(String[] args) {
+//        split("Mrs Richards had 7 physiotherapy appointments. The first appointment was on 16th November 2015 and the last was on 7th December 2016. She gave us details of his private medical insurance provider, Aviva, so that we could claim the fees from them. We have been unable to get payment from them and they have told us that. Mrs Richards's policy with them was terminated on 14th November 2015. We have contacted Mrs Richards on many occasions requesting payment culminating in an email on 23rd January 2017 warning that we would seek legal advice if we had no payment by 31st January 2017. We have have no response to this email and have had no payment.")
+        split("Mrs. Richards had 7 physiotherapy appointments at £78.40 each. The first appointment was on 16th November 2015 and the last was on 7th December 2016. She gave us details of his private medical insurance provider, Aviva, so that we could claim the fees from them. We have been unable to get payment from them and they have told us that. Mrs. Richards's policy with them was terminated on 14th November 2015! We have contacted Mrs Richards on many occasions requesting payment culminating in an email on 23rd January 2017 warning that we would seek legal advice if we had no payment by 31st January 2017. We have have no response to this email and have had no payment.")
+
+
+            .forEach(System.out::println);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/models/ClaimContent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/staff/models/ClaimContent.java
@@ -11,7 +11,7 @@ public class ClaimContent {
     private final String referenceNumber;
     private final String submittedOn;
     private final String issuedOn;
-    private final String reason;
+    private final List<String> reason;
     private final String claimAmount;
     private final String feeAmount;
     private final InterestContent interest;
@@ -27,7 +27,7 @@ public class ClaimContent {
         String referenceNumber,
         String submittedOn,
         String issuedOn,
-        String reason,
+        List<String> reason,
         String claimAmount,
         String feeAmount,
         InterestContent interest,
@@ -65,7 +65,7 @@ public class ClaimContent {
         return issuedOn;
     }
 
-    public String getReason() {
+    public List<String> getReason() {
         return reason;
     }
 

--- a/src/main/resources/staff/templates/document/sealedClaim.html
+++ b/src/main/resources/staff/templates/document/sealedClaim.html
@@ -110,6 +110,22 @@
       padding-top: 10rem;
     }
 
+    ol.enumerate {
+      margin-top: 0;
+      counter-reset: enumerated;
+      list-style: none;
+    }
+
+    ol.enumerate li::before {
+      content: counter(section) "." counter(enumerated) ". ";
+      counter-increment: enumerated;
+      color: #888;
+    }
+
+    ol.enumerate li {
+      margin-bottom: 5px;
+    }
+
     @media print {
       td {
         word-wrap: break-word;
@@ -317,7 +333,11 @@
       <table>
         <tr>
           <td colspan="2" class="keep-white-space"><strong>Reason for claim:</strong><br/>
-            {{ claim.reason | trim }}
+            <ol class="enumerate">
+              {% for reasonLine in claim.reason %}
+                <li>{{ reasonLine }}</li>
+              {% endfor %}
+            </ol>
           </td>
         </tr>
         {% if claim.events is defined %}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-4892

### Change description ###
Candidate strategy to enumerate free-text provided by users.

Enumeration here accepts the users' own paragraphing and treats every sentence terminating character (to whit: `.?!`) as indicative of a new item.

Presentation strategy is with CSS counters; prototype has line-wraps aligned with the text (emulating `list-style-position: outside`) that hasn't been replicated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
