### PR TITLE
ROC-6005 Encode pretty apostrophes as `&#8217;`

### DIFF
--- a/src/main/resources/citizen/templates/document/claimIssueReceipt.html
+++ b/src/main/resources/citizen/templates/document/claimIssueReceipt.html
@@ -170,7 +170,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Claimant&#146;s details</strong>
+    <strong>Claimant&#8217;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -273,7 +273,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Defendant&#146;s details</strong>
+    <strong>Defendant&#8217;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -565,7 +565,7 @@
   </div>
 </div>
 
-<p>If you don&#146;t respond before <strong>4pm, {{ responseDeadline }}</strong>, you could get a County Court Judgment (CCJ) made against you.</p>
+<p>If you don&#8217;t respond before <strong>4pm, {{ responseDeadline }}</strong>, you could get a County Court Judgment (CCJ) made against you.</p>
 
 </body>
 </html>

--- a/src/main/resources/citizen/templates/document/claimIssueReceipt.html
+++ b/src/main/resources/citizen/templates/document/claimIssueReceipt.html
@@ -170,7 +170,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Claimant’s details</strong>
+    <strong>Claimant&#146;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -273,7 +273,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Defendant’s details</strong>
+    <strong>Defendant&#146;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -565,7 +565,7 @@
   </div>
 </div>
 
-<p>If you don’t respond before <strong>4pm, {{ responseDeadline }}</strong>, you could get a County Court Judgment (CCJ) made against you.</p>
+<p>If you don&#146;t respond before <strong>4pm, {{ responseDeadline }}</strong>, you could get a County Court Judgment (CCJ) made against you.</p>
 
 </body>
 </html>

--- a/src/main/resources/citizen/templates/document/claimantResponseReceipt.html
+++ b/src/main/resources/citizen/templates/document/claimantResponseReceipt.html
@@ -146,7 +146,7 @@
 <header>
   <table>
     <tr>
-      <td colspan="2" class="spacing-bottom"><h2 class="normal-font">Claimant&#146;s response</h2></td>
+      <td colspan="2" class="spacing-bottom"><h2 class="normal-font">Claimant&#8217;s response</h2></td>
     </tr>
     <tr>
       <td colspan="2"><p>In the County Court Business Centre</p></td>
@@ -177,13 +177,13 @@
   <div class="section-body">
     <table>
       <tr>
-        <td>Do you accept or reject the defendant&#146;s admission?</td>
+        <td>Do you accept or reject the defendant&#8217;s admission?</td>
         <td>
           {{ defendantAdmissionAccepted }}
         </td>
       </tr>
       <tr>
-        <td><strong>Do you accept the defendant&#146;s repayment plan?</strong></td>
+        <td><strong>Do you accept the defendant&#8217;s repayment plan?</strong></td>
         <td>
           {{ paymentPlanAccepted }}
         </td>

--- a/src/main/resources/citizen/templates/document/claimantResponseReceipt.html
+++ b/src/main/resources/citizen/templates/document/claimantResponseReceipt.html
@@ -146,7 +146,7 @@
 <header>
   <table>
     <tr>
-      <td colspan="2" class="spacing-bottom"><h2 class="normal-font">Claimant’s response</h2></td>
+      <td colspan="2" class="spacing-bottom"><h2 class="normal-font">Claimant&#146;s response</h2></td>
     </tr>
     <tr>
       <td colspan="2"><p>In the County Court Business Centre</p></td>
@@ -177,13 +177,13 @@
   <div class="section-body">
     <table>
       <tr>
-        <td>Do you accept or reject the defendant’s admission?</td>
+        <td>Do you accept or reject the defendant&#146;s admission?</td>
         <td>
           {{ defendantAdmissionAccepted }}
         </td>
       </tr>
       <tr>
-        <td><strong>Do you accept the defendant’s repayment plan?</strong></td>
+        <td><strong>Do you accept the defendant&#146;s repayment plan?</strong></td>
         <td>
           {{ paymentPlanAccepted }}
         </td>

--- a/src/main/resources/citizen/templates/document/defendantResponseReceipt.html
+++ b/src/main/resources/citizen/templates/document/defendantResponseReceipt.html
@@ -224,7 +224,7 @@
 <header>
   <table>
     <tr>
-      <td colspan="2" class="spacing-bottom"><h2 class="normal-font">Defendant&#146;s response</h2></td>
+      <td colspan="2" class="spacing-bottom"><h2 class="normal-font">Defendant&#8217;s response</h2></td>
     </tr>
     <tr>
       <td colspan="2"><p>In the County Court Business Centre</p></td>
@@ -249,7 +249,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Defendant&#146;s details</strong>
+    <strong>Defendant&#8217;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -345,12 +345,12 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Defendant&#146;s response to the claim</strong>
+    <strong>Defendant&#8217;s response to the claim</strong>
   </div>
   <div class="section-body">
     <table>
       <tr>
-        <td>Defendant&#146;s response</td>
+        <td>Defendant&#8217;s response</td>
         <td>
           {{ responseTypeSelected }}
         </td>
@@ -425,7 +425,7 @@
 
       {% if events is defined and events is not empty %}
       <tr>
-        <td colspan="2" style="white-space: pre-line"><strong>Defendant&#146;s timeline of what happened</strong></td>
+        <td colspan="2" style="white-space: pre-line"><strong>Defendant&#8217;s timeline of what happened</strong></td>
       </tr>
       {% for event in events %}
       <tr class="subsection no-border">
@@ -441,7 +441,7 @@
 
       {% if timelineComment is defined and timelineComment is not empty %}
       <tr class="no-border">
-        <td><strong>Comments about claimant&#146;s timeline</strong></td>
+        <td><strong>Comments about claimant&#8217;s timeline</strong></td>
         <td>
           {{ timelineComment }}
         </td>
@@ -450,7 +450,7 @@
 
       {% if evidences is defined and evidences is not empty %}
       <tr>
-        <td colspan="2" style="white-space: pre-line"><strong>Defendant&#146;s evidence</strong></td>
+        <td colspan="2" style="white-space: pre-line"><strong>Defendant&#8217;s evidence</strong></td>
       </tr>
       {% for row in evidences %}
       <tr class="subsection no-border">
@@ -466,7 +466,7 @@
 
       {% if evidenceComment is defined and evidenceComment is not empty %}
       <tr class="no-border">
-        <td><strong>Comments about claimant&#146;s evidence</strong></td>
+        <td><strong>Comments about claimant&#8217;s evidence</strong></td>
         <td>
           {{ evidenceComment }}
         </td>
@@ -518,7 +518,7 @@
 
       {% if statementOfMeans is defined %}
       <tr class="no-border">
-        <td><strong>Reason they can&#146;t pay the full amount immediately</strong></td>
+        <td><strong>Reason they can&#8217;t pay the full amount immediately</strong></td>
         <td>
           {{ statementOfMeans.reason }}
         </td>
@@ -531,7 +531,7 @@
 {% if statementOfMeans is defined  and (paymentOption == 'By instalments' or paymentOption == 'By a set date') %}
 <div class="section">
   <div class="section-heading">
-    <strong>The defendant&#146;s financial details</strong>
+    <strong>The defendant&#8217;s financial details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -863,7 +863,7 @@
     <tr>
       <td><strong>Settle the claim</strong></td>
       <td><p>
-        Unless you&#146;ve been asked not to, you can still contact defendant directly.
+        Unless you&#8217;ve been asked not to, you can still contact defendant directly.
         If you can reach an agreement you may not have to go to a hearing.
       </p></td>
     </tr>
@@ -872,7 +872,7 @@
       <td>
         <p>If the defendant has asked for mediation then the claimant will be asked if they want to mediate.</p>
         <p>
-          If the defendant hasn&#146;t asked for mediation then the case will be reviewed by a judge and might go to a
+          If the defendant hasn&#8217;t asked for mediation then the case will be reviewed by a judge and might go to a
           hearing. The claimant and defendant will be contacted if a hearing date is scheduled and it will be explained
           what they need to do to prepare.
         </p>

--- a/src/main/resources/citizen/templates/document/defendantResponseReceipt.html
+++ b/src/main/resources/citizen/templates/document/defendantResponseReceipt.html
@@ -224,7 +224,7 @@
 <header>
   <table>
     <tr>
-      <td colspan="2" class="spacing-bottom"><h2 class="normal-font">Defendant’s response</h2></td>
+      <td colspan="2" class="spacing-bottom"><h2 class="normal-font">Defendant&#146;s response</h2></td>
     </tr>
     <tr>
       <td colspan="2"><p>In the County Court Business Centre</p></td>
@@ -249,7 +249,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Defendant’s details</strong>
+    <strong>Defendant&#146;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -345,12 +345,12 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Defendant’s response to the claim</strong>
+    <strong>Defendant&#146;s response to the claim</strong>
   </div>
   <div class="section-body">
     <table>
       <tr>
-        <td>Defendant’s response</td>
+        <td>Defendant&#146;s response</td>
         <td>
           {{ responseTypeSelected }}
         </td>
@@ -425,7 +425,7 @@
 
       {% if events is defined and events is not empty %}
       <tr>
-        <td colspan="2" style="white-space: pre-line"><strong>Defendant’s timeline of what happened</strong></td>
+        <td colspan="2" style="white-space: pre-line"><strong>Defendant&#146;s timeline of what happened</strong></td>
       </tr>
       {% for event in events %}
       <tr class="subsection no-border">
@@ -441,7 +441,7 @@
 
       {% if timelineComment is defined and timelineComment is not empty %}
       <tr class="no-border">
-        <td><strong>Comments about claimant’s timeline</strong></td>
+        <td><strong>Comments about claimant&#146;s timeline</strong></td>
         <td>
           {{ timelineComment }}
         </td>
@@ -450,7 +450,7 @@
 
       {% if evidences is defined and evidences is not empty %}
       <tr>
-        <td colspan="2" style="white-space: pre-line"><strong>Defendant’s evidence</strong></td>
+        <td colspan="2" style="white-space: pre-line"><strong>Defendant&#146;s evidence</strong></td>
       </tr>
       {% for row in evidences %}
       <tr class="subsection no-border">
@@ -466,7 +466,7 @@
 
       {% if evidenceComment is defined and evidenceComment is not empty %}
       <tr class="no-border">
-        <td><strong>Comments about claimant’s evidence</strong></td>
+        <td><strong>Comments about claimant&#146;s evidence</strong></td>
         <td>
           {{ evidenceComment }}
         </td>
@@ -518,7 +518,7 @@
 
       {% if statementOfMeans is defined %}
       <tr class="no-border">
-        <td><strong>Reason they can’t pay the full amount immediately</strong></td>
+        <td><strong>Reason they can&#146;t pay the full amount immediately</strong></td>
         <td>
           {{ statementOfMeans.reason }}
         </td>
@@ -531,7 +531,7 @@
 {% if statementOfMeans is defined  and (paymentOption == 'By instalments' or paymentOption == 'By a set date') %}
 <div class="section">
   <div class="section-heading">
-    <strong>The defendant’s financial details</strong>
+    <strong>The defendant&#146;s financial details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -863,7 +863,7 @@
     <tr>
       <td><strong>Settle the claim</strong></td>
       <td><p>
-        Unless you’ve been asked not to, you can still contact defendant directly.
+        Unless you&#146;ve been asked not to, you can still contact defendant directly.
         If you can reach an agreement you may not have to go to a hearing.
       </p></td>
     </tr>
@@ -872,7 +872,7 @@
       <td>
         <p>If the defendant has asked for mediation then the claimant will be asked if they want to mediate.</p>
         <p>
-          If the defendant hasn’t asked for mediation then the case will be reviewed by a judge and might go to a
+          If the defendant hasn&#146;t asked for mediation then the case will be reviewed by a judge and might go to a
           hearing. The claimant and defendant will be contacted if a hearing date is scheduled and it will be explained
           what they need to do to prepare.
         </p>

--- a/src/main/resources/staff/templates/document/defendantPinLetter.html
+++ b/src/main/resources/staff/templates/document/defendantPinLetter.html
@@ -89,7 +89,7 @@
       <strong>Respond to this claim</strong>
     </p>
 
-    <p class="no-spacing">The Civil Money Claims service is run by Her Majesty&#146;s Courts &amp; Tribunal Service (HMCTS):</p>
+    <p class="no-spacing">The Civil Money Claims service is run by Her Majesty&#8217;s Courts &amp; Tribunal Service (HMCTS):</p>
 
     <ol style="margin-top: 6px">
       <li>Go to {{ respondToClaimUrl }}</li>

--- a/src/main/resources/staff/templates/document/defendantPinLetter.html
+++ b/src/main/resources/staff/templates/document/defendantPinLetter.html
@@ -89,7 +89,7 @@
       <strong>Respond to this claim</strong>
     </p>
 
-    <p class="no-spacing">The Civil Money Claims service is run by Her Majesty’s Courts &amp; Tribunal Service (HMCTS):</p>
+    <p class="no-spacing">The Civil Money Claims service is run by Her Majesty&#146;s Courts &amp; Tribunal Service (HMCTS):</p>
 
     <ol style="margin-top: 6px">
       <li>Go to {{ respondToClaimUrl }}</li>

--- a/src/main/resources/staff/templates/document/legalOrderCoverSheet.html
+++ b/src/main/resources/staff/templates/document/legalOrderCoverSheet.html
@@ -81,10 +81,10 @@
       Dear {{ partyFullName }},
     </p>
     <p class="spacing">
-      We&#146;ve attached a court order to this letter which tells you the actions you must take before the hearing, for claim number {{ claimReferenceNumber }}.
+      We&#8217;ve attached a court order to this letter which tells you the actions you must take before the hearing, for claim number {{ claimReferenceNumber }}.
     </p>
     <p class="spacing">
-      You must read the order and do what it tells you by the deadline. If you don&#146;t, your claim or defence will be cancelled.
+      You must read the order and do what it tells you by the deadline. If you don&#8217;t, your claim or defence will be cancelled.
     </p>
   </section>
   <section>

--- a/src/main/resources/staff/templates/document/legalOrderCoverSheet.html
+++ b/src/main/resources/staff/templates/document/legalOrderCoverSheet.html
@@ -81,10 +81,10 @@
       Dear {{ partyFullName }},
     </p>
     <p class="spacing">
-      We’ve attached a court order to this letter which tells you the actions you must take before the hearing, for claim number {{ claimReferenceNumber }}.
+      We&#146;ve attached a court order to this letter which tells you the actions you must take before the hearing, for claim number {{ claimReferenceNumber }}.
     </p>
     <p class="spacing">
-      You must read the order and do what it tells you by the deadline. If you don’t, your claim or defence will be cancelled.
+      You must read the order and do what it tells you by the deadline. If you don&#146;t, your claim or defence will be cancelled.
     </p>
   </section>
   <section>

--- a/src/main/resources/staff/templates/document/legalSealedClaim.html
+++ b/src/main/resources/staff/templates/document/legalSealedClaim.html
@@ -398,7 +398,7 @@
     </tr>
     <tr>
       <td class="border-bottom">
-        Legal representative’s costs
+        Legal representative&#146;s costs
       </td>
       <td align="right" class="border-bottom">
         To be assessed

--- a/src/main/resources/staff/templates/document/legalSealedClaim.html
+++ b/src/main/resources/staff/templates/document/legalSealedClaim.html
@@ -398,7 +398,7 @@
     </tr>
     <tr>
       <td class="border-bottom">
-        Legal representative&#146;s costs
+        Legal representative&#8217;s costs
       </td>
       <td align="right" class="border-bottom">
         To be assessed

--- a/src/main/resources/staff/templates/document/sealedClaim.html
+++ b/src/main/resources/staff/templates/document/sealedClaim.html
@@ -176,7 +176,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Claimant’s details</strong>
+    <strong>Claimant&#146;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -277,7 +277,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Defendant’s details</strong>
+    <strong>Defendant&#146;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -588,7 +588,7 @@
   </div>
 </div>
 
-<p>If you don’t respond before <strong>4pm, {{ responseDeadline }}</strong>, you could get a County Court Judgment (CCJ) made against you.</p>
+<p>If you don&#146;t respond before <strong>4pm, {{ responseDeadline }}</strong>, you could get a County Court Judgment (CCJ) made against you.</p>
 
 </body>
 </html>

--- a/src/main/resources/staff/templates/document/sealedClaim.html
+++ b/src/main/resources/staff/templates/document/sealedClaim.html
@@ -176,7 +176,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Claimant&#146;s details</strong>
+    <strong>Claimant&#8217;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -277,7 +277,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Defendant&#146;s details</strong>
+    <strong>Defendant&#8217;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -588,7 +588,7 @@
   </div>
 </div>
 
-<p>If you don&#146;t respond before <strong>4pm, {{ responseDeadline }}</strong>, you could get a County Court Judgment (CCJ) made against you.</p>
+<p>If you don&#8217;t respond before <strong>4pm, {{ responseDeadline }}</strong>, you could get a County Court Judgment (CCJ) made against you.</p>
 
 </body>
 </html>

--- a/src/main/resources/staff/templates/document/settlementAgreement.html
+++ b/src/main/resources/staff/templates/document/settlementAgreement.html
@@ -140,7 +140,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Claimant’s details</strong>
+    <strong>Claimant&#146;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -194,7 +194,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Defendant’s details</strong>
+    <strong>Defendant&#146;s details</strong>
   </div>
   <div class="section-body">
     <table>

--- a/src/main/resources/staff/templates/document/settlementAgreement.html
+++ b/src/main/resources/staff/templates/document/settlementAgreement.html
@@ -140,7 +140,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Claimant&#146;s details</strong>
+    <strong>Claimant&#8217;s details</strong>
   </div>
   <div class="section-body">
     <table>
@@ -194,7 +194,7 @@
 
 <div class="section">
   <div class="section-heading">
-    <strong>Defendant&#146;s details</strong>
+    <strong>Defendant&#8217;s details</strong>
   </div>
   <div class="section-body">
     <table>

--- a/web.config
+++ b/web.config
@@ -7,7 +7,7 @@
     <httpPlatform stdoutLogEnabled="true"
                   stdoutLogFile="%HOME%\LogFiles\stdout"
                   processPath="%JAVA_HOME%\bin\java.exe"
-        arguments="-javaagent:&quot;%HOME%\site\wwwroot\applicationinsights-agent-2.3.1.jar&quot; -Djava.net.preferIPv4Stack=true -Dserver.port=%HTTP_PLATFORM_PORT% -jar &quot;%HOME%\site\wwwroot\claim-store.jar&quot;">
+        arguments="-javaagent:&quot;%HOME%\site\wwwroot\applicationinsights-agent-2.3.1.jar&quot; -Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true -Dserver.port=%HTTP_PLATFORM_PORT% -jar &quot;%HOME%\site\wwwroot\claim-store.jar&quot;">
     </httpPlatform>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-6005

### Change description ###
Encode right single quotes we're using for apostrophe's in html templates

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
