### PR TITLE
ROC-7744 Cleanup after SIDM-4453

### DIFF
--- a/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
+++ b/src/aat/java/uk/gov/hmcts/cmc/claimstore/tests/idam/IdamTestService.java
@@ -124,8 +124,7 @@ public class IdamTestService {
 
         String code = getCodeFromRedirect(response);
 
-        logger.info("Uplift user '{}' using OAuth2 endpoint until SIDM-4453 is resolved", email);
-        idamApi.exchangeCodeLegacy(
+        idamApi.exchangeCode(
             code,
             AUTHORIZATION_CODE,
             oauth2.getRedirectUrl(),

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/idam/IdamApi.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/idam/IdamApi.java
@@ -40,19 +40,6 @@ public interface IdamApi {
 
     @RequestMapping(
         method = RequestMethod.POST,
-        value = "/oauth2/token",
-        consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE
-    )
-    TokenExchangeResponse exchangeCodeLegacy(
-        @RequestParam("code") String code,
-        @RequestParam("grant_type") String grantType,
-        @RequestParam("redirect_uri") String redirectUri,
-        @RequestParam("client_id") String clientId,
-        @RequestParam("client_secret") String clientSecret
-    );
-
-    @RequestMapping(
-        method = RequestMethod.POST,
         value = "/o/token",
         consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE
     )


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-7744

### Change description ###
Cleanup the temporary use of the legacy OAuth2 endpoint in functional tests after SIDM-4453 is fixed.

When https://github.com/hmcts/cmc-claim-store/pull/1742 is merged to master, edit this PR so it's based on master too. When SIDM-4453 is fixed, builds on this PR should go green automatically.

See https://github.com/hmcts/cmc-claim-store/pull/1742 for the original PR.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
