### PR TITLE
ROC-6630 Map null payment status

### DIFF
--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/PaymentMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/PaymentMapper.java
@@ -57,8 +57,12 @@ public class PaymentMapper implements BuilderMapper<CCDCase, Payment, CCDCase.CC
             ccdCase.getPaymentId(),
             moneyMapper.from(ccdCase.getPaymentAmount()),
             ccdCase.getPaymentReference(),
-            ccdCase.getPaymentDateCreated() != null ? ccdCase.getPaymentDateCreated().format(ISO_DATE) : null,
-            PaymentStatus.fromValue(ccdCase.getPaymentStatus()),
+            ccdCase.getPaymentDateCreated() != null
+                ? ccdCase.getPaymentDateCreated().format(ISO_DATE)
+                : null,
+            ccdCase.getPaymentStatus() != null
+                ? PaymentStatus.fromValue(ccdCase.getPaymentStatus())
+                : null,
             ccdCase.getPaymentNextUrl());
     }
 

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/PaymentMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/PaymentMapperTest.java
@@ -112,6 +112,31 @@ public class PaymentMapperTest {
     }
 
     @Test
+    public void shouldMapPaymentFromCCDIfPaymentStatusIsNull() {
+        //given
+        CCDCase ccdCase = CCDCase.builder()
+            .paymentAmount("400000")
+            .paymentReference("RC-1524-6488-1670-7520")
+            .paymentId("PaymentId")
+            .paymentNextUrl("http://nexturl.test")
+            .paymentStatus(null)
+            .paymentDateCreated(LocalDate.of(2019, 01, 01))
+            .build();
+
+        //when
+        Payment payment = mapper.from(ccdCase);
+
+        //then
+        assertThat(LocalDate.parse(payment.getDateCreated(), ISO_DATE))
+            .isEqualTo(ccdCase.getPaymentDateCreated());
+        assertThat(payment.getId()).isEqualTo(ccdCase.getPaymentId());
+        assertMoney(payment.getAmount()).isEqualTo(ccdCase.getPaymentAmount());
+        assertThat(payment.getReference()).isEqualTo(ccdCase.getPaymentReference());
+        assertThat(payment.getStatus()).isNull();
+        assertThat(payment.getNextUrl()).isEqualTo(ccdCase.getPaymentNextUrl());
+    }
+
+    @Test
     public void shouldMapPaymentFromCCDWhenNoDateCreatedProvided() {
         //given
         CCDCase ccdCase = CCDCase.builder()

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/PaymentStatus.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/PaymentStatus.java
@@ -18,7 +18,7 @@ public enum PaymentStatus {
 
     public static PaymentStatus fromValue(String value) {
         return Arrays.stream(PaymentStatus.values())
-            .filter(val -> val.name().equalsIgnoreCase(value))
+            .filter(val -> val.status.equalsIgnoreCase(value))
             .findFirst()
             .orElseThrow(IllegalArgumentException::new);
     }

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/PaymentStatusTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/PaymentStatusTest.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.cmc.domain.models;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PaymentStatusTest {
+
+    @Test
+    public void shouldMapToPaymentStatusFromString() {
+        assertThat(PaymentStatus.fromValue("Initiated")).isEqualTo(PaymentStatus.INITIATED);
+        assertThat(PaymentStatus.fromValue("initiated")).isEqualTo(PaymentStatus.INITIATED);
+        assertThat(PaymentStatus.fromValue("Success")).isEqualTo(PaymentStatus.SUCCESS);
+        assertThat(PaymentStatus.fromValue("Failed")).isEqualTo(PaymentStatus.FAILED);
+        assertThat(PaymentStatus.fromValue("failed")).isEqualTo(PaymentStatus.FAILED);
+        assertThat(PaymentStatus.fromValue("Pending")).isEqualTo(PaymentStatus.PENDING);
+        assertThat(PaymentStatus.fromValue("pending")).isEqualTo(PaymentStatus.PENDING);
+        assertThat(PaymentStatus.fromValue("Declined")).isEqualTo(PaymentStatus.DECLINED);
+        assertThat(PaymentStatus.fromValue("declined")).isEqualTo(PaymentStatus.DECLINED);
+    }
+
+}


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-6630

### Change description ###
We have some nulls in payments in the ccd database which are not correctly handled in the payment mapper, after introducing the payment status enum.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
