### PR TITLE
ROC-7508-Flyway fails on migrate unable to find flyway_schema_history table

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/CmcDBConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/CmcDBConfiguration.java
@@ -46,6 +46,7 @@ public class CmcDBConfiguration {
     private void migrateFlyway(DataSource dataSource) {
         Flyway.configure()
             .dataSource(dataSource)
+            .baselineOnMigrate(true)
             .locations("db/migration")
             .load()
             .migrate();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-7508

### Change description ###

1. To solve it a solution on flyway doc to set the
baselineOnMigrate to true.
