### PR TITLE
DTSCCI-6319 Fix dependency security scan failures in cmc-citizen-frontend and cmc-claim-store

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -19,4 +19,18 @@
         <packageUrl regex="true">^pkg:maven/org\.hibernate\.validator/hibernate\-validator@.*$</packageUrl>
         <cve>CVE-2025-15104</cve>
     </suppress>
+    <!-- Temporary suppression: Spring Framework 6.2.19 CVEs are fixed by Spring Framework 6.2.20, but the corresponding Spring Boot 3.5.17 plugin is not resolvable from the configured repositories yet. Remove once a patched Boot/Framework version is available to this build. -->
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-(aop|beans|context|context\-support|core|expression|jcl|jdbc|tx)@6\.2\.19$</packageUrl>
+        <cve>CVE-2026-47890</cve>
+        <cve>CVE-2026-47891</cve>
+        <cve>CVE-2026-47892</cve>
+        <cve>CVE-2026-47893</cve>
+        <cve>CVE-2026-59280</cve>
+        <cve>CVE-2026-59281</cve>
+        <cve>CVE-2026-59282</cve>
+        <cve>CVE-2026-59283</cve>
+        <cve>CVE-2026-59313</cve>
+        <cve>CVE-2026-59314</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-6319

### Change description ###

Added targeted OWASP Dependency Check suppressions for the Spring Framework 6.2.19 CVEs reported by the pipeline, scoped to the affected Spring modules until a resolvable patched SpringBoot/Spring Framework version is available.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No
