### PR TITLE
Upgrade cnp library to version 2.5.0

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,7 +1,7 @@
 #!groovy
 import uk.gov.hmcts.contino.AppPipelineDsl
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.5.0")
 
 def product = "cmc"
 def component = "claim-store"


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-6190

### Change description ###

Upgrade cnp library to version 2.5.0

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No
