### PR TITLE
ROC-6127 Serialise claim state and remove submitter id from ioc endpoints

### DIFF
--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapper.java
@@ -65,9 +65,6 @@ public class CaseMapper {
             .submitterId(claim.getSubmitterId())
             .submitterEmail(claim.getSubmitterEmail())
             .issuedOn(claim.getIssuedOn())
-            .state(claim.getState()
-                .map(ClaimState::getValue)
-                .orElse(null))
             .currentInterestAmount(
                 claim.getTotalInterestTillDateOfIssue()
                     .map(interest -> String.valueOf(MonetaryConversions.poundsToPennies(interest)))

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapper.java
@@ -65,6 +65,9 @@ public class CaseMapper {
             .submitterId(claim.getSubmitterId())
             .submitterEmail(claim.getSubmitterEmail())
             .issuedOn(claim.getIssuedOn())
+            .state(claim.getState()
+                .map(ClaimState::getValue)
+                .orElse(null))
             .currentInterestAmount(
                 claim.getTotalInterestTillDateOfIssue()
                     .map(interest -> String.valueOf(MonetaryConversions.poundsToPennies(interest)))

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/ClaimMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/ClaimMapper.java
@@ -5,6 +5,7 @@ import uk.gov.hmcts.cmc.ccd.domain.CCDCase;
 import uk.gov.hmcts.cmc.ccd.mapper.defendant.DefendantMapper;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.ClaimData;
+import uk.gov.hmcts.cmc.domain.models.ClaimState;
 import uk.gov.hmcts.cmc.domain.models.otherparty.TheirDetails;
 import uk.gov.hmcts.cmc.domain.models.party.Party;
 
@@ -96,7 +97,7 @@ public class ClaimMapper {
         paymentMapper.to(claimData.getPayment(), builder);
         interestMapper.to(claimData.getInterest(), builder);
         amountMapper.to(claimData.getAmount(), builder);
-
+        claim.getState().map(state -> builder.state(state.getValue()));
         claim.getTotalAmountTillDateOfIssue().map(moneyMapper::to).ifPresent(builder::totalAmount);
         builder
             .reason(claimData.getReason())
@@ -114,6 +115,7 @@ public class ClaimMapper {
             .map(claimantMapper::from)
             .collect(Collectors.toList());
 
+        claimBuilder.state(ClaimState.fromValue(ccdCase.getState()));
         claimBuilder.claimData(
             new ClaimData(
                 UUID.fromString(ccdCase.getExternalId()),

--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/ClaimMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/ClaimMapper.java
@@ -5,7 +5,6 @@ import uk.gov.hmcts.cmc.ccd.domain.CCDCase;
 import uk.gov.hmcts.cmc.ccd.mapper.defendant.DefendantMapper;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 import uk.gov.hmcts.cmc.domain.models.ClaimData;
-import uk.gov.hmcts.cmc.domain.models.ClaimState;
 import uk.gov.hmcts.cmc.domain.models.otherparty.TheirDetails;
 import uk.gov.hmcts.cmc.domain.models.party.Party;
 
@@ -97,7 +96,6 @@ public class ClaimMapper {
         paymentMapper.to(claimData.getPayment(), builder);
         interestMapper.to(claimData.getInterest(), builder);
         amountMapper.to(claimData.getAmount(), builder);
-        claim.getState().map(state -> builder.state(state.getValue()));
         claim.getTotalAmountTillDateOfIssue().map(moneyMapper::to).ifPresent(builder::totalAmount);
         builder
             .reason(claimData.getReason())
@@ -115,7 +113,6 @@ public class ClaimMapper {
             .map(claimantMapper::from)
             .collect(Collectors.toList());
 
-        claimBuilder.state(ClaimState.fromValue(ccdCase.getState()));
         claimBuilder.claimData(
             new ClaimData(
                 UUID.fromString(ccdCase.getExternalId()),

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/assertion/ClaimAssert.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/assertion/ClaimAssert.java
@@ -69,14 +69,10 @@ public class ClaimAssert extends AbstractAssert<ClaimAssert, Claim> {
             }
         });
 
-        actual.getState().ifPresent(claimState -> {
-            if (ccdCase.getState() != null) {
-                if (!Objects.equals(claimState.getValue(), ccdCase.getState())) {
-                    failWithMessage("Expected CCDCase.state to be <%s> but was <%s>",
-                        ccdCase.getState(), claimState.getValue());
-                }
-            }
-        });
+        if (actual.getState() != null && !Objects.equals(actual.getState().getValue(), ccdCase.getState())) {
+            failWithMessage("Expected CCDCase.state to be <%s> but was <%s>",
+                ccdCase.getState(), actual.getState());
+        }
 
         actual.getTotalInterestTillDateOfIssue().ifPresent(currentInterestAmount -> {
             if (ccdCase.getCurrentInterestAmount() != null) {

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/assertion/ClaimAssert.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/assertion/ClaimAssert.java
@@ -69,6 +69,15 @@ public class ClaimAssert extends AbstractAssert<ClaimAssert, Claim> {
             }
         });
 
+        actual.getState().ifPresent(claimState -> {
+            if (ccdCase.getState() != null) {
+                if (!Objects.equals(claimState.getValue(), ccdCase.getState())) {
+                    failWithMessage("Expected CCDCase.state to be <%s> but was <%s>",
+                        ccdCase.getState(), claimState.getValue());
+                }
+            }
+        });
+
         actual.getTotalInterestTillDateOfIssue().ifPresent(currentInterestAmount -> {
             if (ccdCase.getCurrentInterestAmount() != null) {
                 assertMoney(currentInterestAmount)

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapperTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.cmc.ccd.domain.CCDDirectionOrder;
 import uk.gov.hmcts.cmc.ccd.sample.data.SampleData;
 import uk.gov.hmcts.cmc.ccd.util.MapperUtil;
 import uk.gov.hmcts.cmc.domain.models.Claim;
+import uk.gov.hmcts.cmc.domain.models.ClaimState;
 import uk.gov.hmcts.cmc.domain.models.response.YesNoOption;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
 
@@ -38,7 +39,8 @@ public class CaseMapperTest {
     @Test
     public void shouldMapLegalClaimToCCD() {
         //given
-        Claim claim = SampleClaim.getLegalDataWithReps();
+        Claim claim = SampleClaim.getLegalDataWithReps()
+            .toBuilder().state(null).build();
 
         //when
         CCDCase ccdCase = ccdCaseMapper.to(claim);
@@ -53,7 +55,8 @@ public class CaseMapperTest {
     @Test
     public void shouldMapCitizenClaimToCCD() {
         //given
-        Claim claim = SampleClaim.getCitizenClaim();
+        Claim claim = SampleClaim.getCitizenClaim()
+            .toBuilder().state(null).build();
 
         //when
         CCDCase ccdCase = ccdCaseMapper.to(claim);
@@ -63,7 +66,6 @@ public class CaseMapperTest {
         assertEquals(NO, ccdCase.getMigratedFromClaimStore());
         assertEquals(YES, ccdCase.getApplicants().get(0).getValue().getLeadApplicantIndicator());
         assertEquals(MapperUtil.toCaseName.apply(claim), ccdCase.getCaseName());
-        assertEquals(claim.getState().get().getValue(), ccdCase.getState());
     }
 
     @Test(expected = NullPointerException.class)
@@ -97,6 +99,7 @@ public class CaseMapperTest {
 
         //then
         assertThat(claim).isEqualTo(ccdCase);
+        assertEquals(ClaimState.OPEN, claim.getState());
     }
 
     @Test(expected = NullPointerException.class)

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapperTest.java
@@ -63,6 +63,7 @@ public class CaseMapperTest {
         assertEquals(NO, ccdCase.getMigratedFromClaimStore());
         assertEquals(YES, ccdCase.getApplicants().get(0).getValue().getLeadApplicantIndicator());
         assertEquals(MapperUtil.toCaseName.apply(claim), ccdCase.getCaseName());
+        assertEquals(claim.getState().get().getValue(), ccdCase.getState());
     }
 
     @Test(expected = NullPointerException.class)

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Claim.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Claim.java
@@ -227,10 +227,6 @@ public class Claim {
         return Optional.ofNullable(claimantResponseDeadline);
     }
 
-    public Optional<ClaimState> getState() {
-        return Optional.ofNullable(state);
-    }
-
     public Optional<ReviewOrder> getReviewOrder() {
         return Optional.ofNullable(reviewOrder);
     }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Claim.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/Claim.java
@@ -227,7 +227,6 @@ public class Claim {
         return Optional.ofNullable(claimantResponseDeadline);
     }
 
-    @JsonIgnore
     public Optional<ClaimState> getState() {
         return Optional.ofNullable(state);
     }

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/metadata/CaseMetadata.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/metadata/CaseMetadata.java
@@ -86,7 +86,7 @@ public class CaseMetadata {
             .countyCourtJudgment(CountyCourtJudgmentMetadata.fromClaim(claim))
             .redetermination(RedeterminationMetadata.fromClaim(claim))
             .moneyReceivedOn(claim.getMoneyReceivedOn().orElse(null))
-            .state(claim.getState().orElse(null))
+            .state(claim.getState())
             .claimSubmissionOperationIndicators(claim.getClaimSubmissionOperationIndicators())
             .build();
     }

--- a/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleClaim.java
+++ b/domain-sample-data/src/main/java/uk/gov/hmcts/cmc/domain/models/sampledata/SampleClaim.java
@@ -91,7 +91,7 @@ public final class SampleClaim {
     private ReDetermination reDetermination = new ReDetermination("I feel defendant can pay", CLAIMANT);
     private ClaimDocumentCollection claimDocumentCollection = new ClaimDocumentCollection();
     private LocalDate claimantResponseDeadline;
-    private ClaimState state = null;
+    private ClaimState state = ClaimState.OPEN;
     private ClaimSubmissionOperationIndicators claimSubmissionOperationIndicators
         = ClaimSubmissionOperationIndicators.builder().build();
     private Long ccdCaseId = 1023467890123456L;

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/ioc/CreateClaimCitizenTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/ioc/CreateClaimCitizenTest.java
@@ -143,7 +143,7 @@ public class CreateClaimCitizenTest extends BaseIntegrationTest {
 
     private ResultActions makeRequest(ClaimData claimData, String authorization) throws Exception {
         return webClient
-            .perform(put("/claims/" + USER_ID + "/create-citizen-claim")
+            .perform(put("/claims/create-citizen-claim")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, authorization)
                 .content(jsonMapper.toJson(claimData))

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/ioc/InitiatePaymentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/ioc/InitiatePaymentTest.java
@@ -166,7 +166,7 @@ public class InitiatePaymentTest extends BaseSaveTest {
 
     private ResultActions makeInitiatePaymentRequest(ClaimData claimData, String authorization) throws Exception {
         return webClient
-            .perform(post("/claims/" + USER_ID + "/initiate-citizen-payment")
+            .perform(post("/claims/initiate-citizen-payment")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, authorization)
                 .content(jsonMapper.toJson(claimData))

--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/ioc/ResumePaymentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/controllers/ioc/ResumePaymentTest.java
@@ -178,7 +178,7 @@ public class ResumePaymentTest extends BaseIntegrationTest {
 
     private ResultActions makeResumePaymentRequest(ClaimData claimData, String authorization) throws Exception {
         return webClient
-            .perform(put("/claims/" + USER_ID + "/resume-citizen-payment")
+            .perform(put("/claims/resume-citizen-payment")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, authorization)
                 .content(jsonMapper.toJson(claimData))

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimController.java
@@ -114,17 +114,16 @@ public class ClaimController {
         return claimService.saveRepresentedClaim(submitterId, claimData, authorisation);
     }
 
-    @PostMapping(value = "/{submitterId}/initiate-citizen-payment", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @PostMapping(value = "/initiate-citizen-payment", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ApiOperation("Initiates a citizen payment")
     public CreatePaymentResponse initiatePayment(
         @Valid @NotNull @RequestBody ClaimData claimData,
-        @PathVariable("submitterId") String submitterId,
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation
     ) {
-        return claimService.initiatePayment(authorisation, submitterId, claimData);
+        return claimService.initiatePayment(authorisation, claimData);
     }
 
-    @PutMapping(value = "/{submitterId}/resume-citizen-payment", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @PutMapping(value = "/resume-citizen-payment", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ApiOperation("Resumes a citizen payment")
     public CreatePaymentResponse resumePayment(
         @Valid @NotNull @RequestBody ClaimData claimData,
@@ -133,7 +132,7 @@ public class ClaimController {
         return claimService.resumePayment(authorisation, claimData);
     }
 
-    @PutMapping(value = "/{submitterId}/create-citizen-claim", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @PutMapping(value = "/create-citizen-claim", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ApiOperation("Creates a citizen claim")
     public Claim createClaim(
         @Valid @NotNull @RequestBody ClaimData claimData,

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/claim/PostClaimOrchestrationHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/claim/PostClaimOrchestrationHandler.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.cmc.domain.models.ClaimState;
 
 import java.util.function.Function;
 
-import static java.util.function.Predicate.isEqual;
 import static uk.gov.hmcts.cmc.domain.models.response.YesNoOption.NO;
 
 @Async("threadPoolTaskExecutor")
@@ -113,12 +112,11 @@ public class PostClaimOrchestrationHandler {
                 .andThen(c -> notifyClaimantOperation.perform(c, event))
                 .apply(claim);
 
-            updatedClaim.getState()
-                .filter(isEqual(ClaimState.CREATE))
-                .ifPresent(state -> claimService.updateClaimState(authorisation, updatedClaim, ClaimState.OPEN));
-
+            if (updatedClaim.getState().equals(ClaimState.CREATE)) {
+                claimService.updateClaimState(authorisation, updatedClaim, ClaimState.OPEN);
+            }
         } catch (Exception e) {
-            logger.error("Failed operation processing for event ()", event, e);
+            logger.error("Failed operation processing for event {}", event, e);
         }
     }
 
@@ -141,12 +139,11 @@ public class PostClaimOrchestrationHandler {
                 .andThen(c -> notifyRepresentativeOperation.perform(c, event))
                 .apply(claim);
 
-            updatedClaim.getState()
-                .filter(isEqual(ClaimState.CREATE))
-                .ifPresent(state -> claimService.updateClaimState(authorisation, updatedClaim, ClaimState.OPEN));
-
+            if (updatedClaim.getState().equals(ClaimState.CREATE)) {
+                claimService.updateClaimState(authorisation, updatedClaim, ClaimState.OPEN);
+            }
         } catch (Exception e) {
-            logger.error("Failed operation processing for event ()", event, e);
+            logger.error("Failed operation processing for event {}", event, e);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimService.java
@@ -185,12 +185,11 @@ public class ClaimService {
     @LogExecutionTime
     public CreatePaymentResponse initiatePayment(
         String authorisation,
-        String submitterId,
         ClaimData claimData) {
         User user = userService.getUser(authorisation);
 
         Claim claim = buildClaimFrom(user,
-            submitterId,
+            user.getUserDetails().getId(),
             claimData,
             emptyList());
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/ClaimControllerTest.java
@@ -117,16 +117,14 @@ public class ClaimControllerTest {
     @Test
     public void shouldInitiatePaymentForCitizen() {
         //given
-        String submitterId = "234";
         ClaimData input = SampleClaimData.validDefaults();
 
         CreatePaymentResponse response = CreatePaymentResponse.builder().build();
-        when(claimService.initiatePayment(AUTHORISATION, submitterId, input))
+        when(claimService.initiatePayment(AUTHORISATION, input))
             .thenReturn(response);
 
         //when
-        CreatePaymentResponse output = claimController.initiatePayment(
-            input, submitterId, AUTHORISATION);
+        CreatePaymentResponse output = claimController.initiatePayment(input, AUTHORISATION);
 
         //then
         assertThat(output).isEqualTo(response);

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimServiceTest.java
@@ -501,7 +501,7 @@ public class ClaimServiceTest {
         when(caseRepository.initiatePayment(eq(USER), any(Claim.class)))
             .thenReturn(claim);
 
-        CreatePaymentResponse response = claimService.initiatePayment(AUTHORISATION, "submitterId", VALID_APP);
+        CreatePaymentResponse response = claimService.initiatePayment(AUTHORISATION, VALID_APP);
 
         CreatePaymentResponse expectedResponse = CreatePaymentResponse.builder()
             .nextUrl("http://nexturl.test")

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/utils/CaseDetailsConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/utils/CaseDetailsConverterTest.java
@@ -58,8 +58,7 @@ public class CaseDetailsConverterTest {
         CaseDetails caseDetails = successfulCoreCaseDataStoreSubmitResponse();
         Claim claim = caseDetailsConverter.extractClaim(caseDetails);
         assertThat(claim.getId()).isEqualTo(caseDetails.getId());
-        assertThat(claim.getState()).isPresent();
-        assertThat(claim.getState().orElseThrow(AssertionError::new).getValue()).isEqualTo(caseDetails.getState());
+        assertThat(claim.getState().getValue()).isEqualTo(caseDetails.getState());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-6127

### Change description ###

As part of IOC we need to check the claim status (in ccd) from the frontend, so we need to serialise it back as part of the claim

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
