### PR TITLE
ROC-5863 Ignore free-text settlement data

### DIFF
--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/metadata/PartyStatementMetadata.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/metadata/PartyStatementMetadata.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.cmc.domain.models.metadata;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import uk.gov.hmcts.cmc.domain.models.offers.MadeBy;
+import uk.gov.hmcts.cmc.domain.models.offers.Offer;
+import uk.gov.hmcts.cmc.domain.models.offers.PartyStatement;
+import uk.gov.hmcts.cmc.domain.models.offers.StatementType;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+class PartyStatementMetadata {
+    private final StatementType type;
+    private final MadeBy madeBy;
+    private final LocalDate offerCompletionDate;
+    private final PaymentPlanMetadata offerPaymentPlan;
+
+    static PartyStatementMetadata fromPartyStatement(PartyStatement partyStatement) {
+        if (partyStatement == null) {
+            return null;
+        }
+        Optional<Offer> optionalOffer = partyStatement.getOffer();
+        return new PartyStatementMetadata(
+            partyStatement.getType(),
+            partyStatement.getMadeBy(),
+            optionalOffer
+                .map(Offer::getCompletionDate)
+                .orElse(null),
+            optionalOffer
+                .flatMap(Offer::getPaymentIntention)
+                .map(PaymentPlanMetadata::fromPaymentIntention)
+                .orElse(null)
+        );
+    }
+}

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/metadata/SettlementMetadata.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/metadata/SettlementMetadata.java
@@ -5,17 +5,17 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import uk.gov.hmcts.cmc.domain.models.Claim;
-import uk.gov.hmcts.cmc.domain.models.offers.PartyStatement;
 import uk.gov.hmcts.cmc.domain.models.offers.Settlement;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Getter
 @EqualsAndHashCode
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 class SettlementMetadata {
-    private final List<PartyStatement> partyStatements;
+    private final List<PartyStatementMetadata> partyStatements;
 
     static SettlementMetadata fromClaim(Claim claim) {
         final Optional<Settlement> optionalSettlement = claim.getSettlement();
@@ -24,7 +24,9 @@ class SettlementMetadata {
         }
         final Settlement settlement = optionalSettlement.get();
         return new SettlementMetadata(
-            settlement.getPartyStatements()
+            settlement.getPartyStatements().stream()
+                .map(PartyStatementMetadata::fromPartyStatement)
+                .collect(Collectors.toList())
         );
     }
 }


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/ROC-5863

### Change description ###
New metadata class for party statements that does not include the settlement offer content free-text

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
