### PR TITLE
Add suppression for CVE-2019-10086

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -144,4 +144,11 @@
         <gav regex="true">.*</gav>
         <cve>CVE-2019-3795</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+			Not applicable - we don't actually use, part of Gradle Checkstyle plugin
+			]]></notes>
+        <gav regex="true">.*</gav>
+        <cve>CVE-2019-10086</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION

### Change description ###

Complains about venerability in commons-beanutils: CVE-2019-10086

We don't actually use though - report highlights: 
```
Referenced In Project/Scope:claim-store:checkstyle
```

If you remove checkstyle plugin from our build it passes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
