### PR TITLE
ROC-5104 Proceed with claim creation events when external ID already found in claim store

### DIFF
--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/BaseSubmitClaimTest.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/functional/BaseSubmitClaimTest.java
@@ -56,18 +56,5 @@ public abstract class BaseSubmitClaimTest extends BaseTest {
             .statusCode(HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 
-    @Test
-    public void shouldReturnConflictResponseWhenClaimDataWithDuplicatedExternalIdIsSubmitted() {
-        ClaimData claimData = getSampleClaimDataBuilder().get().build();
-
-        commonOperations.submitPrePaymentClaim(claimData.getExternalId().toString(), user.getAuthorisation());
-
-        submitClaim(claimData)
-            .andReturn();
-        submitClaim(claimData)
-            .then()
-            .statusCode(HttpStatus.CONFLICT.value());
-    }
-
     protected abstract Supplier<SampleClaimData> getSampleClaimDataBuilder();
 }

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimTest.java
@@ -19,8 +19,6 @@ import uk.gov.hmcts.cmc.email.EmailData;
 import uk.gov.hmcts.reform.sendletter.api.SendLetterApi;
 import uk.gov.service.notify.NotificationClientException;
 
-import java.util.UUID;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/SaveClaimTest.java
@@ -100,17 +100,6 @@ public class SaveClaimTest extends BaseSaveTest {
     }
 
     @Test
-    public void shouldFailWhenDuplicateExternalId() throws Exception {
-        UUID externalId = UUID.randomUUID();
-
-        ClaimData claimData = SampleClaimData.builder().withExternalId(externalId).build();
-        claimStore.saveClaim(claimData);
-
-        makeIssueClaimRequest(claimData, AUTHORISATION_TOKEN)
-            .andExpect(status().isConflict());
-    }
-
-    @Test
     public void shouldFailWhenStaffNotificationFails() throws Exception {
         doThrow(new RuntimeException("Sending failed"))
             .when(emailService).sendEmail(anyString(), any(EmailData.class));

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/appinsights/AppInsightsEvent.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/appinsights/AppInsightsEvent.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.cmc.claimstore.appinsights;
 public enum AppInsightsEvent {
     CLAIM_ISSUED_LEGAL("Claim issued - Legal"),
     CLAIM_ISSUED_CITIZEN("Claim issued - Citizen"),
+    CLAIM_ATTEMPT_DUPLICATE("Claim attempt - Duplicate"),
     RESPONSE_FULL_DEFENCE_SUBMITTED("Defendant Response - Full defence submitted"),
     RESPONSE_FULL_DEFENCE_SUBMITTED_STATES_PAID("Defendant Response - Full defence submitted - States Paid"),
     RESPONSE_FULL_ADMISSION_SUBMITTED_IMMEDIATELY("Defendant Response - Full admission submitted - Immediate"),

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
@@ -206,7 +206,7 @@ public class ClaimService {
         } catch (ConflictException e) {
             appInsights.trackEvent(AppInsightsEvent.CLAIM_ATTEMPT_DUPLICATE, CLAIM_EXTERNAL_ID, externalId);
             issuedClaim = caseRepository.getClaimByExternalId(externalId, authorisation)
-                .orElseThrow(RuntimeException::new);
+                .orElseThrow(() -> new NotFoundException("Could not find claim with external ID '" + externalId + "'"));
         }
 
         eventProducer.createClaimIssuedEvent(

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
@@ -40,12 +40,11 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsights.REFERENCE_NUMBER;
 import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsights.CLAIM_EXTERNAL_ID;
+import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsights.REFERENCE_NUMBER;
 import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsightsEvent.CCJ_REQUESTED;
 import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsightsEvent.CLAIM_ISSUED_CITIZEN;
 import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsightsEvent.CLAIM_ISSUED_LEGAL;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-5104

### Change description ###
When saving a claim whose external ID is already found in the claim-store, raise a new app insights event (`Claim attempt - Duplicate` with the external ID) and proceed with the claim creation event as usual.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
