### PR TITLE
ROC-8002 | fixing missing preferred court

### DIFF
--- a/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapper.java
+++ b/ccd-adapter/src/main/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapper.java
@@ -118,6 +118,10 @@ public class CaseMapper {
             builder.channel(ChannelType.valueOf(ccdCase.getChannel().name()));
         }
 
+        if (ccdCase.getPreferredDQCourt() != null) {
+            builder.preferredDQCourt(ccdCase.getPreferredDQCourt());
+        }
+
         return builder.build();
     }
 }

--- a/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapperTest.java
+++ b/ccd-adapter/src/test/java/uk/gov/hmcts/cmc/ccd/mapper/CaseMapperTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cmc.ccd.mapper;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +19,7 @@ import uk.gov.hmcts.cmc.domain.models.sampledata.SampleClaim;
 
 import java.time.LocalDateTime;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -35,6 +37,8 @@ public class CaseMapperTest {
 
     @Autowired
     private CaseMapper ccdCaseMapper;
+
+    private static final String PREFERRED_COURT  = "preferred-court";
 
     @Test
     public void shouldMapLegalClaimToCCD() {
@@ -199,5 +203,19 @@ public class CaseMapperTest {
         //then
         assertTrue(claim.getDirectionOrder().isPresent());
         assertThat(claim.getDirectionOrder().get()).isEqualTo(ccdCase.getDirectionOrder());
+    }
+
+    @Test
+    public void shouldMapPreferredDQCourtOnFromCCDCase() {
+        //given
+        CCDCase ccdCase = SampleData.getCCDCitizenCase(getAmountBreakDown()).toBuilder()
+            .preferredDQCourt(PREFERRED_COURT)
+            .build();
+
+        //when
+        Claim claim = ccdCaseMapper.from(ccdCase);
+
+        //then
+        MatcherAssert.assertThat(claim.getPreferredDQCourt().get(), is(PREFERRED_COURT));
     }
 }


### PR DESCRIPTION



### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-8002


### Change description ###
The preferred court was missing for the cases where mediation has taken place.
That has been fixed now.


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
