### PR TITLE
ROC-6699 Update support controller for DM uploads

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportController.java
@@ -162,6 +162,7 @@ public class SupportController {
         @ApiResponse(code = 404, message = "Claim not found"),
         @ApiResponse(code = 500, message = "Unable to upload document")
     })
+    @SuppressWarnings("squid:S2201") // orElseThrow does not ignore the result
     public ResponseEntity<?> uploadDocumentToDocumentManagement(
         @PathVariable("referenceNumber") String referenceNumber,
         @PathVariable("documentType") ClaimDocumentType documentType

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportController.java
@@ -1,11 +1,15 @@
 package uk.gov.hmcts.cmc.claimstore.controllers.support;
 
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -13,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ServerErrorException;
 import uk.gov.hmcts.cmc.claimstore.events.ccj.CCJStaffNotificationHandler;
 import uk.gov.hmcts.cmc.claimstore.events.ccj.CountyCourtJudgmentEvent;
 import uk.gov.hmcts.cmc.claimstore.events.claim.CitizenClaimCreatedEvent;
@@ -149,24 +154,38 @@ public class SupportController {
         }
     }
 
-    @PutMapping("/claim/{referenceNumber}/claimDocumentType/{claimDocumentType}/uploadDocumentToDocumentManagement")
-    @ApiOperation("Upload document to document Management")
-    public void uploadDocumentToDocumentManagement(
+    @PutMapping("/documents/{referenceNumber}/{documentType}")
+    @ApiOperation("Ensure a document is available on CCD")
+    @ApiResponses({
+        @ApiResponse(code = 200, message = "OK"),
+        @ApiResponse(code = 201, message = "Created"),
+        @ApiResponse(code = 404, message = "Claim not found"),
+        @ApiResponse(code = 500, message = "Unable to upload document")
+    })
+    public ResponseEntity<?> uploadDocumentToDocumentManagement(
         @PathVariable("referenceNumber") String referenceNumber,
-        @PathVariable("claimDocumentType") ClaimDocumentType claimDocumentType,
-        @RequestHeader(value = HttpHeaders.AUTHORIZATION) String authorisation
+        @PathVariable("documentType") ClaimDocumentType documentType
     ) {
+        User caseworker = userService.authenticateAnonymousCaseWorker();
 
         Claim claim = claimService.getClaimByReferenceAnonymous(referenceNumber)
             .orElseThrow(() -> new NotFoundException(String.format(CLAIM_DOES_NOT_EXIST, referenceNumber)));
-        if (StringUtils.isBlank(authorisation)) {
-            throw new BadRequestException(AUTHORISATION_IS_REQUIRED);
+
+        if (claim.getClaimDocument(documentType).isPresent()) {
+            return new ResponseEntity<>(HttpStatus.OK);
         }
-        documentsService.generateDocument(claim.getExternalId(), claimDocumentType, authorisation);
+
+        documentsService.generateDocument(claim.getExternalId(), documentType, caseworker.getAuthorisation());
 
         claimService.getClaimByReferenceAnonymous(referenceNumber)
-            .ifPresent(updatedClaim -> updatedClaim.getClaimDocument(claimDocumentType)
-                .orElseThrow(() -> new NotFoundException("Unable to upload the document. Please try again later")));
+            .orElseThrow(IllegalStateException::new)
+            .getClaimDocument(documentType)
+            .orElseThrow(() -> new ServerErrorException(
+                "Unable to upload the document. Please try again later",
+                new NotFoundException("Unable to upload the document. Please try again later")
+            ));
+
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @PutMapping("/claim/{referenceNumber}/reset-operation")


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/ROC-6699

### Change description ###
Update support endpoint for uploading documents to DM to:
* allow anonymous invocation (use anonymous caseworker)
* report different statuses according to if anything was actually done
200 = the document was already there
201 = a new document was generated and uploaded
4xx for errors according to the relevant service

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
