### PR TITLE
Fix push to use https git repo

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -51,7 +51,6 @@ withPipeline("java", product, component) {
     onMaster {
       withCredentials([usernamePassword(credentialsId: 'jenkins-github-hmcts-api-token', passwordVariable: 'BEARER_TOKEN', usernameVariable: 'USERNAME')]) {
         try {
-          sh('env')  // testing - will remove
           def url = sh(returnStdout: true, script: 'git config remote.origin.url').replace('github.com', '${BEARER_TOKEN}@github.com')
           sh('git remote set-url origin ' + url)
           sh('git fetch origin demo:demo')

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -49,44 +49,19 @@ String notificationsChannel = '#cmc-tech-notification'
 withPipeline("java", product, component) {
   afterCheckout {
     onMaster {
-      try {
-        sh """
-          git fetch origin demo:demo
-          git push --force origin HEAD:demo
-        """
-      } catch (err) {
-        notifyBuildEvent channel: notificationsChannel, color: 'warning', message: 'Failed to update demo branch'
+      withCredentials([usernamePassword(credentialsId: 'jenkins-github-hmcts-api-token', passwordVariable: 'BEARER_TOKEN', usernameVariable: 'USERNAME')]) {
+        try {
+          sh('env')  // testing - will remove
+          def url = sh(returnStdout: true, script: 'git config remote.origin.url').replace('github.com', '${BEARER_TOKEN}@github.com')
+          sh('git remote set-url origin ' + url)
+          sh('git fetch origin demo:demo')
+          sh('git push --force origin HEAD:demo')
+        } catch (err) {
+          notifyBuildEvent channel: notificationsChannel, color: 'warning', message: 'Failed to update demo branch'
+        }
       }
     }
   }
-
-// prod configuration
-
-//  env.IDAM_API_URL = 'https://idam-api.platform.hmcts.net'
-//  env.IDAM_S2S_AUTH_URL = 'http://rpe-service-auth-provider-prod.service.core-compute-prod.internal'
-//  env.CORE_CASE_DATA_API_URL = 'http://ccd-data-store-api-prod.service.core-compute-prod.internal'
-//  env.CLAIM_STORE_DB_HOST = 'prod-data-lb.moneyclaim.reform.hmcts.net'
-//  env.CLAIM_STORE_DB_PORT = '5432'
-//  env.CLAIM_STORE_DB_NAME = 'claimstore'
-//  env.CLAIM_STORE_DB_USERNAME = 'claimstore'
-//
-//  after('smoketest:prod') {
-//    sh './gradlew :ccd-claim-migration:assemble migrateClaims -Djava.util.concurrent.ForkJoinPool.common.parallelism=10'
-//  }
-  
-// aat configuration
-
-//env.IDAM_API_URL = 'https://preprod-idamapi.reform.hmcts.net:3511'
-//  env.IDAM_S2S_AUTH_URL = 'http://rpe-service-auth-provider-aat.service.core-compute-aat.internal'
-//  env.CORE_CASE_DATA_API_URL = 'http://ccd-data-store-api-aat.service.core-compute-aat.internal'
-//  env.CLAIM_STORE_DB_HOST = 'preprod-data-lb.moneyclaim.reform.hmcts.net'
-//  env.CLAIM_STORE_DB_PORT = '5432'
-//  env.CLAIM_STORE_DB_NAME = 'claimstore'
-//  env.CLAIM_STORE_DB_USERNAME = 'claimstore'
-//
-//  after('smoketest:aat') {
-//    sh './gradlew :ccd-claim-migration:assemble migrateClaims -Djava.util.concurrent.ForkJoinPool.common.parallelism=10'
-//  }
 
   loadVaultSecrets(secrets)
   enableSlackNotifications(notificationsChannel)


### PR DESCRIPTION

### Change description ###

Platform changed some infrastructure code that meant git commands were over https and not ssh anymore, this broke the force push to demo.

Also some cleanup of CCD migration comments - no longer required.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
