### PR TITLE
ROC-5116: Save timestamp for countersign settlement

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/SettlementAgreementService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/SettlementAgreementService.java
@@ -76,7 +76,7 @@ public class SettlementAgreementService {
         settlement.countersign(MadeBy.DEFENDANT);
 
         CaseEvent caseEvent = AGREEMENT_COUNTER_SIGNED_BY_DEFENDANT;
-        caseRepository.updateSettlement(claim, settlement, authorisation, caseEvent);
+        caseRepository.reachSettlementAgreement(claim, settlement, authorisation, caseEvent);
 
         Claim updated = claimService.getClaimByExternalId(claim.getExternalId(), authorisation);
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/SettlementAgreementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/SettlementAgreementServiceTest.java
@@ -107,7 +107,7 @@ public class SettlementAgreementServiceTest {
 
         InOrder inOrder = inOrder(caseRepository, eventProducer, ccdEventProducer, appInsights);
 
-        inOrder.verify(caseRepository).updateSettlement(eq(claimWithSettlementAgreement), any(Settlement.class),
+        inOrder.verify(caseRepository).reachSettlementAgreement(eq(claimWithSettlementAgreement), any(Settlement.class),
             eq(AUTHORISATION), eq(AGREEMENT_COUNTER_SIGNED_BY_DEFENDANT));
 
         inOrder.verify(ccdEventProducer).createCCDSettlementEvent(eq(claimWithSettlementAgreement),
@@ -128,7 +128,7 @@ public class SettlementAgreementServiceTest {
 
         InOrder inOrder = inOrder(caseRepository, eventProducer, ccdEventProducer, appInsights);
 
-        inOrder.verify(caseRepository).updateSettlement(eq(claimWithSettlementAgreement), any(Settlement.class),
+        inOrder.verify(caseRepository).reachSettlementAgreement(eq(claimWithSettlementAgreement), any(Settlement.class),
             eq(AUTHORISATION), eq(AGREEMENT_COUNTER_SIGNED_BY_DEFENDANT));
 
         inOrder.verify(ccdEventProducer).createCCDSettlementEvent(eq(claimWithSettlementAgreement),


### PR DESCRIPTION
### JIRA link (if applicable) ###
[ROC-5116](https://tools.hmcts.net/jira/browse/ROC-5116)

### Change description ###
This PR fixes the bug, where countersign settlement agreement was not saving the timestamp.


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

