### PR TITLE
ROC-7063 Allow accepting repayment plans starting in the past

### DIFF
--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/RepaymentPlan.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/RepaymentPlan.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.gov.hmcts.cmc.domain.constraints.DateNotInThePast;
 import uk.gov.hmcts.cmc.domain.constraints.Money;
 import uk.gov.hmcts.cmc.domain.models.ccj.PaymentSchedule;
+import uk.gov.hmcts.cmc.domain.models.response.PaymentIntention;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -25,7 +26,7 @@ public class RepaymentPlan {
     private final BigDecimal instalmentAmount;
 
     @NotNull
-    @DateNotInThePast
+    @DateNotInThePast(groups = PaymentIntention.Proposing.class)
     private final LocalDate firstPaymentDate;
 
     @NotNull

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/claimantresponse/CourtDetermination.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/claimantresponse/CourtDetermination.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.cmc.domain.models.response.PaymentIntention;
 
 import java.math.BigDecimal;
 import java.util.Optional;
+import javax.validation.GroupSequence;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
@@ -15,6 +16,10 @@ import static uk.gov.hmcts.cmc.domain.utils.ToStringStyle.ourStyle;
 
 @Getter
 @EqualsAndHashCode
+@GroupSequence({
+    PaymentIntention.Responding.class,
+    CourtDetermination.class
+})
 public class CourtDetermination {
 
     @NotNull

--- a/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/PaymentIntention.java
+++ b/domain-model/src/main/java/uk/gov/hmcts/cmc/domain/models/response/PaymentIntention.java
@@ -24,7 +24,7 @@ public class PaymentIntention {
     @NotNull
     private final PaymentOption paymentOption;
 
-    @DateNotInThePast
+    @DateNotInThePast(groups = PaymentIntention.Proposing.class)
     private final LocalDate paymentDate;
 
     @Valid
@@ -52,5 +52,11 @@ public class PaymentIntention {
     @Override
     public String toString() {
         return ReflectionToStringBuilder.toString(this, ourStyle());
+    }
+
+    public interface Proposing {
+    }
+
+    public interface Responding {
     }
 }

--- a/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/response/PaymentIntentionTest.java
+++ b/domain-model/src/test/java/uk/gov/hmcts/cmc/domain/models/response/PaymentIntentionTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.cmc.domain.models.response;
+
+import org.junit.Test;
+import uk.gov.hmcts.cmc.domain.models.PaymentOption;
+import uk.gov.hmcts.cmc.domain.models.RepaymentPlan;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PaymentIntentionTest {
+    private static final PaymentIntention SAMPLE_PAYMENT_INTENTION = PaymentIntention.builder()
+        .paymentOption(PaymentOption.INSTALMENTS)
+        .repaymentPlan(RepaymentPlan.builder()
+            .firstPaymentDate(LocalDate.now().minus(10, ChronoUnit.DAYS))
+            .build())
+        .build();
+
+    private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    public void shouldFailPastDateWhenProposing() {
+        Set<ConstraintViolation<PaymentIntention>> violations = validator.validate(
+            SAMPLE_PAYMENT_INTENTION,
+            PaymentIntention.Proposing.class);
+
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+            .containsExactlyInAnyOrder("is in the past");
+    }
+
+    @Test
+    public void shouldPassPastDateWhenResponding() {
+        Set<ConstraintViolation<PaymentIntention>> violations = validator.validate(
+            SAMPLE_PAYMENT_INTENTION,
+            PaymentIntention.Responding.class);
+
+        assertThat(violations).isEmpty();
+    }
+}


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/ROC-7063


### Change description ###
Add validation groups to disable the constraint that the first repayment date cannot be in the past when responding to the proposal

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
