### PR TITLE
MILO report fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportController.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportController.java
@@ -274,14 +274,14 @@ public class SupportController {
         @RequestBody MediationRequest mediationRequest
     ) {
         mediationReportService
-            .sendMediationReport(authorisation, mediationRequest.getReportDate());
+            .sendMediationReport(authorisation, mediationRequest.getReportDate(), mediationRequest.getRecipientEmail());
 
     }
 
     /*
-    * This method is added as to enable PET to regenerate
-    * MILO report(in case of failure) for specific date
-    * */
+     * This method is added as to enable PET to regenerate
+     * MILO report(in case of failure) for specific date
+     * */
     @PostMapping(value = "/reSendMediation", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Re-Generate and Send Mediation Report for Telephone Mediation Service")
     public void reSendMediation(
@@ -292,7 +292,7 @@ public class SupportController {
         LocalDateTime now = LocalDateTime.now();
         logger.info("Support controller started MILO report generation at {}", now);
         mediationReportService
-            .sendMediationReport(authorisation, mediationRequest.getReportDate());
+            .sendMediationReport(authorisation, mediationRequest.getReportDate(), mediationRequest.getRecipientEmail());
         logger.info("MILO report ended at {}, took {} seconds to generate",
             LocalDateTime.now(), Duration.between(now, LocalDateTime.now()).getSeconds());
 

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/CCDElasticSearchRepository.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/repositories/CCDElasticSearchRepository.java
@@ -51,7 +51,7 @@ public class CCDElasticSearchRepository implements CaseSearchApi {
     public List<Claim> getMediationClaims(String authorisation, LocalDate mediationAgreedDate) {
         User user = userService.getUser(authorisation);
 
-        logger.info("ElasticSearch query to fetch data at {} for the date {} ",
+        logger.info("MILO: ElasticSearch query to fetch data at {} for the date {} ",
             LocalDateTime.now(), mediationAgreedDate);
 
         Query mediationQuery = new Query(

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/MediationCSVGenerator.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/MediationCSVGenerator.java
@@ -132,7 +132,7 @@ public class MediationCSVGenerator {
             csvPrinter.flush();
             csvData = stringBuilder.toString();
         } catch (Exception e) {
-            logger.error("Mediation csv generation failed,records details are {}", problematicRecords);
+            logger.error("MILO: Mediation csv generation failed,records details are {}", problematicRecords);
             throw new MediationCSVGenerationException("Error generating Mediation CSV", e);
         }
     }
@@ -144,6 +144,7 @@ public class MediationCSVGenerator {
             .flatMap(List::stream)
             .collect(Collectors.toList());
 
+        logger.info("MILO: total no of claims retrieved {}", result.size());
         if (result.isEmpty()) {
             result.add(MediationRow.builder().build());
         }
@@ -158,7 +159,7 @@ public class MediationCSVGenerator {
                 createMediationRow(claim, DEFENDANT_PARTY_TYPE)
             );
         } catch (MediationCSVGenerationException e) {
-            logger.error("Mediation csv generation failed for {} and error {}",
+            logger.error("MILO: Mediation csv generation failed for {} and error {}",
                 claim.getReferenceNumber(), e.getMessage());
             problematicRecords.put(claim.getReferenceNumber(), e.getMessage());
             return Collections.emptyList();

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/MediationReportService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/MediationReportService.java
@@ -1,6 +1,9 @@
 package uk.gov.hmcts.cmc.claimstore.services;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -14,7 +17,6 @@ import uk.gov.hmcts.cmc.email.EmailService;
 
 import java.time.Clock;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,6 +37,8 @@ public class MediationReportService {
     private final String emailFromAddress;
     private final Clock clock;
 
+    Logger logger = LoggerFactory.getLogger(this.getClass());
+
     @Autowired
     public MediationReportService(
         EmailService emailService,
@@ -54,16 +58,18 @@ public class MediationReportService {
         this.emailFromAddress = emailFromAddress;
     }
 
-    public void sendMediationReport(String authorisation, LocalDate mediationDate) {
+    public void sendMediationReport(String authorisation, LocalDate mediationDate, String emailToAddressFromSupportController) {
         try {
             MediationCSVGenerator generator = new MediationCSVGenerator(caseSearchApi, mediationDate, authorisation);
             generator.createMediationCSV();
             String csvData = generator.getCsvData();
 
-            emailService.sendEmail(emailFromAddress, prepareMediationEmailData(csvData));
+            emailService.sendEmail(emailFromAddress, prepareMediationEmailData(csvData, mediationDate, emailToAddressFromSupportController));
+
 
             Map<String, String> problematicRecords = generator.getProblematicRecords();
             if (!problematicRecords.isEmpty()) {
+                logger.info("MILO: problematicRecords count is {}", problematicRecords.size());
                 reportMediationExceptions(mediationDate, problematicRecords);
             }
         } catch (MediationCSVGenerationException e) {
@@ -72,22 +78,34 @@ public class MediationReportService {
     }
 
     public void automatedMediationReport() throws Exception {
+        logger.info("MILO: Triggering MILO report for {}", LocalDate.now(clock).minusDays(1));
         sendMediationReport(
             userService.authenticateAnonymousCaseWorker().getAuthorisation(),
-            LocalDate.now(clock).minusDays(1)
+            LocalDate.now(clock).minusDays(1), ""
         );
     }
 
-    private EmailData prepareMediationEmailData(String mediationCSV) {
-        String fileName = "MediationCSV." + LocalDate.now().toString() + ".csv";
+    private EmailData prepareMediationEmailData(String mediationCSV, LocalDate mediationDate, String emailToAddressFromSupportController) {
+        LocalDate csvReportingDate = mediationDate.plusDays(1);
+        String fileName = "MediationCSV." + csvReportingDate.toString() + ".csv";
         EmailAttachment mediationCSVAttachment = EmailAttachment.csv(mediationCSV.getBytes(), fileName);
-
-        return new EmailData(
-            emailToAddress,
-            "MediationCSV " + LocalDate.now().toString(),
-            "OCMC mediation" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm dd/mm/yyyy")),
-            Collections.singletonList(mediationCSVAttachment)
-        );
+        if (StringUtils.isBlank(emailToAddressFromSupportController)) {
+            logger.info("MILO: Sending email to support controller mail address");
+            return new EmailData(
+                emailToAddressFromSupportController,
+                "MediationCSV " + mediationDate.toString(),
+                "OCMC mediation" + csvReportingDate.format(DateTimeFormatter.ofPattern("HH:mm dd/mm/yyyy")),
+                Collections.singletonList(mediationCSVAttachment)
+            );
+        } else {
+            logger.info("MILO: Sending email to mediation team");
+            return new EmailData(
+                emailToAddress,
+                "MediationCSV " + mediationDate.toString(),
+                "OCMC mediation" + csvReportingDate.format(DateTimeFormatter.ofPattern("HH:mm dd/mm/yyyy")),
+                Collections.singletonList(mediationCSVAttachment)
+            );
+        }
     }
 
     private void reportMediationException(RuntimeException e, LocalDate reportDate) {

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/MediationReportService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/MediationReportService.java
@@ -88,15 +88,14 @@ public class MediationReportService {
 
     private EmailData prepareMediationEmailData(String mediationCSV,
                                                 LocalDate mediationDate, String emailToAddressFromSupportController) {
-        LocalDate csvReportingDate = mediationDate.plusDays(1);
-        String fileName = "MediationCSV." + csvReportingDate.toString() + ".csv";
+        String fileName = "MediationCSV." + mediationDate.toString() + ".csv";
         EmailAttachment mediationCSVAttachment = EmailAttachment.csv(mediationCSV.getBytes(), fileName);
         if (!StringUtils.isBlank(emailToAddressFromSupportController)) {
             logger.info("MILO: Sending email to support controller mail address");
             return new EmailData(
                 emailToAddressFromSupportController,
                 "MediationCSV " + mediationDate.toString(),
-                "OCMC mediation" + csvReportingDate.format(DateTimeFormatter.ofPattern("HH:mm dd/mm/yyyy")),
+                "OCMC mediation" + mediationDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
                 Collections.singletonList(mediationCSVAttachment)
             );
         } else {
@@ -104,7 +103,7 @@ public class MediationReportService {
             return new EmailData(
                 emailToAddress,
                 "MediationCSV " + mediationDate.toString(),
-                "OCMC mediation" + csvReportingDate.format(DateTimeFormatter.ofPattern("HH:mm dd/mm/yyyy")),
+                "OCMC mediation" + mediationDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
                 Collections.singletonList(mediationCSVAttachment)
             );
         }

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/services/MediationReportService.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/services/MediationReportService.java
@@ -58,14 +58,15 @@ public class MediationReportService {
         this.emailFromAddress = emailFromAddress;
     }
 
-    public void sendMediationReport(String authorisation, LocalDate mediationDate, String emailToAddressFromSupportController) {
+    public void sendMediationReport(String authorisation, LocalDate mediationDate,
+                                    String emailToAddressFromSupportController) {
         try {
             MediationCSVGenerator generator = new MediationCSVGenerator(caseSearchApi, mediationDate, authorisation);
             generator.createMediationCSV();
             String csvData = generator.getCsvData();
 
-            emailService.sendEmail(emailFromAddress, prepareMediationEmailData(csvData, mediationDate, emailToAddressFromSupportController));
-
+            emailService.sendEmail(emailFromAddress,
+                prepareMediationEmailData(csvData, mediationDate, emailToAddressFromSupportController));
 
             Map<String, String> problematicRecords = generator.getProblematicRecords();
             if (!problematicRecords.isEmpty()) {
@@ -85,11 +86,12 @@ public class MediationReportService {
         );
     }
 
-    private EmailData prepareMediationEmailData(String mediationCSV, LocalDate mediationDate, String emailToAddressFromSupportController) {
+    private EmailData prepareMediationEmailData(String mediationCSV,
+                                                LocalDate mediationDate, String emailToAddressFromSupportController) {
         LocalDate csvReportingDate = mediationDate.plusDays(1);
         String fileName = "MediationCSV." + csvReportingDate.toString() + ".csv";
         EmailAttachment mediationCSVAttachment = EmailAttachment.csv(mediationCSV.getBytes(), fileName);
-        if (StringUtils.isBlank(emailToAddressFromSupportController)) {
+        if (!StringUtils.isBlank(emailToAddressFromSupportController)) {
             logger.info("MILO: Sending email to support controller mail address");
             return new EmailData(
                 emailToAddressFromSupportController,

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportControllerTest.java
@@ -614,23 +614,23 @@ class SupportControllerTest {
         @Test
         void shouldSendAppInsightIfMediationReportFails() {
             LocalDate mediationSearchDate = LocalDate.of(2019, 7, 7);
-            doNothing().when(mediationReportService).sendMediationReport(eq(AUTHORISATION), any());
+            doNothing().when(mediationReportService).sendMediationReport(eq(AUTHORISATION), any(), any());
             controller.sendMediation(
                 AUTHORISATION,
                 new MediationRequest(mediationSearchDate, "Holly@cow.com"));
             verify(mediationReportService)
-                .sendMediationReport(eq(AUTHORISATION), eq(mediationSearchDate));
+                .sendMediationReport(eq(AUTHORISATION), eq(mediationSearchDate), "");
         }
 
         @Test
         void shouldRegenerateMiloReportForGivenDate() {
             when(userService.authenticateAnonymousCaseWorker()).thenReturn(USER);
             LocalDate mediationSearchDate = LocalDate.of(2019, 7, 7);
-            doNothing().when(mediationReportService).sendMediationReport(eq(AUTHORISATION), any());
+            doNothing().when(mediationReportService).sendMediationReport(eq(AUTHORISATION), any(), any());
             controller.reSendMediation(
                 new MediationRequest(mediationSearchDate, "Holly@cow.com"));
             verify(mediationReportService)
-                .sendMediationReport(eq(AUTHORISATION), eq(mediationSearchDate));
+                .sendMediationReport(eq(AUTHORISATION), eq(mediationSearchDate), "");
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportControllerTest.java
@@ -80,6 +80,7 @@ class SupportControllerTest {
     private static final UserDetails USER_DETAILS = SampleUserDetails.builder().build();
     private static final User USER = new User(AUTHORISATION, USER_DETAILS);
     private static final String EMAIL_TO_ADDRESS = "";
+    private static final String EMAIl_ADDRESS = "Holly@cow.com";
 
     @Mock
     private ClaimService claimService;
@@ -613,13 +614,13 @@ class SupportControllerTest {
     @DisplayName("App Insights Tests")
     class ApplicationInsightsTests {
         @Test
-        void shouldSendAppInsightIfMediationReportFails() {
+        void shouldSendMediationReportThroughSupportController() {
             LocalDate mediationSearchDate = LocalDate.of(2019, 7, 7);
             doNothing().when(mediationReportService)
                 .sendMediationReport(eq(AUTHORISATION), any(), eq(EMAIL_TO_ADDRESS));
             controller.sendMediation(
                 AUTHORISATION,
-                new MediationRequest(mediationSearchDate, "Holly@cow.com"));
+                new MediationRequest(mediationSearchDate, ""));
             verify(mediationReportService)
                 .sendMediationReport(eq(AUTHORISATION), eq(mediationSearchDate), eq(EMAIL_TO_ADDRESS));
         }
@@ -629,11 +630,11 @@ class SupportControllerTest {
             when(userService.authenticateAnonymousCaseWorker()).thenReturn(USER);
             LocalDate mediationSearchDate = LocalDate.of(2019, 7, 7);
             doNothing().when(mediationReportService)
-                .sendMediationReport(eq(AUTHORISATION), any(), eq(EMAIL_TO_ADDRESS));
+                .sendMediationReport(eq(AUTHORISATION), any(), eq(EMAIl_ADDRESS));
             controller.reSendMediation(
-                new MediationRequest(mediationSearchDate, "Holly@cow.com"));
+                new MediationRequest(mediationSearchDate, EMAIl_ADDRESS));
             verify(mediationReportService)
-                .sendMediationReport(eq(AUTHORISATION), eq(mediationSearchDate), eq(EMAIL_TO_ADDRESS));
+                .sendMediationReport(eq(AUTHORISATION), eq(mediationSearchDate), eq(EMAIl_ADDRESS));
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/controllers/support/SupportControllerTest.java
@@ -79,6 +79,7 @@ class SupportControllerTest {
     private static final String RESPONSE_SUBMITTED = "response";
     private static final UserDetails USER_DETAILS = SampleUserDetails.builder().build();
     private static final User USER = new User(AUTHORISATION, USER_DETAILS);
+    private static final String EMAIL_TO_ADDRESS = "";
 
     @Mock
     private ClaimService claimService;
@@ -614,23 +615,25 @@ class SupportControllerTest {
         @Test
         void shouldSendAppInsightIfMediationReportFails() {
             LocalDate mediationSearchDate = LocalDate.of(2019, 7, 7);
-            doNothing().when(mediationReportService).sendMediationReport(eq(AUTHORISATION), any(), any());
+            doNothing().when(mediationReportService)
+                .sendMediationReport(eq(AUTHORISATION), any(), eq(EMAIL_TO_ADDRESS));
             controller.sendMediation(
                 AUTHORISATION,
                 new MediationRequest(mediationSearchDate, "Holly@cow.com"));
             verify(mediationReportService)
-                .sendMediationReport(eq(AUTHORISATION), eq(mediationSearchDate), "");
+                .sendMediationReport(eq(AUTHORISATION), eq(mediationSearchDate), eq(EMAIL_TO_ADDRESS));
         }
 
         @Test
         void shouldRegenerateMiloReportForGivenDate() {
             when(userService.authenticateAnonymousCaseWorker()).thenReturn(USER);
             LocalDate mediationSearchDate = LocalDate.of(2019, 7, 7);
-            doNothing().when(mediationReportService).sendMediationReport(eq(AUTHORISATION), any(), any());
+            doNothing().when(mediationReportService)
+                .sendMediationReport(eq(AUTHORISATION), any(), eq(EMAIL_TO_ADDRESS));
             controller.reSendMediation(
                 new MediationRequest(mediationSearchDate, "Holly@cow.com"));
             verify(mediationReportService)
-                .sendMediationReport(eq(AUTHORISATION), eq(mediationSearchDate), "");
+                .sendMediationReport(eq(AUTHORISATION), eq(mediationSearchDate), eq(EMAIL_TO_ADDRESS));
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/MediationReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/MediationReportServiceTest.java
@@ -87,7 +87,7 @@ public class MediationReportServiceTest {
 
     @Test
     public void shouldPrepareCSVDataAndInvokeEmailService() throws IOException {
-        service.sendMediationReport(AUTHORISATION, LocalDate.now());
+        service.sendMediationReport(AUTHORISATION, LocalDate.now(), "");
 
         verify(caseSearchApi).getMediationClaims(AUTHORISATION, LocalDate.now());
         verifyEmailData();

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/services/MediationReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/services/MediationReportServiceTest.java
@@ -87,7 +87,7 @@ public class MediationReportServiceTest {
 
     @Test
     public void shouldPrepareCSVDataAndInvokeEmailService() throws IOException {
-        service.sendMediationReport(AUTHORISATION, LocalDate.now(), "");
+        service.sendMediationReport(AUTHORISATION, LocalDate.now(), TO_ADDRESS);
 
         verify(caseSearchApi).getMediationClaims(AUTHORISATION, LocalDate.now());
         verifyEmailData();


### PR DESCRIPTION
### Change description
File name reflecting mediation report date (reflect the date for which the file contains the details) - if it triggered for 6th Feb's report on 10th Feb, filename should be MediationCSV.06-02-2021
Email subject and message will reflect the mediation report date.
Email address - Report can be shared with specific email address on request via support controller
Log statements - to find out how many claims are retrieved from DB via elastic search - this change will confirm the issue with elastic search process.
More log statements for similar exceptions on the process - to help in debugging any further issue.


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-8864

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
