### PR TITLE
Suppression of CVEs

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -144,4 +144,18 @@
         <gav regex="true">.*</gav>
         <cve>CVE-2019-3795</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+			Doesn't look exploitable, will wait for new jackson databind library
+			]]></notes>
+        <gav regex="true">.*</gav>
+        <cve>CVE-2019-14540</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+			Doesn't look exploitable, will wait for new jackson databind library
+			]]></notes>
+        <gav regex="true">.*</gav>
+        <cve>CVE-2019-16335</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###
Suppress CVE-2019-14540 and CVE-2019-16335 from dependency checks as they do not seem to be exploitable and will be patched in an upcoming jackson release.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
