### PR TITLE
ROC-5477 Prepopulate fields for GenerateOrder callback

### DIFF
--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/CaseEvent.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/CaseEvent.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.cmc.ccd.domain;
 
-import uk.gov.hmcts.cmc.domain.exceptions.BadRequestException;
-
 import java.util.Arrays;
 
 public enum CaseEvent {
@@ -51,6 +49,6 @@ public enum CaseEvent {
     public static CaseEvent fromValue(String value) {
         return Arrays.stream(values()).filter(event -> event.value.equals(value))
             .findFirst()
-            .orElseThrow(() -> new BadRequestException("Unknown Case Event: " + value));
+            .orElseThrow(() -> new IllegalArgumentException("Unknown Case Event: " + value));
     }
 }

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/CaseEvent.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/CaseEvent.java
@@ -1,5 +1,9 @@
 package uk.gov.hmcts.cmc.ccd.domain;
 
+import uk.gov.hmcts.cmc.domain.exceptions.BadRequestException;
+
+import java.util.Arrays;
+
 public enum CaseEvent {
 
     CREATE_NEW_CASE("IssueClaim"),
@@ -31,7 +35,8 @@ public enum CaseEvent {
     INTERLOCUTORY_JUDGMENT("InterlocutoryJudgment"),
     REJECT_ORGANISATION_PAYMENT_PLAN("RejectOrganisationPaymentPlan"),
     REFER_TO_JUDGE_BY_CLAIMANT("ReferToJudgeByClaimant"),
-    REFER_TO_JUDGE_BY_DEFENDANT("ReferToJudgeByDefendant");
+    REFER_TO_JUDGE_BY_DEFENDANT("ReferToJudgeByDefendant"),
+    GENERATE_ORDER("GenerateOrder");
 
     private String value;
 
@@ -41,5 +46,11 @@ public enum CaseEvent {
 
     public String getValue() {
         return value;
+    }
+
+    public static CaseEvent fromValue(String value) {
+        return Arrays.stream(values()).filter(event -> event.value.equals(value))
+            .findFirst()
+            .orElseThrow(() -> new BadRequestException("Unknown Case Event: " + value));
     }
 }

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/legaladvisor/CCDOrderDirectionType.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/domain/legaladvisor/CCDOrderDirectionType.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.cmc.ccd.domain.legaladvisor;
+
+public enum CCDOrderDirectionType {
+    DOCUMENTS,
+    EYEWITNESS,
+    MEDIATION
+}

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateOrderCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateOrderCallbackTest.java
@@ -1,0 +1,79 @@
+package uk.gov.hmcts.cmc.claimstore.controllers;
+
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import uk.gov.hmcts.cmc.ccd.domain.CaseEvent;
+import uk.gov.hmcts.cmc.claimstore.MockSpringTest;
+import uk.gov.hmcts.cmc.claimstore.services.CallbackService;
+import uk.gov.hmcts.cmc.domain.exceptions.BadRequestException;
+import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.cmc.claimstore.utils.ResourceLoader.successfulCoreCaseDataStoreSubmitResponse;
+
+@TestPropertySource(
+    properties = {
+        "core_case_data.api.url=http://core-case-data-api"
+    }
+)
+public class GenerateOrderCallbackTest extends MockSpringTest {
+
+    @Test
+    public void shouldPrepopulateFields() throws Exception {
+        MvcResult mvcResult = makeRequest(CallbackService.ABOUT_TO_START_CALLBACK)
+            .andExpect(status().isOk())
+            .andReturn();
+
+        Map<String, Object> responseData = deserializeObjectFrom(
+            mvcResult,
+            AboutToStartOrSubmitCallbackResponse.class
+        ).getData();
+
+        assertThat(responseData).hasSize(3);
+        assertThat(LocalDate.parse(responseData.get("docUploadDeadline").toString()))
+            .isAfterOrEqualTo(LocalDate.now().plusDays(33));
+        assertThat(LocalDate.parse(responseData.get("eyewitnessUploadDeadline").toString()))
+            .isAfterOrEqualTo(LocalDate.now().plusDays(33));
+        assertThat(responseData).flatExtracting("directionList")
+            .containsExactlyInAnyOrder("DOCUMENTS", "EYEWITNESS", "MEDIATION");
+    }
+
+    @Test
+    public void shouldReturnErrorForUnknownCallback() throws Exception {
+        MvcResult mvcResult = makeRequest("not-a-real-callback")
+            .andExpect(status().isBadRequest())
+            .andReturn();
+        assertThat(mvcResult.getResolvedException())
+            .isInstanceOfAny(BadRequestException.class);
+    }
+
+    private ResultActions makeRequest(String callbackType) throws Exception {
+        CaseDetails caseDetailsTemp =  successfulCoreCaseDataStoreSubmitResponse();
+
+        CallbackRequest callbackRequest = CallbackRequest.builder()
+            .eventId(CaseEvent.GENERATE_ORDER.getValue())
+            .caseDetails(CaseDetails.builder()
+                .id(caseDetailsTemp.getId())
+                .data(caseDetailsTemp.getData())
+                .build())
+            .build();
+
+        return webClient
+            .perform(post("/cases/callbacks/" + callbackType)
+                .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                .content(jsonMapper.toJson(callbackRequest))
+            );
+
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateOrderCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/GenerateOrderCallbackTest.java
@@ -17,7 +17,6 @@ import java.time.LocalDate;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.cmc.claimstore.utils.ResourceLoader.successfulCoreCaseDataStoreSubmitResponse;

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/MoreTimeRequestedCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/MoreTimeRequestedCallbackTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.cmc.ccd.domain.CCDYesNoOption;
 import uk.gov.hmcts.cmc.ccd.domain.CaseEvent;
 import uk.gov.hmcts.cmc.claimstore.MockSpringTest;
 import uk.gov.hmcts.cmc.claimstore.rules.MoreTimeRequestRule;
+import uk.gov.hmcts.cmc.claimstore.services.CallbackService;
 import uk.gov.hmcts.cmc.claimstore.services.notifications.MoreTimeRequestedNotificationService;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
 import uk.gov.hmcts.cmc.domain.utils.LocalDateTimeFactory;
@@ -27,9 +28,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.cmc.claimstore.controllers.CallbackController.ABOUT_TO_START_CALLBACK;
-import static uk.gov.hmcts.cmc.claimstore.controllers.CallbackController.ABOUT_TO_SUBMIT_CALLBACK;
-import static uk.gov.hmcts.cmc.claimstore.controllers.CallbackController.SUBMITTED_CALLBACK;
 import static uk.gov.hmcts.cmc.claimstore.utils.ResourceLoader.successfulCoreCaseDataStoreSubmitResponse;
 import static uk.gov.hmcts.cmc.claimstore.utils.VerificationModeUtils.once;
 
@@ -46,7 +44,7 @@ public class MoreTimeRequestedCallbackTest extends MockSpringTest {
 
     @Test
     public void shouldReturnWithNoValidationErrorsOnAboutToStartIfAvailable() throws Exception {
-        MvcResult mvcResult = makeRequest(ABOUT_TO_START_CALLBACK, LocalDate.now().plusDays(3), false)
+        MvcResult mvcResult = makeRequest(CallbackService.ABOUT_TO_START_CALLBACK, LocalDate.now().plusDays(3), false)
             .andExpect(status().isOk())
             .andReturn();
 
@@ -60,7 +58,7 @@ public class MoreTimeRequestedCallbackTest extends MockSpringTest {
 
     @Test
     public void shouldReturnWithValidationErrorsOnAboutToStartIfAlreadyRequested() throws Exception {
-        MvcResult mvcResult = makeRequest(ABOUT_TO_START_CALLBACK, LocalDate.now().plusDays(3), true)
+        MvcResult mvcResult = makeRequest(CallbackService.ABOUT_TO_START_CALLBACK, LocalDate.now().plusDays(3), true)
             .andExpect(status().isOk())
             .andReturn();
 
@@ -76,7 +74,7 @@ public class MoreTimeRequestedCallbackTest extends MockSpringTest {
     @Test
     public void shouldReturnWithValidationErrorsOnAboutToStartIfAlreadyResponded() throws Exception {
         MvcResult mvcResult = makeRequest(
-            ABOUT_TO_START_CALLBACK,
+            CallbackService.ABOUT_TO_START_CALLBACK,
             LocalDate.now().plusDays(3),
             false,
             true
@@ -95,7 +93,7 @@ public class MoreTimeRequestedCallbackTest extends MockSpringTest {
 
     @Test
     public void shouldReturnWithValidationErrorsOnAboutToStartIfPastResponseDeadline() throws Exception {
-        MvcResult mvcResult = makeRequest(ABOUT_TO_START_CALLBACK, LocalDate.now().minusDays(1), false)
+        MvcResult mvcResult = makeRequest(CallbackService.ABOUT_TO_START_CALLBACK, LocalDate.now().minusDays(1), false)
             .andExpect(status().isOk())
             .andReturn();
 
@@ -111,7 +109,7 @@ public class MoreTimeRequestedCallbackTest extends MockSpringTest {
     @Test
     public void shouldModifyResponseDeadlineOnAboutToSubmit() throws Exception {
         LocalDate responseDeadline = LocalDate.now().plusDays(14);
-        MvcResult mvcResult = makeRequest(ABOUT_TO_SUBMIT_CALLBACK, responseDeadline, false)
+        MvcResult mvcResult = makeRequest(CallbackService.ABOUT_TO_SUBMIT_CALLBACK, responseDeadline, false)
             .andExpect(status().isOk())
             .andReturn();
 
@@ -130,7 +128,7 @@ public class MoreTimeRequestedCallbackTest extends MockSpringTest {
     @Test
     public void shouldSendNotificationOnSubmitted() throws Exception {
         LocalDate responseDeadline = LocalDate.now().plusDays(3);
-        MvcResult mvcResult = makeRequest(SUBMITTED_CALLBACK, responseDeadline, false)
+        MvcResult mvcResult = makeRequest(CallbackService.SUBMITTED_CALLBACK, responseDeadline, false)
             .andExpect(status().isOk())
             .andReturn();
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CallbackController.java
@@ -43,7 +43,7 @@ public class CallbackController {
         @PathVariable("callback-type") String callbackType,
         @NotNull @RequestBody CallbackRequest callback
     ) {
-        logger.info("Received callback from CCD, type: {}, eventId: {}", callbackType, callback.getEventId());
+        logger.info("Received callback from CCD, eventId: {}", callback.getEventId());
         return callbackService
             .getCallbackFor(callback.getEventId(), callbackType)
             .execute(claimService, callback);

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/CallbackController.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.cmc.claimstore.controllers;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,9 +11,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.hmcts.cmc.ccd.domain.CaseEvent;
+import uk.gov.hmcts.cmc.claimstore.services.CallbackService;
 import uk.gov.hmcts.cmc.claimstore.services.ClaimService;
-import uk.gov.hmcts.cmc.domain.exceptions.BadRequestException;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackResponse;
 
@@ -25,16 +26,15 @@ import javax.validation.constraints.NotNull;
     consumes = MediaType.APPLICATION_JSON_UTF8_VALUE
 )
 public class CallbackController {
-
-    public static final String ABOUT_TO_START_CALLBACK = "about-to-start";
-    public static final String ABOUT_TO_SUBMIT_CALLBACK = "about-to-submit";
-    public static final String SUBMITTED_CALLBACK = "submitted";
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final ClaimService claimService;
+    private final CallbackService callbackService;
 
     @Autowired
-    public CallbackController(ClaimService claimService) {
+    public CallbackController(ClaimService claimService, CallbackService callbackService) {
         this.claimService = claimService;
+        this.callbackService = callbackService;
     }
 
     @PostMapping(path = "/{callback-type}")
@@ -43,20 +43,9 @@ public class CallbackController {
         @PathVariable("callback-type") String callbackType,
         @NotNull @RequestBody CallbackRequest callback
     ) {
-
-        if (callback.getEventId().equals(CaseEvent.MORE_TIME_REQUESTED_PAPER.getValue())) {
-            switch (callbackType) {
-                case ABOUT_TO_START_CALLBACK:
-                    return claimService.requestMoreTimeOnPaper(callback, true);
-                case ABOUT_TO_SUBMIT_CALLBACK:
-                    return claimService.requestMoreTimeOnPaper(callback, false);
-                case SUBMITTED_CALLBACK:
-                    return claimService.requestMoreTimeOnPaperSubmitted(callback);
-                default:
-                    throw new BadRequestException("Unknown callback type: " + callbackType);
-            }
-        } else {
-            throw new BadRequestException("Unknown event: " + callback.getEventId());
-        }
+        logger.info("Received callback from CCD, type: {}, eventId: {}", callbackType, callback.getEventId());
+        return callbackService
+            .getCallbackFor(callback.getEventId(), callbackType)
+            .execute(claimService, callback);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CallbackService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CallbackService.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.cmc.claimstore.services;
+
+import com.google.common.collect.ImmutableMap;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.cmc.ccd.domain.CaseEvent;
+import uk.gov.hmcts.cmc.domain.exceptions.BadRequestException;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackResponse;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.GENERATE_ORDER;
+import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.MORE_TIME_REQUESTED_PAPER;
+
+@Service
+public class CallbackService {
+    public static final String ABOUT_TO_START_CALLBACK = "about-to-start";
+    public static final String ABOUT_TO_SUBMIT_CALLBACK = "about-to-submit";
+    public static final String SUBMITTED_CALLBACK = "submitted";
+
+    private Map<CaseEvent, Map<String, Callback>> callbacks = ImmutableMap.of(
+        MORE_TIME_REQUESTED_PAPER, ImmutableMap.of(
+            ABOUT_TO_START_CALLBACK, ClaimService::requestMoreTimeOnPaperValidateOnly,
+            ABOUT_TO_SUBMIT_CALLBACK, ClaimService::requestMoreTimeOnPaper,
+            SUBMITTED_CALLBACK, ClaimService::requestMoreTimeOnPaperSubmitted
+        ),
+        GENERATE_ORDER, ImmutableMap.of(
+            ABOUT_TO_START_CALLBACK, ClaimService::prepopulateFields
+        )
+    );
+
+    public Callback getCallbackFor(String eventId, String callbackType) {
+        CaseEvent caseEvent = CaseEvent.fromValue(eventId);
+        
+        return Optional.ofNullable(callbacks.get(caseEvent))
+            .map(callbacks -> callbacks.get(callbackType))
+            .orElseThrow(() -> new BadRequestException(
+                format("Callback for event %s, type %s not implemented", eventId, callbackType)));
+    }
+
+    public interface Callback {
+        CallbackResponse execute(ClaimService claimService, CallbackRequest callbackRequest);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CallbackService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/CallbackService.java
@@ -33,13 +33,14 @@ public class CallbackService {
 
     public Callback getCallbackFor(String eventId, String callbackType) {
         CaseEvent caseEvent = CaseEvent.fromValue(eventId);
-        
+
         return Optional.ofNullable(callbacks.get(caseEvent))
-            .map(callbacks -> callbacks.get(callbackType))
+            .map(c -> c.get(callbackType))
             .orElseThrow(() -> new BadRequestException(
                 format("Callback for event %s, type %s not implemented", eventId, callbackType)));
     }
 
+    @FunctionalInterface
     public interface Callback {
         CallbackResponse execute(ClaimService claimService, CallbackRequest callbackRequest);
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.cmc.claimstore.services;
 
 import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +60,7 @@ import static uk.gov.hmcts.cmc.domain.utils.LocalDateTimeFactory.nowInUTC;
 
 @Component
 public class ClaimService {
+    private final Logger logger = LoggerFactory.getLogger(ClaimService.class);
 
     private final ClaimRepository claimRepository;
     private final IssueDateCalculator issueDateCalculator;
@@ -278,19 +281,17 @@ public class ClaimService {
     }
 
     public AboutToStartOrSubmitCallbackResponse prepopulateFields(CallbackRequest callbackRequest) {
-        AboutToStartOrSubmitCallbackResponseBuilder builder = AboutToStartOrSubmitCallbackResponse
-            .builder();
-
+        logger.info("Prepopulating fields for callback {}", callbackRequest.getEventId());
         LocalDate deadline = legalOrderGenerationDeadlinesCalculator.calculateOrderGenerationDeadlines();
-
         Map<String, Object> data = new HashMap<>();
+        data.put("docUploadDeadline", deadline);
+        data.put("eyewitnessUploadDeadline", deadline);
         data.put("directionList", ImmutableList.of(
             CCDOrderDirectionType.DOCUMENTS.name(),
             CCDOrderDirectionType.EYEWITNESS.name(),
             CCDOrderDirectionType.MEDIATION.name()));
-        data.put("docUploadDeadline", deadline);
-        data.put("eyewitnessUploadDeadline", deadline);
-        return builder
+        return AboutToStartOrSubmitCallbackResponse
+            .builder()
             .data(data)
             .build();
     }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/LegalOrderGenerationDeadlinesCalculator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/LegalOrderGenerationDeadlinesCalculator.java
@@ -24,7 +24,8 @@ public class LegalOrderGenerationDeadlinesCalculator {
     }
 
     public LocalDate calculateOrderGenerationDeadlines() {
-        LocalDate result = LocalDate.now(clock).plusDays(DAYS_FOR_RESPONSE + DAYS_FOR_SERVICE);
+        long totalDays = (long) DAYS_FOR_RESPONSE + DAYS_FOR_SERVICE;
+        LocalDate result = LocalDate.now(clock).plusDays(totalDays);
 
         while (!workingDayIndicator.isWorkingDay(result)) {
             result = result.plusDays(1);

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/LegalOrderGenerationDeadlinesCalculator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/LegalOrderGenerationDeadlinesCalculator.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.cmc.claimstore.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+@Component
+public class LegalOrderGenerationDeadlinesCalculator {
+    private static final int DAYS_FOR_RESPONSE = 28;
+    private static final int DAYS_FOR_SERVICE = 5;
+
+    private final WorkingDayIndicator workingDayIndicator;
+
+    private final Clock clock;
+
+    @Autowired
+    public LegalOrderGenerationDeadlinesCalculator(
+        Clock clock,
+        WorkingDayIndicator workingDayIndicator) {
+        this.clock = clock;
+        this.workingDayIndicator = workingDayIndicator;
+    }
+
+    public LocalDate calculateOrderGenerationDeadlines() {
+        LocalDate result = LocalDate.now(clock).plusDays(DAYS_FOR_RESPONSE + DAYS_FOR_SERVICE);
+
+        while (!workingDayIndicator.isWorkingDay(result)) {
+            result = result.plusDays(1);
+        }
+
+        return result;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/CallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/CallbackServiceTest.java
@@ -29,7 +29,7 @@ public class CallbackServiceTest {
         assertNotNull(callback);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void shouldThrowIfUnsupportedEvent() {
         callbackService.getCallbackFor(
                 "this event does not exist",

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/CallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/CallbackServiceTest.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.cmc.claimstore.services;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.cmc.domain.exceptions.BadRequestException;
+
+import static org.junit.Assert.assertNotNull;
+import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.GENERATE_ORDER;
+import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.MORE_TIME_REQUESTED_PAPER;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CallbackServiceTest {
+
+    private CallbackService callbackService;
+
+    @Before
+    public void setUp() {
+        callbackService = new CallbackService();
+    }
+
+    @Test
+    public void shouldGetCallbackForSupportedEvent() {
+        CallbackService.Callback callback = callbackService
+            .getCallbackFor(
+                MORE_TIME_REQUESTED_PAPER.getValue(),
+                CallbackService.ABOUT_TO_START_CALLBACK);
+        assertNotNull(callback);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldThrowIfUnsupportedEvent() {
+        callbackService.getCallbackFor(
+                "this event does not exist",
+                CallbackService.ABOUT_TO_START_CALLBACK);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldThrowIfUnimplementedCallbackForValidEvent() {
+        callbackService.getCallbackFor(
+                GENERATE_ORDER.getValue(),
+                CallbackService.SUBMITTED_CALLBACK);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
@@ -98,6 +98,8 @@ public class ClaimServiceTest {
     @Mock
     private DirectionsQuestionnaireDeadlineCalculator directionsQuestionnaireDeadlineCalculator;
     @Mock
+    private LegalOrderGenerationDeadlinesCalculator legalOrderGenerationDeadlinesCalculator;
+    @Mock
     private EventProducer eventProducer;
     @Mock
     private CCDEventProducer ccdEventProducer;
@@ -116,6 +118,7 @@ public class ClaimServiceTest {
             userService,
             issueDateCalculator,
             responseDeadlineCalculator,
+            legalOrderGenerationDeadlinesCalculator,
             directionsQuestionnaireDeadlineCalculator,
             new MoreTimeRequestRule(new ClaimDeadlineService()),
             eventProducer,

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/LegalOrderGenerationDeadlinesCalculatorTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/LegalOrderGenerationDeadlinesCalculatorTest.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.cmc.claimstore.services;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.cmc.claimstore.utils.DayAssert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LegalOrderGenerationDeadlinesCalculatorTest {
+    private static final int DAYS_FOR_RESPONSE = 28;
+    private static final int DAYS_FOR_SERVICE = 5;
+    private static final LocalDate TODAY = LocalDate.of(2019, 1, 2);
+
+    private LegalOrderGenerationDeadlinesCalculator calculator;
+
+    @Mock
+    private WorkingDayIndicator workingDayIndicator;
+
+    @Mock
+    private Clock clock;
+
+    @Before
+    public void setUp() {
+        calculator = new LegalOrderGenerationDeadlinesCalculator(
+            clock,
+            workingDayIndicator);
+        when(clock.instant()).thenReturn(TODAY.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        when(clock.getZone()).thenReturn(ZoneId.systemDefault());
+    }
+
+    @Test
+    public void shouldCalculateDeadline() {
+        when(workingDayIndicator.isWorkingDay(any(LocalDate.class))).thenReturn(true);
+
+        LocalDate responseDeadline = calculator.calculateOrderGenerationDeadlines();
+        LocalDate expected = TODAY.plusDays(DAYS_FOR_RESPONSE + DAYS_FOR_SERVICE);
+
+        assertThat(responseDeadline).isWeekday().isTheSame(expected);
+    }
+
+    @Test
+    public void shouldCalculateDeadlineAsTheNextWorkingDayIfDeadlineIsOnAHoliday() {
+        when(workingDayIndicator.isWorkingDay(any(LocalDate.class))).thenReturn(false).thenReturn(true);
+        LocalDate expected = TODAY.plusDays(DAYS_FOR_RESPONSE + DAYS_FOR_SERVICE + 1);
+        LocalDate responseDeadline = calculator.calculateOrderGenerationDeadlines();
+
+        assertThat(responseDeadline).isTheSame(expected);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/LegalOrderGenerationDeadlinesCalculatorTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/LegalOrderGenerationDeadlinesCalculatorTest.java
@@ -8,7 +8,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Clock;
 import java.time.LocalDate;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -33,8 +33,8 @@ public class LegalOrderGenerationDeadlinesCalculatorTest {
         calculator = new LegalOrderGenerationDeadlinesCalculator(
             clock,
             workingDayIndicator);
-        when(clock.instant()).thenReturn(TODAY.atStartOfDay(ZoneId.systemDefault()).toInstant());
-        when(clock.getZone()).thenReturn(ZoneId.systemDefault());
+        when(clock.instant()).thenReturn(TODAY.atStartOfDay(ZoneOffset.UTC).toInstant());
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
     }
 
     @Test
@@ -49,7 +49,8 @@ public class LegalOrderGenerationDeadlinesCalculatorTest {
 
     @Test
     public void shouldCalculateDeadlineAsTheNextWorkingDayIfDeadlineIsOnAHoliday() {
-        when(workingDayIndicator.isWorkingDay(any(LocalDate.class))).thenReturn(false).thenReturn(true);
+        when(workingDayIndicator.isWorkingDay(any(LocalDate.class)))
+            .thenReturn(false, true);
         LocalDate expected = TODAY.plusDays(DAYS_FOR_RESPONSE + DAYS_FOR_SERVICE + 1);
         LocalDate responseDeadline = calculator.calculateOrderGenerationDeadlines();
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-5477


### Change description ###

Adding a about to start callback to the generate order event, to prepopulate the doc upload deadline, the eyewitness upload deadline and the direction list (all selected).

In other PRs I might move those callback-specific methods out of the ClaimService (which is doing too many things) into the CallbackService.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
