### PR TITLE
Judges direction order - null pointer fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/callbacks/rules/GenerateOrderRule.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/ccd/callbacks/rules/GenerateOrderRule.java
@@ -70,10 +70,14 @@ public class GenerateOrderRule {
         List<CCDCollectionElement<CCDOrderDirection>> otherDirectionOrder =
             ccdCase.getOtherDirections() == null ? List.of() : ccdCase.getOtherDirections();
 
-        if (uploadDeadlineDate.isBefore(LocalDate.now()) || eyewitnessUploadDeadlineDate.isBefore(LocalDate.now())) {
+        if ((uploadDeadlineDate != null && uploadDeadlineDate.isBefore(LocalDate.now()))
+            || (eyewitnessUploadDeadlineDate != null
+            && eyewitnessUploadDeadlineDate.isBefore(LocalDate.now()))) {
             validationErrors.add(PAST_DATE_ERROR_MESSAGE);
         }
-        if (otherDirectionOrder.stream().anyMatch(e -> e.getValue().getSendBy().isBefore(LocalDate.now()))) {
+        if (otherDirectionOrder.stream().anyMatch(e ->
+            e.getValue().getSendBy() != null
+                && e.getValue().getSendBy().isBefore(LocalDate.now()))) {
             validationErrors.add(PAST_DATE_ERROR_MESSAGE);
         }
     }

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ccd/callbacks/rules/GenerateOrderRuleTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/ccd/callbacks/rules/GenerateOrderRuleTest.java
@@ -150,6 +150,16 @@ public class GenerateOrderRuleTest {
     }
 
     @Test
+    public void shouldNotReturnDateValidationWhenOptional() {
+        CCDCase ccdCase = CCDCase.builder()
+            .build();
+        List<String> validations = new ArrayList<>();
+        generateOrderRule.validateDate(ccdCase, validations);
+
+        Assertions.assertThat(validations).isEmpty();
+    }
+
+    @Test
     public void shouldReturnDateValidationErrorForOtherDirectionsSendByDate() {
         List<CCDCollectionElement<CCDOrderDirection>> otherDirections = ImmutableList.of(
             CCDOrderDirection.builder()
@@ -181,6 +191,36 @@ public class GenerateOrderRuleTest {
         Assertions.assertThat(validations).isNotEmpty()
             .hasSize(1)
             .contains(GenerateOrderRule.PAST_DATE_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void shouldNotReturnDateValidationErrorForOtherDirectionsSendByDateWhenOptional() {
+        List<CCDCollectionElement<CCDOrderDirection>> otherDirections = ImmutableList.of(
+            CCDOrderDirection.builder()
+                .directionComment("a direction")
+                .extraOrderDirection(OTHER)
+                .otherDirectionHeaders(UPLOAD)
+                .forParty(BOTH)
+                .build(),
+            CCDOrderDirection.builder()
+                .extraOrderDirection(EXPERT_REPORT_PERMISSION)
+                .forParty(BOTH)
+                .build()
+        )
+            .stream()
+            .map(e -> CCDCollectionElement.<CCDOrderDirection>builder().value(e).build())
+            .collect(Collectors.toList());
+
+        CCDCase ccdCase = CCDCase.builder()
+            .docUploadDeadline(LocalDate.now().plusDays(10))
+            .eyewitnessUploadDeadline(LocalDate.now().plusDays(10))
+            .otherDirections(otherDirections)
+            .build();
+
+        List<String> validations = new ArrayList<>();
+        generateOrderRule.validateDate(ccdCase, validations);
+
+        Assertions.assertThat(validations).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-8454

### Change description ###
Null check has been added as part of validation for the optional date fields

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
