### PR TITLE
ROC-8577-Nightly-build-Dependency-error-suppressed

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -185,4 +185,10 @@
         ]]></notes>
         <cve>CVE-2020-13943</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+            httpclient
+        ]]></notes>
+        <cve>CVE-2020-13956</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-8577

### Change description ###
Suppressed dependency error CVE-2020-13956 caused by http-client


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No
