### PR TITLE
DTSCCI-5447: Preserve Bearer prefix on Authorization header to auth provider /details

### DIFF
--- a/charts/cmc-claim-store/Chart.yaml
+++ b/charts/cmc-claim-store/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cmc-claim-store
 home: https://github.com/hmcts/cmc-claim-store
-version: 4.1.60
+version: 4.1.61
 description: Helm chart for the HMCTS CMC Claim-Store service
 # be aware when bumping version that it is used elsewhere, e.g.:
 # chart-cmc - demo: https://github.com/hmcts/chart-cmc/tree/master/cmc

--- a/src/main/java/uk/gov/hmcts/cmc/claimstore/security/S2sAuthFilter.java
+++ b/src/main/java/uk/gov/hmcts/cmc/claimstore/security/S2sAuthFilter.java
@@ -83,10 +83,10 @@ public class S2sAuthFilter extends OncePerRequestFilter {
         if (header == null || header.isBlank()) {
             return null;
         }
+        // The auth provider's /details endpoint expects the "Bearer " prefix on the
+        // Authorization header forwarded by the Feign client. Match the library's
+        // ServiceAuthFilter, which prepends "Bearer " when absent.
         String bearerPrefix = "Bearer ";
-        if (header.startsWith(bearerPrefix)) {
-            return header.substring(bearerPrefix.length());
-        }
-        return header;
+        return header.startsWith(bearerPrefix) ? header : bearerPrefix + header;
     }
 }

--- a/src/test/java/uk/gov/hmcts/cmc/claimstore/security/S2sAuthFilterTest.java
+++ b/src/test/java/uk/gov/hmcts/cmc/claimstore/security/S2sAuthFilterTest.java
@@ -86,7 +86,7 @@ class S2sAuthFilterTest {
         request.addHeader(S2sAuthFilter.SERVICE_AUTH_HEADER, "Bearer test-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        doThrow(new InvalidTokenException("invalid token")).when(authTokenValidator).getServiceName("test-token");
+        doThrow(new InvalidTokenException("invalid token")).when(authTokenValidator).getServiceName("Bearer test-token");
 
         filter.doFilterInternal(request, response, filterChain);
 
@@ -101,7 +101,7 @@ class S2sAuthFilterTest {
         request.addHeader(S2sAuthFilter.SERVICE_AUTH_HEADER, "Bearer test-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        when(authTokenValidator.getServiceName("test-token")).thenReturn("bulk_scan");
+        when(authTokenValidator.getServiceName("Bearer test-token")).thenReturn("bulk_scan");
 
         filter.doFilterInternal(request, response, filterChain);
 
@@ -116,11 +116,11 @@ class S2sAuthFilterTest {
         request.addHeader(S2sAuthFilter.SERVICE_AUTH_HEADER, "Bearer test-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        when(authTokenValidator.getServiceName("test-token")).thenReturn("cmc");
+        when(authTokenValidator.getServiceName("Bearer test-token")).thenReturn("cmc");
 
         filter.doFilterInternal(request, response, filterChain);
 
-        verify(authTokenValidator).getServiceName("test-token");
+        verify(authTokenValidator).getServiceName("Bearer test-token");
         verify(filterChain).doFilter(request, response);
         assertEquals(200, response.getStatus());
     }
@@ -132,11 +132,11 @@ class S2sAuthFilterTest {
         request.addHeader(S2sAuthFilter.SERVICE_AUTH_HEADER, "plain-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        when(authTokenValidator.getServiceName("plain-token")).thenReturn("cmc");
+        when(authTokenValidator.getServiceName("Bearer plain-token")).thenReturn("cmc");
 
         filter.doFilterInternal(request, response, filterChain);
 
-        verify(authTokenValidator).getServiceName("plain-token");
+        verify(authTokenValidator).getServiceName("Bearer plain-token");
         verify(filterChain).doFilter(request, response);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #3493 (already merged). The original hotfix removed the `validate(token)` call — that resolved the `/authorisation-check` 404 errors — but exposed a second bug: `S2sAuthFilter.extractBearerToken` strips the `Bearer ` prefix before passing the token to `getServiceName(token)`. The Feign client forwards that raw token as the `Authorization` header on `GET /details`, and `rpe-service-auth-provider` rejects it with `401 "Invalid authorization header"`.

This PR matches the behaviour of the library's stock `uk.gov.hmcts.reform.authorisation.filters.ServiceAuthFilter`, which always passes a `"Bearer <token>"` string to `getServiceName(token)`.

## Evidence

Prod App Insights, after PR #3493 rolled out at ~09:50 UTC:

- `exceptions | where outerMessage contains 'authorisation-check'` — zero (`/authorisation-check` fix landed)
- `exceptions | where type == 'InvalidTokenException'` — ~18/hour, new message `[401 Unauthorized] during [GET] to .../details: {"message":"Invalid authorization header"}`
- `/cases/callbacks/about-to-submit` still returning 401 (~18/hour vs ~36/hour before — halved because there's now only one call per request instead of two)
- `/health` and `/lease` calls to the same auth provider return 200, so the service is otherwise healthy

## Why the library does the opposite of CMC's filter

Decompiled `uk.gov.hmcts.reform.authorisation.filters.ServiceAuthFilter.extractBearerToken`:

```
if header.startsWith("Bearer") -> return header as-is
else                           -> return "Bearer " + header
```

CMC's custom `S2sAuthFilter` was doing the inverse (strip when present, return raw when absent).

## Diff

- `S2sAuthFilter.extractBearerToken`: always returns a `Bearer `-prefixed string
- `S2sAuthFilterTest`: updated to assert `getServiceName("Bearer test-token")`, plus the no-prefix-input case now asserts the prefix is added
- `Chart.yaml`: 4.1.60 -> 4.1.61

## Test plan

- [x] `./gradlew :test --tests S2sAuthFilterTest` passes
- [ ] After merge: monitor prod App Insights for `outerMessage contains 'Invalid authorization header'` — should drop to zero
- [ ] After merge: `POST /cases/callbacks/about-to-submit` returns 200, not 401