### PR TITLE
Bump quartz version because of CVE-2019-13990

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,13 @@ allprojects {
       ) {
         entry 'jackson-module-parameter-names'
       }
+      // solves CVE-2019-13990
+      dependencySet(
+        group: 'org.quartz-scheduler',
+        version: '2.3.2'
+      ) {
+        entry 'quartz'
+      }
     }
   }
 }


### PR DESCRIPTION

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
