### PR TITLE
increase memory for nodejs

### DIFF
--- a/charts/cmc-claim-store/values.preview.template.yaml
+++ b/charts/cmc-claim-store/values.preview.template.yaml
@@ -53,6 +53,8 @@ cmc-citizen-frontend:
     image: hmctspublic.azurecr.io/cmc/citizen-frontend:latest  # master
     ingressIP: ${INGRESS_IP}
     consulIP: ${CONSUL_LB_IP}
+    memoryRequests: 512Mi
+    memoryLimits: 1024Mi
     releaseNameOverride: ${SERVICE_NAME}-nodejs
     readinessDelay: 90  # claim-store will start much slower
     livenessDelay: 90  # claim-store will start much slower


### PR DESCRIPTION
### Change description ###

Nodejs10 requires more memory to run. This was already done in citizen-frontend:

https://github.com/hmcts/cmc-citizen-frontend/blob/master/charts/cmc-citizen-frontend/values.yaml#L4-L5

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
