### PR TITLE
[DRAFT - ROLLBACK] DTSCCI-5447: Disable S2S filter on callbacks if hotfix #3493 fails

### DIFF
--- a/charts/cmc-claim-store/Chart.yaml
+++ b/charts/cmc-claim-store/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cmc-claim-store
 home: https://github.com/hmcts/cmc-claim-store
-version: 4.1.60
+version: 4.1.61
 description: Helm chart for the HMCTS CMC Claim-Store service
 # be aware when bumping version that it is used elsewhere, e.g.:
 # chart-cmc - demo: https://github.com/hmcts/chart-cmc/tree/master/cmc

--- a/charts/cmc-claim-store/values.yaml
+++ b/charts/cmc-claim-store/values.yaml
@@ -92,7 +92,6 @@ java:
     CLAIM_STAYED_SCHEDULE: ''
     ASYNC_MAX_THREADPOOL_SIZE: 50
     IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
-    IDAM_S2S_AUTH_SERVICES_ALLOWED: ccd_data
     IDAM_API_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     IDAM_WEB_URL: https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net
     PDF_SERVICE_URL: http://cmc-pdf-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal


### PR DESCRIPTION
> :warning: **Do not merge unless PR #3493 (the hotfix) is deployed to prod and fails to resolve the callback 401s.**
> This PR is held in draft as a pre-prepared emergency rollback.

## Summary

Removes `IDAM_S2S_AUTH_SERVICES_ALLOWED: ccd_data` from \`values.yaml\`, restoring the pre-`abeb0254e` behaviour where `S2sAuthFilter.doFilterInternal` short-circuits via:

\`\`\`java
if (allowedServices.isEmpty()) {
    filterChain.doFilter(request, response);
    return;
}
\`\`\`

This bypasses S2S service-name validation on `/cases/callbacks/**` entirely. That is the long-standing pre-incident behaviour (it has been this way for months/years before May 2026), so it is a known-stable rollback target.

## When to merge

Only if **after deploying PR #3493**:
- App Insights still shows `outerMessage contains 'authorisation-check'` exceptions, OR
- `POST /cases/callbacks/about-to-submit` continues returning 401 in prod, OR
- A new failure mode emerges from the hotfix (e.g. 403s from unexpected service name)

In any of those cases, merging this PR and deploying restores callbacks immediately.

## Why this is a fallback, not the primary fix

This rollback removes S2S service-name validation on callbacks entirely — which is a security regression relative to the intent of the original DTSCC-5388 work. It is acceptable as a short-term rollback because it matches the behaviour that ran in prod for a long time prior to May 2026 without incident. The proper fix is PR #3493.

## Chart version

Bumped `charts/cmc-claim-store/Chart.yaml` from `4.1.60` → `4.1.61` so the chart change is picked up by Flux.

## Test plan

- [ ] Move out of draft only when needed
- [ ] After merge: prod callback 401s stop, `POST /cases/callbacks/about-to-submit` returns 200
- [ ] Follow-up ticket to re-introduce `IDAM_S2S_AUTH_SERVICES_ALLOWED` together with a working S2S validation path