### PR TITLE
Suppress dependency check error: CVE-2018-1000840

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -116,4 +116,11 @@
         <gav regex="true">.*</gav>
         <cve>CVE-2018-8088</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+			Not applicable - relates to XML processing
+			]]></notes>
+        <gav regex="true">.*</gav>
+        <cve>CVE-2018-1000840</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

Suppress dependency check - irrelevant as specific to XML processing:
```
> Task :dependencyCheckAnalyze

Verifying dependencies for project claim-store

Checking for updates and analyzing dependencies for vulnerabilities

Generating report for project claim-store

Found 2 vulnerabilities in project claim-store

One or more dependencies were identified with known vulnerabilities:

javax.json-api-1.1.4.jar: ids:(javax.json:javax.json-api:1.1.4, cpe:/a:processing:processing:1.1.4) : CVE-2018-1000840

javax.json-1.1.4.jar: ids:(org.glassfish:javax.json:1.1.4, cpe:/a:processing:processing:1.1.4) : CVE-2018-1000840
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
