### PR TITLE
ROC-7508-Flyway revert version upgrade to unblock pipeline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-json'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
 
-  compile group: 'org.flywaydb', name: 'flyway-core', version: '6.2.2'
+  compile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
 
   compile group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback
   compile group: 'ch.qos.logback', name: 'logback-core', version: versions.logback

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/config/CmcDBConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/config/CmcDBConfiguration.java
@@ -46,7 +46,6 @@ public class CmcDBConfiguration {
     private void migrateFlyway(DataSource dataSource) {
         Flyway.configure()
             .dataSource(dataSource)
-            .baselineOnMigrate(true)
             .locations("db/migration")
             .load()
             .migrate();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-7508

### Change description ###
Revert the flyway upgrade to avoid hassles with the migration strategy thats required for the upgrade from 5.4.2 to 6.2.2