### PR TITLE
SIDAM code freeze - changes for AAT

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -34,7 +34,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 // Vars needed for AKS testing
 env.FRONTEND_BASE_URL = 'https://moneyclaims.aat.platform.hmcts.net'
-env.IDAM_API_URL = 'https://idam-api.aat.platform.hmcts.net'
+env.IDAM_API_URL = 'http://idam-api-idam-aat.service.core-compute-idam-aat.internal'
 env.S2S_URL = 'http://rpe-service-auth-provider-aat.service.core-compute-aat.internal'
 
 String notificationsChannel = '#cmc-tech-notification'

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -34,7 +34,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 // Vars needed for AKS testing
 env.FRONTEND_BASE_URL = 'https://moneyclaims.aat.platform.hmcts.net'
-env.IDAM_API_URL = 'https://preprod-idamapi.reform.hmcts.net:3511'
+env.IDAM_API_URL = 'https://idam-api.aat.platform.hmcts.net'
 env.S2S_URL = 'http://rpe-service-auth-provider-aat.service.core-compute-aat.internal'
 
 String notificationsChannel = '#cmc-tech-notification'

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -34,7 +34,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 // Vars needed for AKS testing
 env.FRONTEND_BASE_URL = 'https://moneyclaims.aat.platform.hmcts.net'
-env.IDAM_API_URL = 'http://idam-api-idam-aat.service.core-compute-idam-aat.internal'
+env.IDAM_API_URL = 'https://idam-api.aat.platform.hmcts.net'
 env.S2S_URL = 'http://rpe-service-auth-provider-aat.service.core-compute-aat.internal'
 
 String notificationsChannel = '#cmc-tech-notification'

--- a/charts/cmc-claim-store/values.template.yaml
+++ b/charts/cmc-claim-store/values.template.yaml
@@ -39,7 +39,7 @@ java:
   environment:
     IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-aat.service.core-compute-aat.internal
     SEND_LETTER_URL: http://rpe-send-letter-service-aat.service.core-compute-aat.internal
-    IDAM_API_URL: https://idam-api.aat.platform.hmcts.net
+    IDAM_API_URL: http://idam-api-idam-aat.service.core-compute-idam-aat.internal
     PDF_SERVICE_URL: http://cmc-pdf-service-aat.service.core-compute-aat.internal
     DOCUMENT_MANAGEMENT_URL: http://dm-store-aat.service.core-compute-aat.internal
     REFORM_TEAM: cmc

--- a/charts/cmc-claim-store/values.template.yaml
+++ b/charts/cmc-claim-store/values.template.yaml
@@ -39,7 +39,7 @@ java:
   environment:
     IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-aat.service.core-compute-aat.internal
     SEND_LETTER_URL: http://rpe-send-letter-service-aat.service.core-compute-aat.internal
-    IDAM_API_URL: http://idam-api-idam-aat.service.core-compute-idam-aat.internal
+    IDAM_API_URL: https://idam-api.aat.platform.hmcts.net
     PDF_SERVICE_URL: http://cmc-pdf-service-aat.service.core-compute-aat.internal
     DOCUMENT_MANAGEMENT_URL: http://dm-store-aat.service.core-compute-aat.internal
     REFORM_TEAM: cmc

--- a/charts/cmc-claim-store/values.template.yaml
+++ b/charts/cmc-claim-store/values.template.yaml
@@ -39,7 +39,7 @@ java:
   environment:
     IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-aat.service.core-compute-aat.internal
     SEND_LETTER_URL: http://rpe-send-letter-service-aat.service.core-compute-aat.internal
-    IDAM_API_URL: https://preprod-idamapi.reform.hmcts.net:3511
+    IDAM_API_URL: https://idam-api.aat.platform.hmcts.net
     PDF_SERVICE_URL: http://cmc-pdf-service-aat.service.core-compute-aat.internal
     DOCUMENT_MANAGEMENT_URL: http://dm-store-aat.service.core-compute-aat.internal
     REFORM_TEAM: cmc

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,4 +1,4 @@
-idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
+idam_api_url = "https://idam-api.aat.platform.hmcts.net"
 db_host = "preprod-data-lb.moneyclaim.reform.hmcts.net"
 frontend_url = "https://moneyclaims.aat.platform.hmcts.net"
 capacity = "2"

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 import uk.gov.hmcts.cmc.claimstore.idam.IdamApi;
 import uk.gov.hmcts.cmc.claimstore.idam.TacticalIdamApi;
 import uk.gov.hmcts.cmc.claimstore.idam.models.AuthenticateUserResponse;
@@ -17,6 +18,7 @@ import uk.gov.hmcts.cmc.claimstore.services.UserService;
 import uk.gov.hmcts.cmc.claimstore.tests.AATConfiguration;
 import uk.gov.hmcts.cmc.claimstore.tests.helpers.TestData;
 
+import java.nio.charset.Charset;
 import java.util.Base64;
 
 import static uk.gov.hmcts.cmc.claimstore.services.UserService.AUTHORIZATION_CODE;
@@ -97,7 +99,7 @@ public class IdamTestService {
     private void upliftUser(String email, String password, TokenExchangeResponse exchangeResponse) {
         if (strategicIdam) {
             Response response = idamInternalApi.upliftUser(
-                email,
+                UriUtils.encode(email, Charset.forName("UTF-8")),
                 password,
                 exchangeResponse.getAccessToken(),
                 oauth2.getClientId(),


### PR DESCRIPTION
### Change description ###

SIDAM doesnt allow unencoded values like: `civilmoneyclaims+mAueB1l5Gk%40gmail.com`. This fix encodes email param first.

This should be backward compatible for TIDAM.

Tested locally.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
