### PR TITLE
DTSCCI-1302: Fix cmc_defendant provider pact verification

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/cmc/claimstore/api/provider/CmcDefendantApiProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/cmc/claimstore/api/provider/CmcDefendantApiProviderTest.java
@@ -5,16 +5,23 @@ import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
 import au.com.dius.pact.provider.junitsupport.Provider;
 import au.com.dius.pact.provider.junitsupport.State;
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
-import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.junitsupport.loader.PactBrokerConsumerVersionSelectors;
+import au.com.dius.pact.provider.junitsupport.loader.SelectorBuilder;
 import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.hmcts.cmc.claimstore.controllers.ClaimController;
 import uk.gov.hmcts.cmc.claimstore.models.idam.UserInfo;
 import uk.gov.hmcts.cmc.claimstore.repositories.CCDCaseApi;
@@ -30,14 +37,12 @@ import static uk.gov.hmcts.cmc.claimstore.api.provider.ProviderTestUtils.getClai
 
 @ExtendWith(SpringExtension.class)
 @Provider("cmc_defendant")
-@PactBroker(scheme = "${PACT_BROKER_SCHEME:http}",
-    host = "${PACT_BROKER_URL:localhost}",
-    port = "${PACT_BROKER_PORT:80}",
-    consumerVersionSelectors = {@VersionSelector(tag = "master")}
+@PactBroker(
+    url = "${PACT_BROKER_FULL_URL:http://localhost:80}",
+    providerBranch = "${pact.provider.branch:master}"
 )
 @ContextConfiguration(classes = {GetClaimsContractConfig.class})
 @IgnoreNoPactsToVerify
-@Disabled("DTSCCI-1302: provider verification fix pending in separate PR")
 public class CmcDefendantApiProviderTest {
 
     @Autowired
@@ -49,6 +54,14 @@ public class CmcDefendantApiProviderTest {
     @Autowired
     private ClaimController claimController;
 
+    @PactBrokerConsumerVersionSelectors
+    public static SelectorBuilder consumerVersionSelectors() {
+        return new SelectorBuilder()
+            .matchingBranch()
+            .mainBranch()
+            .deployedOrReleased();
+    }
+
     @TestTemplate
     @ExtendWith(PactVerificationSpringProvider.class)
     void pactVerificationTestTemplate(PactVerificationContext context) {
@@ -59,9 +72,22 @@ public class CmcDefendantApiProviderTest {
 
     @BeforeEach
     void before(PactVerificationContext context) {
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
         System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        testTarget.setControllers(claimController);
+
+        ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .registerModule(new Jdk8Module())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter(objectMapper);
+
+        MockMvc mockMvc = MockMvcBuilders
+            .standaloneSetup(claimController)
+            .setMessageConverters(converter)
+            .build();
+
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setMockMvc(mockMvc);
         if (context != null) {
             context.setTarget(testTarget);
         }

--- a/src/contractTest/java/uk/gov/hmcts/cmc/claimstore/api/provider/ProviderTestUtils.java
+++ b/src/contractTest/java/uk/gov/hmcts/cmc/claimstore/api/provider/ProviderTestUtils.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.cmc.domain.models.response.YesNoOption;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 public class ProviderTestUtils {
@@ -78,11 +79,11 @@ public class ProviderTestUtils {
                 .responseMethod(ResponseMethod.OFFLINE)
                 .build())
             .moneyReceivedOn(LocalDate.now())
-            .countyCourtJudgmentRequestedAt(LocalDateTime.now())
-            .createdAt(LocalDateTime.now())
-            .reDeterminationRequestedAt(LocalDateTime.now())
+            .countyCourtJudgmentRequestedAt(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS))
+            .createdAt(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS))
+            .reDeterminationRequestedAt(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS))
             .intentionToProceedDeadline(LocalDate.now())
-            .claimantRespondedAt(LocalDateTime.now())
+            .claimantRespondedAt(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS))
             .claimantResponse(ResponseAcceptation.builder()
                 .amountPaid(new BigDecimal(30))
                 .paymentReceived(YesNoOption.YES)


### PR DESCRIPTION

### JIRA link (if applicable) ###
DTSCCI-1302


### Change description ###
- Remove `@Disabled` annotation added in DTSCCI-1301
- Modernize PactBroker annotation to use url and providerBranch
- Replace deprecated @VersionSelector with @PactBrokerConsumerVersionSelectors
- Configure ObjectMapper with JavaTimeModule and Jdk8Module for correct serialization of Java 8 date/time and Optional types
- Truncate LocalDateTime values to microsecond precision in test data to match consumer pact regex expectation of 1-6 fractional digits


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No
