### PR TITLE
Fix helm tags

### DIFF
--- a/charts/cmc-claim-store/Chart.yaml
+++ b/charts/cmc-claim-store/Chart.yaml
@@ -1,7 +1,7 @@
 description: Helm chart for the HMCTS CMC Claim-Store service
 name: cmc-claim-store
 home: https://github.com/hmcts/cmc-claim-store
-version: 0.0.6
+version: 0.0.7
 maintainers:
   - name: HMCTS CMC Dev Team
     email: cmc-developers@HMCTS.NET

--- a/charts/cmc-claim-store/values.template.yaml
+++ b/charts/cmc-claim-store/values.template.yaml
@@ -1,6 +1,6 @@
 tags:
-  - postgresql-pod
-  - cmc-citizen-frontend-pod
+  postgresql-pod: true
+  cmc-citizen-frontend-pod: true
 
 postgresql:
   resources:


### PR DESCRIPTION
### Change description ###

Importing this chart into frontend breaks - tags are ignored and claim-store frontend is initialised too.

E.g. https://github.com/hmcts/cmc-citizen-frontend/blob/3d8f7c10d5e2915ab4ac6d61c4fba4d8d05e462d/charts/cmc-citizen-frontend/values.template.yaml#L86  - doesnt have any effect :(

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
