### PR TITLE
ROC-6725 Update metadata structure to support multi-party (for LR)

### DIFF
--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/metadata/CaseMetadata.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/metadata/CaseMetadata.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.cmc.domain.models.ClaimDocument;
 import uk.gov.hmcts.cmc.domain.models.ClaimState;
 import uk.gov.hmcts.cmc.domain.models.ClaimSubmissionOperationIndicators;
 import uk.gov.hmcts.cmc.domain.models.Payment;
+import uk.gov.hmcts.cmc.domain.models.otherparty.TheirDetails;
+import uk.gov.hmcts.cmc.domain.models.party.Party;
 
 import java.net.URI;
 import java.time.LocalDate;
@@ -18,6 +20,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.cmc.domain.models.ClaimDocumentType.SEALED_CLAIM;
 import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
@@ -35,9 +38,9 @@ public class CaseMetadata {
     private final List<String> features;
     private final URI sealedClaimDocument;
     private final String submitterId;
-    private final String submitterPartyType;
+    private final List<String> submitterPartyTypes;
     private final String defendantId;
-    private final String defendantPartyType;
+    private final List<String> defendantPartyTypes;
     private final LocalDate responseDeadline;
     private final Boolean moreTimeRequested;
     private final DefendantResponseMetadata defendantResponse;
@@ -66,9 +69,13 @@ public class CaseMetadata {
                 .map(ClaimDocument::getDocumentManagementUrl)
                 .orElse(null))
             .submitterId(claim.getSubmitterId())
-            .submitterPartyType(claim.getClaimData().getClaimant().getClass().getSimpleName())
+            .submitterPartyTypes(claim.getClaimData().getClaimants().stream()
+                .map(Party::getClass).map(Class::getSimpleName)
+                .collect(toList()))
             .defendantId(claim.getDefendantId())
-            .defendantPartyType(claim.getClaimData().getDefendant().getClass().getSimpleName())
+            .defendantPartyTypes(claim.getClaimData().getDefendants().stream()
+                .map(TheirDetails::getClass).map(Class::getSimpleName)
+                .collect(toList()))
             .responseDeadline(claim.getResponseDeadline())
             .moreTimeRequested(claim.isMoreTimeRequested())
             .defendantResponse(DefendantResponseMetadata.fromClaim(claim))

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/CaseMetadataControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/CaseMetadataControllerTest.java
@@ -181,9 +181,13 @@ public class CaseMetadataControllerTest {
     private static void assertValid(Claim dto, CaseMetadata metadata) {
         assertEquals(dto.getId(), metadata.getId());
         assertEquals(dto.getSubmitterId(), metadata.getSubmitterId());
-        assertEquals(dto.getClaimData().getClaimant().getClass().getSimpleName(), metadata.getSubmitterPartyType());
+        assertEquals(
+            dto.getClaimData().getClaimant().getClass().getSimpleName(),
+            metadata.getSubmitterPartyTypes().get(0));
         assertEquals(dto.getDefendantId(), metadata.getDefendantId());
-        assertEquals(dto.getClaimData().getDefendant().getClass().getSimpleName(), metadata.getDefendantPartyType());
+        assertEquals(
+            dto.getClaimData().getDefendant().getClass().getSimpleName(),
+            metadata.getDefendantPartyTypes().get(0));
         assertEquals(dto.getExternalId(), metadata.getExternalId());
         assertEquals(dto.getReferenceNumber(), metadata.getReferenceNumber());
         assertEquals(dto.getCreatedAt(), metadata.getCreatedAt());


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/ROC-6725

### Change description ###
Case Metadata structure assumed 1 claimant and 1 defendant, but legal-rep claims can already have multiples of either and both. This PR modifies the class to support multiple claimants and multiple defendants.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
