### PR TITLE
DTSCCI-6223 Fix Renovate PRs not auto-merging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,7 @@
 package.json
 yarn.lock
 charts/**/Chart.yaml
+infrastructure/.terraform-version
+infrastructure/state.tf
 .github/workflows/*.yaml
+.github/workflows/*.yml

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
   ],
   "automergeSchedule": ["after 8am and before 4pm every weekday"],
   "schedule": ["after 8am and before 11am every weekday"],
-  "rebaseWhen": "conflicted",
+  "rebaseWhen": "behind-base-branch",
   "automergeStrategy": "squash",
   "prConcurrentLimit": 5,
   "helmv3": {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-6223

### Change description ###

Added CODEOWNERS exemptions for Renovate-managed dependency files so eligible Renovate PRs are not blocked by default code-owner review when checks have passed.

This covers the repo’s current Renovate update surfaces, including workflow .yml files and package/lock/version files, while leaving normal ownership in place for application code and non-exempt paths.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No
