### PR TITLE
Suppress CVE-2019-16942 and CVE-2019-16943 vulnerability errors.

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -165,4 +165,18 @@
         <gav regex="true">.*</gav>
         <cve>CVE-2019-16869</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+			Doesn't look exploitable, will wait for new jackson databind library
+			]]></notes>
+        <gav regex="true">.*</gav>
+        <cve>CVE-2019-16942</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+			Doesn't look exploitable, will wait for new jackson databind library
+			]]></notes>
+        <gav regex="true">.*</gav>
+        <cve>CVE-2019-16943</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###
List the CVEs as suppressed due to not being exploitable in our service.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
