### PR TITLE
Fixes to sort application not starting

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/CCDStoreConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/CCDStoreConfiguration.java
@@ -49,6 +49,21 @@ public class CCDStoreConfiguration {
     }
 
     @Bean
+    public CCDCreateCaseService ccdCreateCaseService(
+        CoreCaseDataApi coreCaseDataApi,
+        AuthTokenGenerator authTokenGenerator,
+        CaseAccessApi caseAccessApi,
+        UserService userService
+    ) {
+        return new CCDCreateCaseService(
+            coreCaseDataApi,
+            authTokenGenerator,
+            caseAccessApi,
+            userService
+        );
+    }
+
+    @Bean
     public CoreCaseDataService coreCaseDataService(
         CaseMapper caseMapper,
         UserService userService,

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/CCDCreateCaseService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/CCDCreateCaseService.java
@@ -28,10 +28,11 @@ public class CCDCreateCaseService {
     private final UserService userService;
 
     @Autowired
-    public CCDCreateCaseService(CoreCaseDataApi coreCaseDataApi,
-                                AuthTokenGenerator authTokenGenerator,
-                                CaseAccessApi caseAccessApi,
-                                UserService userService
+    public CCDCreateCaseService(
+        CoreCaseDataApi coreCaseDataApi,
+        AuthTokenGenerator authTokenGenerator,
+        CaseAccessApi caseAccessApi,
+        UserService userService
     ) {
         this.coreCaseDataApi = coreCaseDataApi;
         this.authTokenGenerator = authTokenGenerator;


### PR DESCRIPTION

### Change description ###

```***************************
APPLICATION FAILED TO START
***************************

Description:

Parameter 7 of method coreCaseDataService in uk.gov.hmcts.cmc.claimstore.config.CCDStoreConfiguration required a bean of type 'uk.gov.hmcts.cmc.claimstore.services.ccd.CCDCreateCaseService' that could not be found.


Action:

Consider defining a bean of type 'uk.gov.hmcts.cmc.claimstore.services.ccd.CCDCreateCaseService' in your configuration.
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
