### PR TITLE
ROC-5179 - Missing Instalment amount and financial details In Defendant Response PDF

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/PartAdmissionResponseContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/PartAdmissionResponseContentProvider.java
@@ -38,6 +38,7 @@ public class PartAdmissionResponseContentProvider {
     }
 
     public Map<String, Object> createContent(PartAdmissionResponse partAdmissionResponse) {
+
         Map<String, Object> content = new HashMap<>();
 
         List<TimelineEvent> events = null;

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/PartAdmissionResponseContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/PartAdmissionResponseContentProvider.java
@@ -38,7 +38,6 @@ public class PartAdmissionResponseContentProvider {
     }
 
     public Map<String, Object> createContent(PartAdmissionResponse partAdmissionResponse) {
-
         Map<String, Object> content = new HashMap<>();
 
         List<TimelineEvent> events = null;
@@ -82,6 +81,7 @@ public class PartAdmissionResponseContentProvider {
         content.put("evidences", evidences);
         content.put("evidenceComment", evidenceComment);
 
+        content.put("paymentIntentionIsPresent", partAdmissionResponse.getPaymentIntention().isPresent());
         partAdmissionResponse.getPaymentIntention().ifPresent(
             paymentIntention ->
                 content.putAll(paymentIntentionContentProvider.createContent(

--- a/src/main/resources/citizen/templates/document/defendantResponseReceipt.html
+++ b/src/main/resources/citizen/templates/document/defendantResponseReceipt.html
@@ -201,7 +201,7 @@
         </td>
       </tr>
       {% if defendant.contactPerson is defined %}
-      <tr>
+      <tr>x
         <td>Contact person</td>
         <td>
           {{ defendant.contactPerson }}
@@ -410,7 +410,7 @@
   </div>
 </div>
 
-{% if responseType == "FULL_ADMISSION" or (responseType == "PART_ADMISSION" and paymentIntention is defined )%}
+{% if responseType == "FULL_ADMISSION" or (responseType == "PART_ADMISSION" and paymentIntentionIsPresent)%}
 <div class="section">
   <div class="section-heading">
     <strong>How the defendant will pay

--- a/src/main/resources/citizen/templates/document/defendantResponseReceipt.html
+++ b/src/main/resources/citizen/templates/document/defendantResponseReceipt.html
@@ -201,7 +201,7 @@
         </td>
       </tr>
       {% if defendant.contactPerson is defined %}
-      <tr>x
+      <tr>
         <td>Contact person</td>
         <td>
           {{ defendant.contactPerson }}

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/PartAdmissionResponseContentProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/PartAdmissionResponseContentProviderTest.java
@@ -55,6 +55,9 @@ public class PartAdmissionResponseContentProviderTest {
             .isInstanceOf(List.class);
         assertThat((List<String>) content.get("responseDefence"))
             .contains(SampleResponse.USER_DEFENCE);
+        assertThat(content)
+            .containsKey("paymentIntentionIsPresent")
+            .containsValues(false);
     }
 
     @Test
@@ -68,6 +71,9 @@ public class PartAdmissionResponseContentProviderTest {
         assertThat(content)
             .containsKeys("paymentOption")
             .containsValues("Immediately");
+        assertThat(content)
+            .containsKeys("paymentIntentionIsPresent")
+            .containsValues(true);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-5179



### Change description ###
Fix defendant response PDF issue where the payment intention section would not be shown when present.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
