### PR TITLE
Upgrade the mockito deprecated method

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/rpa/RequestForJudgementNotificationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cmc/claimstore/rpa/RequestForJudgementNotificationServiceTest.java
@@ -26,7 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.hmcts.cmc.claimstore.documents.output.PDF.EXTENSION;
 import static uk.gov.hmcts.cmc.claimstore.rpa.ClaimIssuedNotificationService.JSON_EXTENSION;
 import static uk.gov.hmcts.cmc.claimstore.utils.DocumentNameUtils.buildJsonRequestForJudgementFileBaseName;
@@ -140,7 +140,7 @@ public class RequestForJudgementNotificationServiceTest extends BaseMockSpringTe
 
         service.notifyRobotics(event);
 
-        verifyZeroInteractions(emailService);
+        verifyNoInteractions(emailService);
     }
 
     @Test
@@ -155,6 +155,6 @@ public class RequestForJudgementNotificationServiceTest extends BaseMockSpringTe
 
         service.notifyRobotics(event);
 
-        verifyZeroInteractions(emailService);
+        verifyNoInteractions(emailService);
     }
 }

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/support/DeadlineSupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/support/DeadlineSupportControllerTest.java
@@ -28,7 +28,7 @@ import static java.time.temporal.ChronoUnit.YEARS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -80,7 +80,7 @@ public class DeadlineSupportControllerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
         assertThat(response.getBody()).isEqualTo("Unrecognised deadline type: unknown");
-        verifyZeroInteractions(dqService);
+        verifyNoInteractions(dqService);
     }
 
     @Test
@@ -98,7 +98,7 @@ public class DeadlineSupportControllerTest {
         assertThat(response.getBody())
             .isEqualTo("Claim %s already has a directions questionnaire deadline of %s.",
                 reference, deadline);
-        verifyZeroInteractions(dqService);
+        verifyNoInteractions(dqService);
     }
 
     @Test
@@ -115,7 +115,7 @@ public class DeadlineSupportControllerTest {
         assertThat(response.getBody())
             .isEqualTo("Claim %s has online DQs enabled; "
                 + "cannot define a directions questionnaire deadline", reference);
-        verifyZeroInteractions(dqService);
+        verifyNoInteractions(dqService);
     }
 
     @Test
@@ -132,7 +132,7 @@ public class DeadlineSupportControllerTest {
         assertThat(response.getBody())
             .isEqualTo("Claim %s does not have a response; "
                 + "cannot define a directions questionnaire deadline", reference);
-        verifyZeroInteractions(dqService);
+        verifyNoInteractions(dqService);
     }
 
     @Test
@@ -152,7 +152,7 @@ public class DeadlineSupportControllerTest {
         assertThat(response.getBody())
             .isEqualTo("Claim %s is from before 5.0.0 and its defendant agreed to mediation; "
                 + "cannot define a directions questionnaire deadline.", reference);
-        verifyZeroInteractions(dqService);
+        verifyNoInteractions(dqService);
     }
 
     @Test
@@ -172,7 +172,7 @@ public class DeadlineSupportControllerTest {
         assertThat(response.getBody())
             .isEqualTo("Claim %s is from before 5.0.0 and its defendant fully admitted; "
                 + "cannot define a directions questionnaire deadline.", reference);
-        verifyZeroInteractions(dqService);
+        verifyNoInteractions(dqService);
     }
 
     @Test
@@ -215,7 +215,7 @@ public class DeadlineSupportControllerTest {
         assertThat(response.getBody())
             .isEqualTo("Claim %s does not have a claimant response; "
                 + "cannot define a directions questionnaire deadline", reference);
-        verifyZeroInteractions(dqService);
+        verifyNoInteractions(dqService);
     }
 
     @Test
@@ -235,7 +235,7 @@ public class DeadlineSupportControllerTest {
         assertThat(response.getBody())
             .isEqualTo("Claim %s has an acceptation claimant response; "
                 + "cannot define a directions questionnaire deadline.", reference);
-        verifyZeroInteractions(dqService);
+        verifyNoInteractions(dqService);
     }
 
     @Test
@@ -255,7 +255,7 @@ public class DeadlineSupportControllerTest {
         assertThat(response.getBody())
             .isEqualTo("Claim %s has a mediation agreement; "
                 + "cannot define a directions questionnaire deadline.", reference);
-        verifyZeroInteractions(dqService);
+        verifyNoInteractions(dqService);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/events/DocumentUploadHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/events/DocumentUploadHandlerTest.java
@@ -44,7 +44,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.cmc.claimstore.utils.DocumentNameUtils.buildClaimIssueReceiptFileBaseName;
 import static uk.gov.hmcts.cmc.claimstore.utils.DocumentNameUtils.buildDefendantLetterFileBaseName;
@@ -267,7 +267,7 @@ public class DocumentUploadHandlerTest {
                 SampleClaim.getWithClaimantResponse(
                     SampleClaimantResponse.validDefaultAcceptation()), AUTHORISATION));
 
-        verifyZeroInteractions(claimantDirectionsQuestionnairePdfService);
+        verifyNoInteractions(claimantDirectionsQuestionnairePdfService);
     }
 
     @Test
@@ -277,7 +277,7 @@ public class DocumentUploadHandlerTest {
                 SampleClaim.getWithClaimantResponse(
                     SampleClaimantResponse.validDefaultRejection()), AUTHORISATION));
 
-        verifyZeroInteractions(claimantDirectionsQuestionnairePdfService);
+        verifyNoInteractions(claimantDirectionsQuestionnairePdfService);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/events/claim/PostClaimOrchestrationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/events/claim/PostClaimOrchestrationHandlerTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.hmcts.cmc.domain.models.ClaimDocumentType.CLAIM_ISSUE_RECEIPT;
 import static uk.gov.hmcts.cmc.domain.models.ClaimDocumentType.SEALED_CLAIM;
 
@@ -225,7 +225,7 @@ public class PostClaimOrchestrationHandlerTest {
         postClaimOrchestrationHandler.citizenIssueHandler(event);
 
         //then
-        verifyZeroInteractions(pinOrchestrationService);
+        verifyNoInteractions(pinOrchestrationService);
         verify(citizenServiceDocumentsService).sealedClaimDocument(eq(claimWithPinOperationSucceededIndicator));
         verify(pdfServiceClient).generateFromHtml(any(), anyMap());
         verify(claimIssueReceiptService).createPdf(eq(claimWithPinOperationSucceededIndicator));
@@ -253,10 +253,10 @@ public class PostClaimOrchestrationHandlerTest {
         postClaimOrchestrationHandler.citizenIssueHandler(event);
 
         //then
-        verifyZeroInteractions(pinOrchestrationService);
-        verifyZeroInteractions(claimantOperationService);
-        verifyZeroInteractions(rpaOperationService);
-        verifyZeroInteractions(uploadOperationService);
+        verifyNoInteractions(pinOrchestrationService);
+        verifyNoInteractions(claimantOperationService);
+        verifyNoInteractions(rpaOperationService);
+        verifyNoInteractions(uploadOperationService);
 
     }
 
@@ -294,7 +294,7 @@ public class PostClaimOrchestrationHandlerTest {
         verify(rpaOperationService).notify(eq(claimWithUploadSealedClaimSuccess), eq(AUTHORISATION), any());
         verify(uploadOperationService).uploadDocument(eq(claimWithUploadSealedClaimSuccess),
             eq(AUTHORISATION), any());
-        verifyZeroInteractions(pinOrchestrationService);
+        verifyNoInteractions(pinOrchestrationService);
 
     }
 
@@ -329,8 +329,8 @@ public class PostClaimOrchestrationHandlerTest {
         verify(claimantOperationService).notifyCitizen(eq(claimWithClaimReceiptUploadSuccess),
             any(), eq(AUTHORISATION));
         verify(rpaOperationService).notify(eq(claimWithClaimReceiptUploadSuccess), eq(AUTHORISATION), any());
-        verifyZeroInteractions(uploadOperationService);
-        verifyZeroInteractions(pinOrchestrationService);
+        verifyNoInteractions(uploadOperationService);
+        verifyNoInteractions(pinOrchestrationService);
 
     }
 
@@ -359,9 +359,9 @@ public class PostClaimOrchestrationHandlerTest {
         verify(pdfServiceClient).generateFromHtml(any(), anyMap());
         verify(claimIssueReceiptService).createPdf(eq(claimWithRpaSuccess));
         verify(claimantOperationService).notifyCitizen(eq(claimWithRpaSuccess), any(), eq(AUTHORISATION));
-        verifyZeroInteractions(rpaOperationService);
-        verifyZeroInteractions(uploadOperationService);
-        verifyZeroInteractions(pinOrchestrationService);
+        verifyNoInteractions(rpaOperationService);
+        verifyNoInteractions(uploadOperationService);
+        verifyNoInteractions(pinOrchestrationService);
 
     }
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/events/claimantresponse/ClaimantResponseStaffNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/events/claimantresponse/ClaimantResponseStaffNotificationHandlerTest.java
@@ -14,7 +14,7 @@ import uk.gov.hmcts.cmc.domain.utils.LocalDateTimeFactory;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.hmcts.cmc.claimstore.utils.VerificationModeUtils.once;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -64,7 +64,7 @@ public class ClaimantResponseStaffNotificationHandlerTest {
         ClaimantResponseEvent event = new ClaimantResponseEvent(SampleClaim.builder().build(), authorisation);
         handler.onClaimantResponse(event);
 
-        verifyZeroInteractions(statesPaidStaffNotificationService, claimantRejectionStaffNotificationService);
+        verifyNoInteractions(statesPaidStaffNotificationService, claimantRejectionStaffNotificationService);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -73,7 +73,7 @@ public class ClaimantResponseStaffNotificationHandlerTest {
 
         handler.notifyStaffWithClaimantsIntentionToProceed(event);
 
-        verifyZeroInteractions(statesPaidStaffNotificationService, claimantRejectionStaffNotificationService);
+        verifyNoInteractions(statesPaidStaffNotificationService, claimantRejectionStaffNotificationService);
     }
 
     public void shouldNotifyStaffWhenClaimantIntendsToProceed() {

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/FormaliseResponseAcceptanceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/FormaliseResponseAcceptanceServiceTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.INTERLOCUTORY_JUDGMENT;
 import static uk.gov.hmcts.cmc.claimstore.utils.VerificationModeUtils.once;
 import static uk.gov.hmcts.cmc.domain.models.claimantresponse.DecisionType.CLAIMANT;
@@ -145,7 +145,7 @@ public class FormaliseResponseAcceptanceServiceTest {
             .orElseThrow(IllegalStateException::new))
             .isEqualTo(respondentPayingBySetDate);
 
-        verifyZeroInteractions(settlementAgreementService);
+        verifyNoInteractions(settlementAgreementService);
     }
 
     @Test
@@ -176,7 +176,7 @@ public class FormaliseResponseAcceptanceServiceTest {
             .getRepaymentPlan().orElseThrow(IllegalAccessError::new))
             .isEqualTo(repaymentPlanOfDefendant);
 
-        verifyZeroInteractions(settlementAgreementService);
+        verifyNoInteractions(settlementAgreementService);
     }
 
     @Test
@@ -211,7 +211,7 @@ public class FormaliseResponseAcceptanceServiceTest {
             .orElseThrow(IllegalStateException::new))
             .isEqualTo(appliedPaymentDate);
 
-        verifyZeroInteractions(settlementAgreementService);
+        verifyNoInteractions(settlementAgreementService);
     }
 
     @Test
@@ -248,7 +248,7 @@ public class FormaliseResponseAcceptanceServiceTest {
             .orElseThrow(IllegalStateException::new))
             .isEqualTo(appliedPaymentDate);
 
-        verifyZeroInteractions(settlementAgreementService);
+        verifyNoInteractions(settlementAgreementService);
     }
 
     @Test
@@ -282,7 +282,7 @@ public class FormaliseResponseAcceptanceServiceTest {
             .getValue()
             .getPayBySetDate().isPresent()).isFalse();
 
-        verifyZeroInteractions(settlementAgreementService);
+        verifyNoInteractions(settlementAgreementService);
     }
 
     @Test
@@ -317,7 +317,7 @@ public class FormaliseResponseAcceptanceServiceTest {
             .orElseThrow(IllegalStateException::new))
             .isEqualTo(appliedPlan);
 
-        verifyZeroInteractions(settlementAgreementService);
+        verifyNoInteractions(settlementAgreementService);
     }
 
     @Test
@@ -349,7 +349,7 @@ public class FormaliseResponseAcceptanceServiceTest {
             .orElseThrow(IllegalStateException::new))
             .isEqualTo(repaymentPlan);
 
-        verifyZeroInteractions(settlementAgreementService);
+        verifyNoInteractions(settlementAgreementService);
     }
 
     @Test
@@ -383,7 +383,7 @@ public class FormaliseResponseAcceptanceServiceTest {
 
         assertThat(paymentIntentionWithinOffer).isEqualTo(paymentIntentionOfDefendant);
 
-        verifyZeroInteractions(countyCourtJudgmentService);
+        verifyNoInteractions(countyCourtJudgmentService);
     }
 
     @Test
@@ -417,7 +417,7 @@ public class FormaliseResponseAcceptanceServiceTest {
 
         assertThat(paymentIntentionWithinOffer).isEqualTo(paymentIntentionOfDefendant);
 
-        verifyZeroInteractions(countyCourtJudgmentService);
+        verifyNoInteractions(countyCourtJudgmentService);
     }
 
     @Test
@@ -454,7 +454,7 @@ public class FormaliseResponseAcceptanceServiceTest {
 
         assertThat(paymentIntentionWithinOffer).isEqualTo(paymentIntention);
 
-        verifyZeroInteractions(countyCourtJudgmentService);
+        verifyNoInteractions(countyCourtJudgmentService);
     }
 
     @Test
@@ -492,7 +492,7 @@ public class FormaliseResponseAcceptanceServiceTest {
 
         assertThat(paymentIntentionWithinOffer).isEqualTo(paymentIntention);
 
-        verifyZeroInteractions(countyCourtJudgmentService);
+        verifyNoInteractions(countyCourtJudgmentService);
     }
 
     @Test
@@ -529,7 +529,7 @@ public class FormaliseResponseAcceptanceServiceTest {
         assertThat(paymentIntentionWithinOffer)
             .isEqualTo(fullAdmissionResponseWithInstalments.getPaymentIntention());
 
-        verifyZeroInteractions(countyCourtJudgmentService);
+        verifyNoInteractions(countyCourtJudgmentService);
     }
 
     @Test
@@ -567,7 +567,7 @@ public class FormaliseResponseAcceptanceServiceTest {
 
         assertThat(paymentIntentionWithinOffer).isEqualTo(fullAdmissionResponseBySetDate.getPaymentIntention());
 
-        verifyZeroInteractions(countyCourtJudgmentService);
+        verifyNoInteractions(countyCourtJudgmentService);
     }
 
     @Test
@@ -582,8 +582,8 @@ public class FormaliseResponseAcceptanceServiceTest {
 
         verify(eventProducer, once()).createInterlocutoryJudgmentEvent(eq(claim));
         verify(caseRepository, once()).saveCaseEvent(anyString(), eq(claim), eq(INTERLOCUTORY_JUDGMENT));
-        verifyZeroInteractions(countyCourtJudgmentService);
-        verifyZeroInteractions(settlementAgreementService);
+        verifyNoInteractions(countyCourtJudgmentService);
+        verifyNoInteractions(settlementAgreementService);
     }
 
     private PartAdmissionResponse getPartAdmissionResponsePayByInstalments() {

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/DefendantResponseNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/notifications/DefendantResponseNotificationServiceTest.java
@@ -21,7 +21,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsights.REFERENCE_NUMBER;
 import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsightsEvent.NOTIFICATION_FAILURE;
@@ -216,6 +216,6 @@ public class DefendantResponseNotificationServiceTest extends BaseNotificationSe
 
         service.notifyClaimant(claimWithNoResponse, reference);
 
-        verifyZeroInteractions(emailTemplates, notificationClient);
+        verifyNoInteractions(emailTemplates, notificationClient);
     }
 }


### PR DESCRIPTION
### Change description ###
After bumping up the mockito version, we have `verifyZeroInteractions` deprecated. It's recommended to use `verifyNoInteractions` instead.


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

