### PR TITLE
Upgrade Postgres JDBC Driver to 42.2.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,7 @@ dependencies {
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
 
   compile group: 'org.elasticsearch', name: 'elasticsearch', version: '7.7.0'
-  compile group: 'org.postgresql', name: 'postgresql', version: '42.2.12'
+  compile group: 'org.postgresql', name: 'postgresql', version: '42.2.14'
 
   compile group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.15.1-RELEASE'
 

--- a/job-scheduler/build.gradle
+++ b/job-scheduler/build.gradle
@@ -11,7 +11,7 @@ dependencies {
   compile group: 'org.springframework.retry', name: 'spring-retry'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
-  compile group: 'org.postgresql', name: 'postgresql', version: '42.2.12'
+  compile group: 'org.postgresql', name: 'postgresql', version: '42.2.14'
   compile group: 'com.google.guava', name: 'guava', version: '20.0'
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Upgrade Postgres JDBC Driver to 42.2.14 to fix known vulnerability (CVE-2020-13692)

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No
