### PR TITLE
Remove next url from SamplePayment

### DIFF
--- a/domain-model/src/test/resources/claim-application.json
+++ b/domain-model/src/test/resources/claim-application.json
@@ -67,8 +67,7 @@
     "reference": "RC-1524-6488-1670-7520",
     "status": "success",
     "id": "PaymentId",
-    "date_created": "2019-01-01",
-    "next_url": "http://nexturl.test"
+    "date_created": "2019-01-01"
   },
   "feeAmountInPennies": 4000,
   "reason": "reason",

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SamplePayment.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SamplePayment.java
@@ -17,7 +17,6 @@ public class SamplePayment {
             .amount(new BigDecimal("40.99"))
             .dateCreated("2019-01-01")
             .id("PaymentId")
-            .nextUrl("http://nexturl.test")
             .status("success");
     }
 }

--- a/src/test/resources/claim-application.json
+++ b/src/test/resources/claim-application.json
@@ -46,7 +46,6 @@
     "amount": 40.99,
     "reference": "RC-1524-6488-1670-7520",
     "status": "success",
-    "next_url": "http://nexturl.test",
     "date_created": "2019-01-01"
   },
   "amount": {


### PR DESCRIPTION
### Change description ###

Adding next url to the payment has to yet be released in ccd, so functional tests (which seem to rely on the default builder) don't like this.


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

