### PR TITLE
Feature/ROC-7378 and ROC-7379 feature toggle added for staff email full admission/part admission/full defence

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/DefendantResponseStaffNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/events/response/DefendantResponseStaffNotificationHandler.java
@@ -1,12 +1,14 @@
 package uk.gov.hmcts.cmc.claimstore.events.response;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.cmc.claimstore.services.staff.DefendantResponseStaffNotificationService;
 import uk.gov.hmcts.cmc.domain.models.Claim;
 
 @Component
+@ConditionalOnProperty("feature_toggles.staff_emails_enabled")
 public class DefendantResponseStaffNotificationHandler {
 
     private final DefendantResponseStaffNotificationService defendantResponseStaffNotificationService;


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-7378
https://tools.hmcts.net/jira/browse/ROC-7379


### Change description ###
Added a feature toggle to turn on/off the staff emails in case of full admission/part admission/full defence.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
