### PR TITLE
Suppress CVE-2019-12814

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -144,4 +144,11 @@
         <gav regex="true">.*</gav>
         <cve>CVE-2019-3795</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+           no fix available, not affected anyway
+           ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@.*$</packageUrl>
+        <cve>CVE-2019-12814</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION

### Change description ###

Already suppressed in multiple hmcts github repos. E.g. https://github.com/hmcts/java-logging/blob/2accf8b06b47a19a8412e834e0cb56a1b5445510/config/owasp/suppressions.xml

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
