### PR TITLE
Dtscci 6193 fix cv es

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,7 +247,7 @@ dependencies {
 
   implementation group: 'commons-io', name: 'commons-io', version: '2.22.0'
 
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.5.0'
+  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.6'
 
   implementation group: 'org.elasticsearch', name: 'elasticsearch', version: versions.elasticSearch
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.13'
@@ -320,7 +320,7 @@ dependencies {
 
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
   testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock'
-  fortify group: 'com.github.hmcts', name: 'fortify-client', version: '1.2.2', classifier: 'all'
+  fortify group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.10', classifier: 'all'
 
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
   testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'

--- a/build.gradle
+++ b/build.gradle
@@ -187,6 +187,11 @@ allprojects {
 
       dependency group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
       dependency group: 'org.apache.commons', name: 'commons-io', version: '2.22.0'
+
+      // springdoc 2.8.17 pulls swagger-ui 5.32.2, which still bundles a vulnerable DOMPurify (3.3.2).
+      // Pin the webjar to the latest release so the bundled DOMPurify clears CVE-2026-41238/41239/41240
+      // and the related 2026-* swagger-ui/DOMPurify CVEs.
+      dependency group: 'org.webjars', name: 'swagger-ui', version: '5.32.14'
     }
   }
 
@@ -247,7 +252,7 @@ dependencies {
 
   implementation group: 'commons-io', name: 'commons-io', version: '2.22.0'
 
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.6'
+  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.17'
 
   implementation group: 'org.elasticsearch', name: 'elasticsearch', version: versions.elasticSearch
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.13'


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-6193



### Change description ###
DTSCCI-6193: Bump springdoc/swagger-ui to clear remaining swagger-ui CVEs
    
    springdoc-openapi-starter-webmvc-ui 2.8.6 -> 2.8.17 alone still pulls
    swagger-ui 5.32.2, which bundles DOMPurify 3.3.2 - vulnerable to
    CVE-2026-41238/41239/41240 and the rest of the 2026-* DOMPurify batch
    (no swagger-ui release existed with a fixed DOMPurify when the previous
    commit landed).
    
    Pin org.webjars:swagger-ui to 5.32.14 via dependencyManagement, which
    bundles DOMPurify 3.4.13 and clears the remaining 13 Medium + 4 Low
    CVEs (CVE-2026-41238, -41239, -41240, -49458, -49459, -49978, -65898,
    -65899, -65900, -65901, -65902, -65903, -65912, -65913, -65914,
    -66010, -75838).
    
    Together with the prior fortify-client bump (3 High + 6 Medium) and
    the springdoc 2.5.0 -> 2.8.6 DOMPurify bump (3 Medium), this clears
    the full corrected master count of 3 High / 22 Medium / 4 Low.
    
    Verified via `gradlew dependencies --configuration runtimeClasspath`
    (org.webjars:swagger-ui resolves 5.32.2 -> 5.32.14, DOMPurify.version
    "3.4.13" confirmed in the resolved jar; no beanutils/okio/vulnerable
    gson/okhttp/httpclient nodes remain) and a full compileJava/
    compileTestJava.


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
