### PR TITLE
ROC-7916 - Fix for claimant rejection for FullDefence, No Mediation, Offline DQ throws 409 exception

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseService.java
@@ -108,14 +108,6 @@ public class ClaimantResponseService {
             caseRepository.saveCaseEvent(authorization, updatedClaim, CaseEvent.STAY_CLAIM);
         }
 
-        if (!isSettlementAgreement(response, claimantResponse)) {
-            eventProducer.createClaimantResponseEvent(updatedClaim, authorization);
-        }
-
-        if (isSettlePreJudgment(claimantResponse)) {
-            caseRepository.saveCaseEvent(authorization, updatedClaim, SETTLED_PRE_JUDGMENT);
-        }
-
         CaseEvent caseEvent = null;
         if (claimantResponse.getType() == REJECTION) {
             ResponseRejection responseRejection = (ResponseRejection) claimantResponse;
@@ -128,6 +120,14 @@ public class ClaimantResponseService {
             } else {
                 caseRepository.saveCaseEvent(authorization, updatedClaim, caseEvent);
             }
+        }
+
+        if (!isSettlementAgreement(response, claimantResponse)) {
+            eventProducer.createClaimantResponseEvent(updatedClaim, authorization);
+        }
+
+        if (isSettlePreJudgment(claimantResponse)) {
+            caseRepository.saveCaseEvent(authorization, updatedClaim, SETTLED_PRE_JUDGMENT);
         }
 
         raiseAppInsightEvents(updatedClaim, response, claimantResponse, caseEvent);

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseServiceTest.java
@@ -27,11 +27,7 @@ import uk.gov.hmcts.cmc.domain.models.sampledata.SampleHearingLocation;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
 
 import java.math.BigDecimal;
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.*;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -94,6 +90,7 @@ public class ClaimantResponseServiceTest {
 
     @Before
     public void setUp() {
+        clock = Clock.fixed(Instant.now(), ZoneId.of("UTC"));
         claimantResponseService = new ClaimantResponseService(
             claimService,
             appInsights,
@@ -507,16 +504,16 @@ public class ClaimantResponseServiceTest {
 
         final Claim claim = SampleClaim.builder()
             .withFeatures(ImmutableList.of(ADMISSIONS.getValue()))
-            .withResponseDeadline(LocalDate.now().minusMonths(2))
+            .withResponseDeadline(LocalDate.now().plusDays(2))
             .withResponse(SampleResponse.FullDefence.builder().build())
             .withRespondedAt(respondedAt)
             .withClaimantResponse(claimantResponse)
             .build();
 
         when(claimService.getClaimByExternalId(eq(EXTERNAL_ID), eq(AUTHORISATION))).thenReturn(claim);
-        when(LocalDate.now(clock)).thenReturn(LocalDate.now());
         when(caseRepository.saveClaimantResponse(any(Claim.class), any(ResponseRejection.class), eq(AUTHORISATION)))
             .thenReturn(claim);
+        when(directionsQuestionnaireDeadlineCalculator.calculate(any())).thenReturn(LocalDate.now());
         when(directionsQuestionnaireService.prepareCaseEvent(any(), any()))
             .thenReturn(DIRECTIONS_QUESTIONNAIRE_DEADLINE);
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ClaimantResponseServiceTest.java
@@ -27,7 +27,13 @@ import uk.gov.hmcts.cmc.domain.models.sampledata.SampleHearingLocation;
 import uk.gov.hmcts.cmc.domain.models.sampledata.SampleResponse;
 
 import java.math.BigDecimal;
-import java.time.*;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,7 +42,12 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.*;
+import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.ASSIGNING_FOR_JUDGE_DIRECTIONS;
+import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.ASSIGNING_FOR_LEGAL_ADVISOR_DIRECTIONS;
+import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.DIRECTIONS_QUESTIONNAIRE_DEADLINE;
+import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.LIFT_STAY;
+import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.REFERRED_TO_MEDIATION;
+import static uk.gov.hmcts.cmc.ccd.domain.CaseEvent.STAY_CLAIM;
 import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsights.REFERENCE_NUMBER;
 import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsightsEvent.BOTH_OPTED_IN_FOR_MEDIATION_PILOT;
 import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsightsEvent.BOTH_OPTED_IN_FOR_NON_MEDIATION_PILOT;
@@ -51,7 +62,11 @@ import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsightsEvent.LA_PILOT_
 import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsightsEvent.MEDIATION_NON_PILOT_ELIGIBLE;
 import static uk.gov.hmcts.cmc.claimstore.appinsights.AppInsightsEvent.MEDIATION_PILOT_ELIGIBLE;
 import static uk.gov.hmcts.cmc.claimstore.utils.VerificationModeUtils.once;
-import static uk.gov.hmcts.cmc.domain.models.ClaimFeatures.*;
+import static uk.gov.hmcts.cmc.domain.models.ClaimFeatures.ADMISSIONS;
+import static uk.gov.hmcts.cmc.domain.models.ClaimFeatures.DQ_FLAG;
+import static uk.gov.hmcts.cmc.domain.models.ClaimFeatures.JUDGE_PILOT_FLAG;
+import static uk.gov.hmcts.cmc.domain.models.ClaimFeatures.LA_PILOT_FLAG;
+import static uk.gov.hmcts.cmc.domain.models.ClaimFeatures.MEDIATION_PILOT;
 import static uk.gov.hmcts.cmc.domain.models.response.YesNoOption.YES;
 import static uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim.EXTERNAL_ID;
 


### PR DESCRIPTION



### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-7916

### Change description ###

This is a fix  for if opted out for new feature, claimant rejection for FullDefence, No Mediation, should update DQDeadline and the claimant response submission should not fail with a 409.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No
