### PR TITLE
ROC-8014 Add LaunchDarkly integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,7 @@ dependencies {
   compile project(':rpa-mapper')
   compile project(':domain-sample-data')
   compile project(':job-scheduler')
+  compile project(':launch-darkly-client')
 
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
@@ -383,6 +384,7 @@ sonarqube {
         "**/DBCaseRepository.java",
         "**/MapperUtil.java",
         "**/CCDCaseApi.java",
+        "launch-darkly-client/**",
         "rpa-mapper/**"
       ].join(",")
   }

--- a/charts/cmc-claim-store/Chart.yaml
+++ b/charts/cmc-claim-store/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cmc-claim-store
 home: https://github.com/hmcts/cmc-claim-store
-version: 4.1.4
+version: 4.1.5
 description: Helm chart for the HMCTS CMC Claim-Store service
 # be aware when bumping version that it is used elsewhere, e.g.:
 # chart-cmc - demo: https://github.com/hmcts/chart-cmc/tree/master/cmc

--- a/charts/cmc-claim-store/values.preview.template.yaml
+++ b/charts/cmc-claim-store/values.preview.template.yaml
@@ -43,6 +43,7 @@ java:
         - rpa-email-response
         - rpa-email-ccj
         - rpa-email-paid-in-full
+        - launchDarkly-sdk-key
   environment:
     LOG_LEVEL: DEBUG
     CMC_DB_HOST: ${SERVICE_NAME}-postgresql

--- a/charts/cmc-claim-store/values.yaml
+++ b/charts/cmc-claim-store/values.yaml
@@ -29,6 +29,7 @@ java:
         - rpa-email-response
         - rpa-email-ccj
         - rpa-email-paid-in-full
+        - launchDarkly-sdk-key
   environment:
     REFORM_TEAM: cmc
     REFORM_SERVICE_NAME: claim-store

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -91,6 +91,11 @@ data "azurerm_key_vault_secret" "oauth_client_secret" {
   key_vault_id = "${data.azurerm_key_vault.cmc_key_vault.id}"
 }
 
+data "azurerm_key_vault_secret" "launch_darkly_sdk_key" {
+  name = "launchDarkly-sdk-key"
+  key_vault_id = "${data.azurerm_key_vault.cmc_key_vault.id}"
+}
+
 resource "azurerm_key_vault_secret" "cmc-db-password" {
   name      = "cmc-db-password"
   value     = "${module.database.postgresql_password}"

--- a/launch-darkly-client/build.gradle
+++ b/launch-darkly-client/build.gradle
@@ -1,0 +1,17 @@
+apply plugin: 'jacoco'
+apply plugin: 'net.ltgt.apt'
+
+sourceCompatibility = 11
+
+dependencies {
+  compile group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '4.14.0'
+  compile group: 'org.springframework', name: 'spring-context-support'
+
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api'
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
+  testCompile group: 'org.mockito', name: 'mockito-junit-jupiter'
+}
+
+test {
+  useJUnitPlatform()
+}

--- a/launch-darkly-client/src/main/java/uk/gov/hmcts/cmc/launchdarkly/LaunchDarklyClient.java
+++ b/launch-darkly-client/src/main/java/uk/gov/hmcts/cmc/launchdarkly/LaunchDarklyClient.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.cmc.launchdarkly;
+
+import com.launchdarkly.client.LDClientInterface;
+import com.launchdarkly.client.LDUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.cmc.launchdarkly.internal.LDClientFactory;
+
+import java.io.IOException;
+
+@Service
+public class LaunchDarklyClient {
+    public static final LDUser CLAIM_STORE_USER = new LDUser.Builder("claim-store-api")
+        .anonymous(true)
+        .build();
+
+    private final LDClientInterface internalClient;
+
+    @Autowired
+    public LaunchDarklyClient(
+        LDClientFactory ldClientFactory,
+        @Value("${launchdarkly.sdk-key}") String sdkKey,
+        @Value("${launchdarkly.offline-mode:false}") Boolean offlineMode
+    ) {
+        this.internalClient = ldClientFactory.create(sdkKey, offlineMode);
+        Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+    }
+
+    public boolean isFeatureEnabled(String feature, LDUser user) {
+        return internalClient.boolVariation(feature, user, false);
+    }
+
+    private void close() {
+        try {
+            internalClient.close();
+        } catch (IOException e) {
+            // can't do anything clever here because things are being destroyed
+            e.printStackTrace(System.err);
+        }
+    }
+}

--- a/launch-darkly-client/src/main/java/uk/gov/hmcts/cmc/launchdarkly/internal/LDClientFactory.java
+++ b/launch-darkly-client/src/main/java/uk/gov/hmcts/cmc/launchdarkly/internal/LDClientFactory.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.cmc.launchdarkly.internal;
+
+import com.launchdarkly.client.LDClient;
+import com.launchdarkly.client.LDClientInterface;
+import com.launchdarkly.client.LDConfig;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LDClientFactory {
+    public LDClientInterface create(String sdkKey, boolean offlineMode) {
+        LDConfig config = new LDConfig.Builder()
+            .offline(offlineMode)
+            .build();
+        return new LDClient(sdkKey, config);
+    }
+}

--- a/launch-darkly-client/src/test/java/uk/gov/hmcts/cmc/launchdarkly/LaunchDarklyClientTest.java
+++ b/launch-darkly-client/src/test/java/uk/gov/hmcts/cmc/launchdarkly/LaunchDarklyClientTest.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.cmc.launchdarkly;
+
+import com.launchdarkly.client.LDClientInterface;
+import com.launchdarkly.client.LDUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.cmc.launchdarkly.internal.LDClientFactory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LaunchDarklyClientTest {
+    private static final String SDK_KEY = "fake key";
+    private static final String FAKE_FEATURE = "fake feature";
+
+    @Mock
+    private LDClientFactory ldClientFactory;
+
+    @Mock
+    private LDClientInterface ldClient;
+
+    @Mock
+    private LDUser ldUser;
+
+    private LaunchDarklyClient launchDarklyClient;
+
+    @BeforeEach
+    void setUp() {
+        when(ldClientFactory.create(eq(SDK_KEY), anyBoolean())).thenReturn(ldClient);
+        launchDarklyClient = new LaunchDarklyClient(ldClientFactory, SDK_KEY, true);
+    }
+
+    @Test
+    void testFeatureEnabled() {
+        when(ldClient.boolVariation(eq(FAKE_FEATURE), any(LDUser.class), anyBoolean())).thenReturn(true);
+        assertTrue(launchDarklyClient.isFeatureEnabled(FAKE_FEATURE, ldUser));
+    }
+
+    @Test
+    void testFeatureDisabled() {
+        when(ldClient.boolVariation(eq(FAKE_FEATURE), any(LDUser.class), anyBoolean())).thenReturn(false);
+        assertFalse(launchDarklyClient.isFeatureEnabled(FAKE_FEATURE, ldUser));
+    }
+}

--- a/launch-darkly-client/src/test/java/uk/gov/hmcts/cmc/launchdarkly/internal/LDClientFactoryTest.java
+++ b/launch-darkly-client/src/test/java/uk/gov/hmcts/cmc/launchdarkly/internal/LDClientFactoryTest.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.cmc.launchdarkly.internal;
+
+import com.launchdarkly.client.LDClientInterface;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class LDClientFactoryTest {
+    private LDClientFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new LDClientFactory();
+    }
+
+    @Test
+    void testCreate() {
+        LDClientInterface client = factory.create("test key", true);
+        assertNotNull(client);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,4 @@ include 'ccd-adapter'
 include 'rpa-mapper'
 include 'job-scheduler'
 include 'ccd-sample-data'
-
+include 'launch-darkly-client'

--- a/sonarlint
+++ b/sonarlint
@@ -1,3 +1,5 @@
 #!/bin/bash
-sonarlint -Dsonar.java.libraries=build/libs --src "{src/main/**,email-client/src/main/**,ccd-adapter/src/main/**}"  --tests "{src/test/**,src/apiTest/**,email-client/src/test/**,ccd-adapter/src/test/**}"
+sonarlint -Dsonar.java.libraries=build/libs \
+  --src "{src/main/**,email-client/src/main/**,ccd-adapter/src/main/**,launch-darkly-client/src/main/**}" \
+  --tests "{src/test/**,src/apiTest/**,email-client/src/test/**,ccd-adapter/src/test/**,launch-darkly-client/src/test/**}"
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/healthcheck/LaunchDarklyHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/healthcheck/LaunchDarklyHealthIndicator.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.cmc.claimstore.healthcheck;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.cmc.launchdarkly.LaunchDarklyClient;
+
+@Component
+public class LaunchDarklyHealthIndicator implements HealthIndicator {
+    private static final String TOGGLE = "launch-darkly-health-roc-8014";
+    private final LaunchDarklyClient launchDarklyClient;
+
+    @Autowired
+    public LaunchDarklyHealthIndicator(LaunchDarklyClient launchDarklyClient) {
+        this.launchDarklyClient = launchDarklyClient;
+    }
+
+    @Override
+    public Health health() {
+        return Health.up()
+            .withDetail(TOGGLE, launchDarklyClient.isFeatureEnabled(TOGGLE, LaunchDarklyClient.CLAIM_STORE_USER))
+            .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,9 @@ spring:
     password: ${CMC_DB_PASSWORD:-}
     url: jdbc:postgresql://${CMC_DB_HOST:}:${CMC_DB_PORT:}/${CMC_DB_NAME:cmc}${CMC_DB_CONNECTION_OPTIONS:}
 
+launchdarkly:
+  sdk-key: "${LAUNCH_DARKLY_SDK_KEY:sdk-c732c882-b5df-4e9b-9ec1-679836b93907}"
+
 quartzProperties:
   org.quartz:
     scheduler:

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -22,3 +22,4 @@ spring:
         rpa-email-response: rpa.notifications.responseRecipient
         rpa-email-ccj: rpa.notifications.countyCourtJudgementRecipient
         rpa-email-paid-in-full: rpa.notifications.paidInFullRecipient
+        launchDarkly-sdk-key: LAUNCH_DARKLY_SDK_KEY

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/healthcheck/LaunchDarklyHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/healthcheck/LaunchDarklyHealthIndicatorTest.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.cmc.claimstore.healthcheck;
+
+import com.launchdarkly.client.LDUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import uk.gov.hmcts.cmc.launchdarkly.LaunchDarklyClient;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LaunchDarklyHealthIndicatorTest {
+    @Mock
+    private LaunchDarklyClient client;
+
+    private LaunchDarklyHealthIndicator healthIndicator;
+
+    @BeforeEach
+    void setUp() {
+        healthIndicator = new LaunchDarklyHealthIndicator(client);
+    }
+
+    @Test
+    void testToggleEnabled() {
+        when(client.isFeatureEnabled(eq("launch-darkly-health-roc-8014"), any(LDUser.class))).thenReturn(true);
+        Health result = healthIndicator.health();
+        assertNotNull(result);
+        assertEquals(Status.UP, result.getStatus());
+        Map<String, Object> details = result.getDetails();
+        assertTrue(details.containsKey("launch-darkly-health-roc-8014"));
+        assertTrue((boolean) details.get("launch-darkly-health-roc-8014"));
+    }
+
+    @Test
+    void testToggleDisabled() {
+        when(client.isFeatureEnabled(eq("launch-darkly-health-roc-8014"), any(LDUser.class))).thenReturn(false);
+        Health result = healthIndicator.health();
+        assertNotNull(result);
+        assertEquals(Status.UP, result.getStatus());
+        Map<String, Object> details = result.getDetails();
+        assertTrue(details.containsKey("launch-darkly-health-roc-8014"));
+        assertFalse((boolean) details.get("launch-darkly-health-roc-8014"));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-8014

### Change description ###
Integrate LaunchDarkly into the claim-store. Add a temporary health indicator revealing the state of a temporary toggle, for testing purposes.

Clean-up PR: https://github.com/hmcts/cmc-claim-store/pull/1714

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
