### PR TITLE
ROC-6843: Move mocked configuration in aat as not required for integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,7 +258,7 @@ sourceSets {
   aat {
     java {
       compileClasspath += main.output
-      runtimeClasspath += main.output + integrationTest.output
+      runtimeClasspath += main.output
       srcDir('src/aat/java')
     }
     resources {

--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/deprectaed/MockedDatabaseConfiguration.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/deprectaed/MockedDatabaseConfiguration.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.cmc.claimstore.deprecated;
+package uk.gov.hmcts.cmc.claimstore.tests.deprectaed;
 
 import org.flywaydb.core.Flyway;
 import org.mockito.Answers;


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Move mocked configuration in aat as not required for integration tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
