### PR TITLE
ROC-5964 Defendant response PDF to show "Retired" when appropriate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG APP_INSIGHTS_AGENT_VERSION=2.3.1
-FROM hmctspublic.azurecr.io/hmcts/imported/distroless/java:8
+FROM hmctspublic.azurecr.io/base/java:openjdk-8-distroless-1.0
 
 LABEL maintainer="https://github.com/hmcts/cmc-claim-store"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG APP_INSIGHTS_AGENT_VERSION=2.3.1
-FROM hmctspublic.azurecr.io/hmcts/cnp-java-base:openjdk-8-distroless-1.0
+FROM hmctspublic.azurecr.io/hmcts/imported/distroless/java:8
 
 LABEL maintainer="https://github.com/hmcts/cmc-claim-store"
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/StatementOfMeansContentProvider.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/documents/content/StatementOfMeansContentProvider.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.cmc.domain.models.statementofmeans.OnTaxPayments;
 import uk.gov.hmcts.cmc.domain.models.statementofmeans.Residence;
 import uk.gov.hmcts.cmc.domain.models.statementofmeans.SelfEmployment;
 import uk.gov.hmcts.cmc.domain.models.statementofmeans.StatementOfMeans;
+import uk.gov.hmcts.cmc.domain.models.statementofmeans.Unemployment;
 
 import java.util.Map;
 
@@ -214,6 +215,8 @@ public class StatementOfMeansContentProvider {
                 return "Self-employed";
             } else if (employment.getEmployers().size() > 0) {
                 return "Employed";
+            } else if (employment.getUnemployment().map(Unemployment::isRetired).orElse(false)) {
+                return "Retired";
             } else {
                 return "Unemployed";
             }

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/StatementOfMeansContentProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/documents/content/StatementOfMeansContentProviderTest.java
@@ -12,7 +12,7 @@ import uk.gov.hmcts.cmc.domain.models.statementofmeans.Unemployment;
 import java.util.Map;
 
 import static java.math.BigDecimal.TEN;
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StatementOfMeansContentProviderTest {
@@ -37,12 +37,12 @@ public class StatementOfMeansContentProviderTest {
     }
 
     @Test
-    public void shouldProvideJobTypeEmployedAndSelfmployed() {
+    public void shouldProvideJobTypeEmployedAndSelfEmployed() {
         StatementOfMeansContentProvider.JobTypeContentProvider jobTypeContentProvider =
             new StatementOfMeansContentProvider.JobTypeContentProvider();
 
         Employment employment = Employment.builder()
-            .employers(asList(Employer.builder().name("CMC").jobTitle("My sweet job").build()))
+            .employers(singletonList(Employer.builder().name("CMC").jobTitle("My sweet job").build()))
             .selfEmployment(SelfEmployment.builder()
                 .jobTitle("Director")
                 .annualTurnover(TEN)
@@ -75,7 +75,7 @@ public class StatementOfMeansContentProviderTest {
         StatementOfMeansContentProvider.JobTypeContentProvider jobTypeContentProvider =
             new StatementOfMeansContentProvider.JobTypeContentProvider();
         Employment employment = Employment.builder()
-            .employers(asList(Employer.builder().name("CMC").jobTitle("My sweet job").build()))
+            .employers(singletonList(Employer.builder().name("CMC").jobTitle("My sweet job").build()))
             .build();
         String jobType = jobTypeContentProvider.createJobType(employment);
         assertThat(jobType)
@@ -83,11 +83,23 @@ public class StatementOfMeansContentProviderTest {
     }
 
     @Test
-    public void shouldProvideJobTypeUnEmployed() {
+    public void shouldProvideJobTypeRetired() {
         StatementOfMeansContentProvider.JobTypeContentProvider jobTypeContentProvider =
             new StatementOfMeansContentProvider.JobTypeContentProvider();
         Employment employment = Employment.builder()
             .unemployment(Unemployment.builder().retired(true).build())
+            .build();
+        String jobType = jobTypeContentProvider.createJobType(employment);
+        assertThat(jobType)
+            .isEqualTo("Retired");
+    }
+
+    @Test
+    public void shouldProvideJobTypeUnEmployed() {
+        StatementOfMeansContentProvider.JobTypeContentProvider jobTypeContentProvider =
+            new StatementOfMeansContentProvider.JobTypeContentProvider();
+        Employment employment = Employment.builder()
+            .unemployment(Unemployment.builder().retired(false).build())
             .build();
         String jobType = jobTypeContentProvider.createJobType(employment);
         assertThat(jobType)


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/ROC-5964

### Change description ###
Distinguish between "Retired" and other unemployed job states in the defendant response PDF.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
